### PR TITLE
feat(speech): apply pronunciation dictionaries in batch export (silent, §4.7.4)

### DIFF
--- a/quill/core/speech/batch_export.py
+++ b/quill/core/speech/batch_export.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
+from quill.core.speech.pronunciation import PronunciationDictionary, apply_pronunciations
 from quill.core.speech.text_polish import UnsupportedFormatError, extract_text, polish_for_tts
 
 __all__ = [
@@ -55,6 +56,10 @@ class BatchExportOptions:
     espeak_executable: Path | None = None
     espeak_voice: str = "en"
     espeak_rate: int = 175
+    # Pronunciation dictionaries (§4.7): the resolved active set for this engine
+    # and (the source folder as) project. Applied as a silent text transform before
+    # synthesis — batch writes audio files to disk and never reads aloud.
+    pronunciation_dictionaries: list[PronunciationDictionary] = field(default_factory=list)
 
 
 @dataclass
@@ -64,6 +69,7 @@ class BatchFileResult:
     status: BatchStatus = "pending"
     error: str | None = None
     duration_s: float | None = None
+    pronunciation_applied: int = 0  # §4.7.10 per-file substitution count
 
 
 ProgressFn = Callable[[int, int, "BatchFileResult"], None]
@@ -187,6 +193,14 @@ def run_batch_export(
         t0 = time.monotonic()
         try:
             text = extract_text(res.source_path)
+            # §4.7.4: pronunciation correction runs before polishing, as a silent
+            # text transform (no audio) — the same stage the live path uses.
+            if options.pronunciation_dictionaries:
+                applied = apply_pronunciations(
+                    text, options.engine, options.pronunciation_dictionaries
+                )
+                text = applied.text
+                res.pronunciation_applied = applied.total_applied
             text = polish_for_tts(text)
             if not text.strip():
                 res.status = "skipped"

--- a/tests/unit/core/speech/test_batch_export_pronunciation.py
+++ b/tests/unit/core/speech/test_batch_export_pronunciation.py
@@ -1,0 +1,77 @@
+"""Batch export applies pronunciation dictionaries as a silent text transform.
+
+Batch writes audio files to disk and never reads aloud; here we monkeypatch the
+synthesis call so no engine runs, and assert the *text* handed to synthesis was
+corrected and the per-file substitution count recorded (§4.7.4, §4.7.10).
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from quill.core.speech import batch_export
+from quill.core.speech.batch_export import (
+    BatchExportOptions,
+    BatchFileResult,
+    run_batch_export,
+)
+from quill.core.speech.pronunciation import PronunciationDictionary, PronunciationEntry
+
+
+def _options(src: Path, out: Path, **kw: object) -> BatchExportOptions:
+    return BatchExportOptions(source_folder=src, output_folder=out, **kw)  # type: ignore[arg-type]
+
+
+def test_pronunciations_corrected_before_synthesis_silently(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "doc.md").write_text("I love QUILL.", encoding="utf-8")
+    out = tmp_path / "out"
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        batch_export,
+        "_synthesize_one",
+        lambda text, output_path, opts: seen.append(text),
+    )
+
+    dictionary = PronunciationDictionary(
+        id="d", entries=[PronunciationEntry(term="QUILL", replacement="kwill")]
+    )
+    options = _options(src, out, pronunciation_dictionaries=[dictionary])
+    results = [BatchFileResult(source_path=src / "doc.md")]
+
+    run_batch_export(options, results, lambda *_: None, threading.Event())
+
+    assert seen and "kwill" in seen[0]  # the corrected text reached synthesis
+    assert "QUILL" not in seen[0]
+    assert results[0].status == "done"
+    assert results[0].pronunciation_applied == 1
+
+
+def test_no_dictionaries_leaves_text_untouched(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "doc.md").write_text("Plain QUILL text.", encoding="utf-8")
+    out = tmp_path / "out"
+
+    seen: list[str] = []
+    monkeypatch.setattr(
+        batch_export,
+        "_synthesize_one",
+        lambda text, output_path, opts: seen.append(text),
+    )
+
+    options = _options(src, out)  # no pronunciation_dictionaries
+    results = [BatchFileResult(source_path=src / "doc.md")]
+    run_batch_export(options, results, lambda *_: None, threading.Event())
+
+    assert seen and "QUILL" in seen[0]
+    assert results[0].pronunciation_applied == 0


### PR DESCRIPTION
Wires `apply_pronunciations` into `run_batch_export` as a **silent text transform** between extract and polish — batch writes audio files to disk and never reads aloud; only the text handed to synthesis changes.

- `BatchExportOptions.pronunciation_dictionaries` (resolved active set) and `BatchFileResult.pronunciation_applied` (per-file count, §4.7.10).
- Engine-free tests monkeypatch `_synthesize_one` and assert the corrected text reaches synthesis.

`ruff` + scoped `mypy` clean; speech tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)