### PR TITLE
feat(recovery): Clear Logs button + harden window close (#210)

### DIFF
--- a/quill/tools/module_size_budgets.json
+++ b/quill/tools/module_size_budgets.json
@@ -23,7 +23,7 @@
   "_next_target_main_frame": 15000,
   "_default_cap": 600,
   "budgets": {
-    "quill/ui/main_frame.py": 22397,
+    "quill/ui/main_frame.py": 22406,
     "quill/ui/assistant_tools.py": 1877,
     "quill/ui/assistant_panel.py": 725,
     "quill/ui/main_frame_power_tools.py": 863,
@@ -99,5 +99,6 @@
   "_rebaseline_2026_06_15_docx": "Save As Word/.docx (#204): main_frame.py 22231->22232 for docx wildcard + filter-extension map entry. export.py gains write_docx_document (Pandoc gfm->docx); pandoc.py gains convert_file_with_pandoc.",
   "_rebaseline_2026_06_15_citations": "Citation help (#203): main_frame.py 22232->22320 for insert_citation (form-driven MLA/Chicago/APA builder) + command registration + command-map entry; main_frame_menu.py 2993->3001 for Insert > Insert Citation id/item/binding. New core module citations.py (pure).",
   "_rebaseline_2026_06_15_bugfix": "#209/#210 fixes: setup_wizard_pages.py 632->637 (Profile page -> wx.RadioBox so arrow keys wrap within the group, #209); main_frame.py 22337->22352 (_on_close destroys straggler top-level windows so run-from-source exits, #210).",
-  "_rebaseline_2026_06_15_clearlogs": "Crash Recovery dialog: add Clear Logs button + _clear_recovery_logs helper (unlink, truncate in-use files) with a confirmation message dialog showing the count. main_frame.py 22352->22397."
+  "_rebaseline_2026_06_15_clearlogs": "Crash Recovery dialog: add Clear Logs button + _clear_recovery_logs helper (unlink, truncate in-use files) with a confirmation message dialog showing the count. main_frame.py 22352->22397.",
+  "_rebaseline_2026_06_15_close": "#210 (reopened): _on_close guards every shutdown step with _safely() so a failing/slow step (watch worker, ssh, settings write, recovery lock, sound backend) can never throw before event.Skip(), plus an explicit ExitMainLoop fallback. main_frame.py re-measured."
 }

--- a/quill/tools/module_size_budgets.json
+++ b/quill/tools/module_size_budgets.json
@@ -23,7 +23,7 @@
   "_next_target_main_frame": 15000,
   "_default_cap": 600,
   "budgets": {
-    "quill/ui/main_frame.py": 22352,
+    "quill/ui/main_frame.py": 22397,
     "quill/ui/assistant_tools.py": 1877,
     "quill/ui/assistant_panel.py": 725,
     "quill/ui/main_frame_power_tools.py": 863,
@@ -98,5 +98,6 @@
   "_rebaseline_2026_06_14_bugs": "bugs branch (#165-#180) merged into main: a11y fixes (#166/#167/#170/#177/#178/#180), startup folder (#168), feature-search coverage (#171), glossary/guide-in-browser/WebView2 guard (#172/#173/#175), wizard UX (#177), Describe Image AttributeError (#165), Kelly Ford credits. Budgets re-measured after the merge.",
   "_rebaseline_2026_06_15_docx": "Save As Word/.docx (#204): main_frame.py 22231->22232 for docx wildcard + filter-extension map entry. export.py gains write_docx_document (Pandoc gfm->docx); pandoc.py gains convert_file_with_pandoc.",
   "_rebaseline_2026_06_15_citations": "Citation help (#203): main_frame.py 22232->22320 for insert_citation (form-driven MLA/Chicago/APA builder) + command registration + command-map entry; main_frame_menu.py 2993->3001 for Insert > Insert Citation id/item/binding. New core module citations.py (pure).",
-  "_rebaseline_2026_06_15_bugfix": "#209/#210 fixes: setup_wizard_pages.py 632->637 (Profile page -> wx.RadioBox so arrow keys wrap within the group, #209); main_frame.py 22337->22352 (_on_close destroys straggler top-level windows so run-from-source exits, #210)."
+  "_rebaseline_2026_06_15_bugfix": "#209/#210 fixes: setup_wizard_pages.py 632->637 (Profile page -> wx.RadioBox so arrow keys wrap within the group, #209); main_frame.py 22337->22352 (_on_close destroys straggler top-level windows so run-from-source exits, #210).",
+  "_rebaseline_2026_06_15_clearlogs": "Crash Recovery dialog: add Clear Logs button + _clear_recovery_logs helper (unlink, truncate in-use files) with a confirmation message dialog showing the count. main_frame.py 22352->22397."
 }

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -5246,54 +5246,65 @@ class MainFrame(
         if not self._can_close_all_documents():
             event.Veto()
             return
+
+        # #210: the window must always close. Every shutdown step below runs
+        # under its own guard so that one failing or slow step (a watch worker,
+        # an SSH socket, a settings write, the recovery lock, the sound backend)
+        # can never throw out of this handler before we reach event.Skip() and
+        # leave the frame stuck open. A failed step is logged, not fatal.
+        def _safely(step: str, action: Callable[[], object]) -> None:
+            try:
+                action()
+            except Exception:  # noqa: BLE001 - shutdown must never block close
+                import logging
+
+                logging.getLogger(__name__).warning("Shutdown step failed: %s", step, exc_info=True)
+
+        def _shutdown_sound_manager() -> None:
+            from quill.ui import sound_manager
+
+            sound_manager.shutdown()
+
         # H-3-ui: destroy the modeless Watch Queue Monitor so it does not
         # outlive the main frame and leak a window reference.
         if self._watch_queue_monitor is not None:
-            try:
-                self._watch_queue_monitor.Destroy()
-            except Exception:  # noqa: BLE001
-                pass
+            _safely("watch queue monitor", self._watch_queue_monitor.Destroy)
             self._watch_queue_monitor = None
             self._watch_queue_listbox = None
             self._watch_queue_pause_button = None
-        self._watch_service.stop()
-        self._unregister_global_hotkeys()
-        self._remove_tray_icon()
-        self.close_ssh_connections()
+        _safely("watch service", self._watch_service.stop)
+        _safely("global hotkeys", self._unregister_global_hotkeys)
+        _safely("tray icon", self._remove_tray_icon)
+        _safely("ssh connections", self.close_ssh_connections)
         # #32: drop GitHub-temp files no longer referenced by an open tab so
         # the user's app-data directory does not accumulate copies of files
         # they opened once and never saved back.
         prune = getattr(self, "prune_orphaned_github_temp", None)
         if callable(prune):
-            try:
-                prune()
-            except Exception:  # noqa: BLE001 - cleanup must never block shutdown
-                pass
-        save_settings(self.settings)
-        self.flush_persistent_undo()
-        mark_clean_exit(self.session_id)
-        try:
-            from quill.ui import sound_manager
-
-            sound_manager.shutdown()
-        except Exception:  # noqa: BLE001
-            pass
-        # #210: when run from source the process could refuse to exit because a
-        # modeless top-level window (for example the Ask Quill chat frame) was
-        # still alive, so wx kept the main loop running after the main frame
-        # closed. Destroy any stragglers here so closing the main window always
-        # ends the loop and the process exits.
+            _safely("github temp prune", prune)
+        _safely("save settings", lambda: save_settings(self.settings))
+        _safely("persistent undo flush", self.flush_persistent_undo)
+        _safely("clean-exit marker", lambda: mark_clean_exit(self.session_id))
+        _safely("sound manager", _shutdown_sound_manager)
+        # Destroy any straggler top-level windows (e.g. a modeless Ask Quill
+        # chat frame) so they do not keep the wx main loop alive after the main
+        # frame closes.
         wx = self._wx
         get_tlws = getattr(wx, "GetTopLevelWindows", None)
         if callable(get_tlws):
             for window in list(get_tlws()):
                 if window is self.frame:
                     continue
-                try:
-                    window.Destroy()
-                except Exception:  # noqa: BLE001
-                    pass
+                _safely("destroy window", window.Destroy)
         event.Skip()
+        # Belt-and-suspenders: explicitly end the main loop after this event is
+        # processed, so the process exits even if a window slipped past the
+        # cleanup above or wx is not configured to exit on the last frame.
+        app = wx.GetApp() if hasattr(wx, "GetApp") else None
+        exit_loop = getattr(app, "ExitMainLoop", None)
+        call_after = getattr(wx, "CallAfter", None)
+        if callable(exit_loop) and callable(call_after):
+            call_after(exit_loop)
 
     def _on_iconize(self, event: object) -> None:
         if self.settings.tray_enabled and event.IsIconized():

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -5379,6 +5379,31 @@ class MainFrame(
         enabled = bool(event.IsChecked())
         self.toggle_extend_selection_mode(enabled)
 
+    def _clear_recovery_logs(self, logs_path: Path) -> int:
+        """Delete log files in *logs_path*; return how many were removed.
+
+        A file held open by the active logger (typically the current
+        ``quill.log`` on Windows) cannot be unlinked, so it is truncated to zero
+        bytes instead and still counted as cleared. Best effort: anything that
+        can be neither removed nor truncated is skipped.
+        """
+        removed = 0
+        try:
+            entries = [entry for entry in logs_path.iterdir() if entry.is_file()]
+        except OSError:
+            return 0
+        for entry in entries:
+            try:
+                entry.unlink()
+                removed += 1
+            except OSError:
+                try:
+                    entry.write_bytes(b"")
+                    removed += 1
+                except OSError:
+                    continue
+        return removed
+
     def _offer_crash_recovery(self) -> None:
         if not self._recovery_offers:
             return
@@ -5456,12 +5481,14 @@ class MainFrame(
 
         restore_button = wx.Button(dialog, id=wx.ID_YES, label="Restore Latest Snapshot")
         open_logs_button = wx.Button(dialog, label="Open Logs Folder")
+        clear_logs_button = wx.Button(dialog, label="Clear Logs")
         save_diagnostics_button = wx.Button(dialog, label="Save Diagnostics...")
         skip_label = "Discard and Continue" if offer.dismissal_count >= 3 else "Skip Recovery"
         skip_button = wx.Button(dialog, id=wx.ID_NO, label=skip_label)
         buttons = wx.BoxSizer(wx.HORIZONTAL)
         buttons.Add(restore_button, 0, wx.RIGHT, 6)
         buttons.Add(open_logs_button, 0, wx.RIGHT, 6)
+        buttons.Add(clear_logs_button, 0, wx.RIGHT, 6)
         buttons.Add(save_diagnostics_button, 0, wx.RIGHT, 6)
         buttons.AddStretchSpacer(1)
         buttons.Add(skip_button, 0)
@@ -5470,6 +5497,7 @@ class MainFrame(
 
         restore_button.Bind(wx.EVT_BUTTON, lambda _e: dialog.EndModal(wx.ID_YES))
         open_logs_button.Bind(wx.EVT_BUTTON, lambda _e: dialog.EndModal(wx.ID_APPLY))
+        clear_logs_button.Bind(wx.EVT_BUTTON, lambda _e: dialog.EndModal(wx.ID_CLEAR))
         save_diagnostics_button.Bind(wx.EVT_BUTTON, lambda _e: dialog.EndModal(wx.ID_SAVE))
         skip_button.Bind(wx.EVT_BUTTON, lambda _e: dialog.EndModal(wx.ID_NO))
         dialog.SetDefaultItem(restore_button)
@@ -5484,6 +5512,21 @@ class MainFrame(
                 )
                 if result == wx.ID_APPLY:
                     self.open_logs_folder()
+                    continue
+                if result == wx.ID_CLEAR:
+                    removed = self._clear_recovery_logs(logs_path)
+                    if removed:
+                        message = (
+                            f"Removed {removed} log file{'s' if removed != 1 else ''} from:\n"
+                            f"{logs_path}"
+                        )
+                    else:
+                        message = f"There were no log files to remove in:\n{logs_path}"
+                    with wx.MessageDialog(
+                        self.frame, message, "Logs Cleared", wx.OK | wx.ICON_INFORMATION
+                    ) as confirm:
+                        self._show_modal_dialog(confirm, "Logs Cleared", restore_editor_focus=False)
+                    self._set_status(f"Cleared {removed} log file(s)")
                     continue
                 if result == wx.ID_SAVE:
                     self.save_diagnostics_bundle()

--- a/tests/unit/ui/fixtures/dialog_inventory.json
+++ b/tests/unit/ui/fixtures/dialog_inventory.json
@@ -34,6 +34,7 @@
   "quill/ui/main_frame.py::MainFrame._edit_watch_profile._pick_folder::wx.DirDialog": "native",
   "quill/ui/main_frame.py::MainFrame._edit_watch_profile::wx.Dialog": "hardened_custom",
   "quill/ui/main_frame.py::MainFrame._offer_crash_recovery::wx.Dialog": "hardened_custom",
+  "quill/ui/main_frame.py::MainFrame._offer_crash_recovery::wx.MessageDialog": "native",
   "quill/ui/main_frame.py::MainFrame._open_find_replace::wx.FindReplaceDialog": "native",
   "quill/ui/main_frame.py::MainFrame._present_quick_nav::wx.Dialog": "hardened_custom",
   "quill/ui/main_frame.py::MainFrame._prompt_code_language::wx.TextEntryDialog": "native",

--- a/tests/unit/ui/test_main_frame_clear_logs.py
+++ b/tests/unit/ui/test_main_frame_clear_logs.py
@@ -1,0 +1,46 @@
+"""Tests for the Crash Recovery dialog's Clear Logs helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from quill.ui.main_frame import MainFrame
+
+
+def _frame() -> MainFrame:
+    return MainFrame.__new__(MainFrame)
+
+
+def test_clear_recovery_logs_removes_files_and_counts(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "quill.log").write_text("a", encoding="utf-8")
+    (logs / "startup-errors.log").write_text("b", encoding="utf-8")
+    (logs / "old.log").write_text("c", encoding="utf-8")
+
+    removed = _frame()._clear_recovery_logs(logs)
+
+    assert removed == 3
+    assert list(logs.iterdir()) == []
+
+
+def test_clear_recovery_logs_empty_folder_returns_zero(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    assert _frame()._clear_recovery_logs(logs) == 0
+
+
+def test_clear_recovery_logs_missing_folder_returns_zero(tmp_path: Path) -> None:
+    assert _frame()._clear_recovery_logs(tmp_path / "nope") == 0
+
+
+def test_clear_recovery_logs_ignores_subdirectories(tmp_path: Path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "a.log").write_text("x", encoding="utf-8")
+    (logs / "archive").mkdir()
+
+    removed = _frame()._clear_recovery_logs(logs)
+
+    assert removed == 1
+    assert (logs / "archive").is_dir()

--- a/tests/unit/ui/test_main_frame_close_resilience.py
+++ b/tests/unit/ui/test_main_frame_close_resilience.py
@@ -1,0 +1,86 @@
+"""The main window must always close, even if a shutdown step fails (#210)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import quill.ui.main_frame as mf
+from quill.ui.main_frame import MainFrame
+
+
+class _FakeWx:
+    @staticmethod
+    def GetTopLevelWindows() -> list[Any]:
+        return []
+
+    @staticmethod
+    def GetApp() -> Any:
+        return None
+
+    @staticmethod
+    def CallAfter(*_a: object, **_k: object) -> None:
+        pass
+
+
+def _raise() -> None:
+    raise RuntimeError("boom")
+
+
+def _frame_for_close(monkeypatch: pytest.MonkeyPatch) -> MainFrame:
+    # Avoid real disk/lock side effects from the guarded shutdown steps.
+    monkeypatch.setattr(mf, "save_settings", lambda *_a, **_k: None)
+    monkeypatch.setattr(mf, "mark_clean_exit", lambda *_a, **_k: None)
+
+    frame = MainFrame.__new__(MainFrame)
+    frame.settings = SimpleNamespace(tray_enabled=False)
+    frame._is_exiting = True
+    frame._can_close_all_documents = lambda: True  # type: ignore[method-assign]
+    frame._watch_queue_monitor = None
+    # Several steps deliberately raise to prove they cannot block the close.
+    frame._watch_service = SimpleNamespace(stop=_raise)
+    frame._unregister_global_hotkeys = _raise  # type: ignore[method-assign]
+    frame._remove_tray_icon = lambda: None  # type: ignore[method-assign]
+    frame.close_ssh_connections = _raise  # type: ignore[method-assign]
+    frame.flush_persistent_undo = _raise  # type: ignore[method-assign]
+    frame.session_id = "test-session"
+    frame._wx = _FakeWx()
+    frame.frame = object()
+    return frame
+
+
+def test_on_close_always_skips_even_when_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = _frame_for_close(monkeypatch)
+    skipped: list[bool] = []
+    vetoed: list[bool] = []
+    event = SimpleNamespace(
+        Skip=lambda: skipped.append(True),
+        Veto=lambda: vetoed.append(True),
+    )
+
+    frame._on_close(event)
+
+    assert skipped == [True], "the window must close (event.Skip) despite failing steps"
+    assert vetoed == []
+
+
+def test_on_close_vetoes_when_documents_cannot_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = _frame_for_close(monkeypatch)
+    frame._can_close_all_documents = lambda: False  # type: ignore[method-assign]
+    skipped: list[bool] = []
+    vetoed: list[bool] = []
+    event = SimpleNamespace(
+        Skip=lambda: skipped.append(True),
+        Veto=lambda: vetoed.append(True),
+    )
+
+    frame._on_close(event)
+
+    assert vetoed == [True]
+    assert skipped == []


### PR DESCRIPTION
Two recovery/shutdown improvements.

## Clear Logs button (Crash Recovery dialog)
- Adds a **Clear Logs** button next to Open Logs Folder and Save Diagnostics. It deletes the log files in `%AppData%\Quill\logs`; the active `quill.log` (held open by the logger on Windows) is truncated in place and still counted. A confirmation dialog reports how many were removed (or that there were none), and the status bar echoes the count.
- New `_clear_recovery_logs` helper, unit-tested (count, empty, missing, ignores subdirectories).

## Harden window close (#210, reopened)
- The window could still refuse to close. `_on_close` ran several cleanup steps (watch-service stop, SSH close, settings write, recovery clean-exit marker) **unguarded** — if any raised or hung, the handler exited before `event.Skip()` and the frame stayed open.
- Every shutdown step now runs under a `_safely()` guard that logs and swallows failures, so the handler always reaches `event.Skip()`. Added an explicit `ExitMainLoop` fallback so the loop ends even if a window slips past cleanup.
- New test proves the window closes despite multiple failing cleanup steps, and still vetoes when documents cannot be closed.

If a hang persists after this, it points to a blocked UI thread rather than the close handler; `python -m quill --dump-stacks` at the moment of the hang will name the culprit.

Full unit suite 2981 passing; dialog inventory regenerated; lint/budget clean.