### PR TITLE
test(ci): give whole-tree banned-patterns scan a longer timeout

### DIFF
--- a/tests/unit/tools/test_check_banned_patterns.py
+++ b/tests/unit/tools/test_check_banned_patterns.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 from quill.tools.check_banned_patterns import (
     _REPO_ROOT,
     _BareWxVisitor,
@@ -24,6 +26,11 @@ def _bare_wx_violations(source: str) -> list[tuple[int, str]]:
     return visitor.violations
 
 
+# find_violations() walks and AST-parses the entire repository tree, which can
+# brush up against the global 30s pytest-timeout on a loaded CI runner (it has
+# flaked with a timeout there). Give this single whole-tree scan more headroom;
+# the rest of the suite keeps the default.
+@pytest.mark.timeout(180)
 def test_clean_tree_has_no_violations() -> None:
     assert find_violations() == []
 


### PR DESCRIPTION
test_clean_tree_has_no_violations runs find_violations(), which walks and AST-parses the entire repo. On a loaded CI runner it brushed up against the global 30s pytest-timeout and flaked (observed on a main push CI run, run 27968770714). Adds @pytest.mark.timeout(180) for this single whole-tree scan; the rest of the suite keeps the 30s default.

Test-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)