### PR TITLE
feat(build): Python 3.13 runtime, winrt OCR, bundled Kokoro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 Next public beta. Rolls up the 0.7.0 line plus subsequent fixes. The GitHub Pages update feed is intentionally left pointed at the prior release so existing testers are not prompted to update until 0.8.0 is published as a release.
 
+### Runtime and packaging
+
+- **Bundled Python runtime moved to 3.13.** The Windows installer's embedded interpreter is now CPython **3.13.14** (was 3.12.6). Minimum supported Python stays 3.12. Every bundled dependency ships a 3.13 Windows wheel.
+- **Native Windows OCR migrated off `winsdk` to the `winrt-*` packages.** `winsdk` (the legacy monolith) shipped no wheel past CPython 3.12, which blocked the 3.13 move; it is replaced by Microsoft's pywinrt namespace packages (`winrt-runtime`, `winrt-Windows.Media.Ocr`, and the Graphics.Imaging/Globalization/Storage namespaces), which ship 3.13 wheels. The projected API is identical, so zero-install Windows OCR (OCR-1) is unchanged for users. Internal: `quill/platform/windows/windows_ocr.py` imports from `winrt.windows.*`; the availability flag is now `_WINRT_AVAILABLE`.
+- **Kokoro neural voices are now bundled in the installer.** The Kokoro ONNX model and voices ship under `{app}/kokoro-models`, so the engine works offline at first launch without the ~114 MB download. The build stages them from a local directory (`--kokoro-dir`) or downloads and SHA-256-verifies them from the pinned kokoro-onnx release.
+
 ### Documentation accuracy and locked-feature hygiene
 
 - **Documentation reconciled against the code.** All user-facing docs (user guide, release notes, control reference, PRD, keybinding standard) were verified against `quill/ui/main_frame_menu.py`, `quill/core/keymap.py`, and `quill/core/feature_catalog.py`. Locked-off features (**BITS Whisperer**, **GLOW**) were removed from the user-facing docs and preserved in `docs/planning/deferred-locked-features.md`; offline-speech menu paths were corrected to the flat **Tools > Speech** (the gated "Whisperer" submenu no longer appears in docs); and stale keybindings/menu names were fixed to match the code — AI Grammar and Style (`Ctrl+Alt+Shift+G`), Translate Selection (`Ctrl+Alt+Shift+T`), AI Thesaurus (`Ctrl+Alt+Shift+H`), Compare navigation (`Ctrl+Alt+Shift+.` / `,` / `D`), Verbosity Quiet/Meeting/Undo (no default key), Replace (`Ctrl+H`), Browser Preview (`QUILL Key + V`), List submenu under **Insert** (not Format), the **Advanced** Tools submenu (was documented as "Power Tools"), and **Keymap Editor** (was "Keyboard Manager").

--- a/docs/release/clean-quill-install.ps1
+++ b/docs/release/clean-quill-install.ps1
@@ -8,9 +8,19 @@
     like a first-time install. Verifies the machine is clean afterward.
 
     Locations removed:
-      - %LOCALAPPDATA%\Programs\QUILL for All   (install dir)
+      - %LOCALAPPDATA%\Programs\QUILL for All   (install dir, 0.7.0+)
+      - %LOCALAPPDATA%\Programs\Quill           (install dir, 0.5.0/0.6.0 branding)
+      - %ProgramFiles%\QUILL for All            (admin-elevated install, 0.7.0+)
+      - %ProgramFiles%\Quill                    (admin-elevated install, 0.5.0/0.6.0)
       - %APPDATA%\Quill                          (settings, keymap, recovery, AI)
       - %LOCALAPPDATA%\Quill                     (caches, if present)
+
+    The 0.5.0/0.6.0 installer used AppName "Quill" (dir "Quill"); 0.7.0+ uses
+    "QUILL for All". Because all releases share the same Inno AppId, an upgrade
+    reuses the original folder - so a clean reset for upgrade-path testing must
+    cover BOTH names. The installer is per-user by default but allows elevating
+    to an admin (Program Files) install via the privileges dialog, so those
+    locations are cleaned too.
 
     WARNING: %APPDATA%\Quill holds your real settings and any per-user data.
     Deleting it is what makes the test a true fresh install. Use -Backup to
@@ -39,10 +49,18 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$installDir = Join-Path $env:LOCALAPPDATA 'Programs\QUILL for All'
+# Per-user install dirs (default). Both AppName variants across versions.
+$installDirNew = Join-Path $env:LOCALAPPDATA 'Programs\QUILL for All'
+$installDirOld = Join-Path $env:LOCALAPPDATA 'Programs\Quill'
+# Admin-elevated install dirs (only if the user chose elevation in the dialog).
+$pf = if ($env:ProgramFiles) { $env:ProgramFiles } else { 'C:\Program Files' }
+$installPfNew = Join-Path $pf 'QUILL for All'
+$installPfOld = Join-Path $pf 'Quill'
+$installDirs = @($installDirNew, $installDirOld, $installPfNew, $installPfOld)
+
 $dataRoaming = Join-Path $env:APPDATA 'Quill'
 $dataLocal  = Join-Path $env:LOCALAPPDATA 'Quill'
-$targets = @($installDir, $dataRoaming, $dataLocal)
+$targets = @($installDirs + @($dataRoaming, $dataLocal))
 
 function Write-State {
     param([string]$Label)
@@ -57,11 +75,15 @@ function Write-State {
 
 Write-State -Label 'before'
 
-# 1. Stop any running QUILL process.
+# 1. Stop any running QUILL process (matched by install dir, either branding).
 $procNames = @('quill', 'pythonw', 'python')
+$installDirsLower = $installDirs | ForEach-Object { $_.ToLower() }
 $running = Get-Process -Name $procNames -ErrorAction SilentlyContinue |
     Where-Object {
-        try { $_.Path -and $_.Path.ToLower().Contains('quill for all') } catch { $false }
+        try {
+            $p = $_.Path
+            $p -and ($installDirsLower | Where-Object { $p.ToLower().StartsWith($_) })
+        } catch { $false }
     }
 if ($running) {
     Write-Host ""
@@ -94,13 +116,15 @@ if (-not $Force) {
 # 2b. Run the Inno Setup uninstaller first if present, so the Add/Remove
 #     Programs entry, registry keys, and Start Menu shortcuts are cleared
 #     too (manual folder deletion alone leaves those orphaned).
-if (Test-Path -LiteralPath $installDir) {
-    $uninst = Get-ChildItem -LiteralPath $installDir -Filter 'unins*.exe' -ErrorAction SilentlyContinue |
-        Sort-Object Name | Select-Object -First 1
-    if ($uninst) {
-        Write-Host "Running uninstaller: $($uninst.FullName)"
-        Start-Process -FilePath $uninst.FullName -ArgumentList '/VERYSILENT', '/NORESTART', '/SUPPRESSMSGBOXES' -Wait
-        Start-Sleep -Milliseconds 500
+foreach ($dir in $installDirs) {
+    if (Test-Path -LiteralPath $dir) {
+        $uninst = Get-ChildItem -LiteralPath $dir -Filter 'unins*.exe' -ErrorAction SilentlyContinue |
+            Sort-Object Name | Select-Object -First 1
+        if ($uninst) {
+            Write-Host "Running uninstaller: $($uninst.FullName)"
+            Start-Process -FilePath $uninst.FullName -ArgumentList '/VERYSILENT', '/NORESTART', '/SUPPRESSMSGBOXES' -Wait
+            Start-Sleep -Milliseconds 500
+        }
     }
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ authors = [
 classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: MacOS",
 ]
@@ -93,12 +94,25 @@ mp3 = ["mutagen>=1.47"]
 # an "ElevenLabs API key" credential is configured. All calls go through the
 # host-owned gateway quill/core/ai/elevenlabs_tts.py (the only importer of the SDK).
 elevenlabs = ["elevenlabs>=1.0.0"]
-# Native Windows OCR (OCR-1): a thin pip wheel projecting the Windows.Media.Ocr
+# Native Windows OCR (OCR-1): thin pip wheels projecting the Windows.Media.Ocr
 # WinRT APIs that ship inside Windows 10/11. The OCR engine itself is a built-in
-# OS component, so end users install nothing extra — bundling this wheel makes
+# OS component, so end users install nothing extra — bundling these wheels makes
 # the zero-install Windows backend available; Tesseract (OCR-2) stays a separate
 # opt-in install for users who choose it.
-ocr = ["winsdk>=1.0.0b10; sys_platform == 'win32'"]
+#
+# These are the Microsoft pywinrt ``winrt-*`` namespace packages. They replace
+# the legacy ``winsdk`` monolith, whose wheels stopped at cp312 and so blocked
+# the embedded-runtime move to Python 3.13; the projected API is identical (see
+# quill/platform/windows/windows_ocr.py). Only the directly-imported namespaces
+# plus winrt-runtime are listed; pywinrt pulls the rest (Foundation,
+# Storage.Streams, ...) transitively.
+ocr = [
+    "winrt-runtime>=3.2.1; sys_platform == 'win32'",
+    "winrt-Windows.Media.Ocr>=3.2.1; sys_platform == 'win32'",
+    "winrt-Windows.Graphics.Imaging>=3.2.1; sys_platform == 'win32'",
+    "winrt-Windows.Globalization>=3.2.1; sys_platform == 'win32'",
+    "winrt-Windows.Storage>=3.2.1; sys_platform == 'win32'",
+]
 # Kokoro neural TTS (offline, no GPU/torch required). kokoro-onnx runs the Kokoro
 # voice model through onnxruntime (CPU). Voice model files (~114 MB) are downloaded
 # on first use via Voice Picker > Download Kokoro and stored in the app data dir.

--- a/quill/core/speech/engine_install.py
+++ b/quill/core/speech/engine_install.py
@@ -57,9 +57,12 @@ _KOKORO_ONNX_PACK = "kokoro-onnx"
 _KOKORO_ONNX_MODULE = "kokoro_onnx"
 
 # kokoro-onnx pulls in onnxruntime as a transitive dep; soundfile handles WAV I/O.
+# Keep these floors in sync with the pyproject ``kokoro`` extra -- the latest
+# kokoro-onnx is 0.5.0 (capped at Python <3.14), so an earlier >=0.9 floor here
+# was unsatisfiable and the on-demand install could never resolve a version.
 _KOKORO_ONNX_REQUIREMENTS: tuple[str, ...] = (
-    "kokoro-onnx>=0.9",
-    "soundfile>=0.12",
+    "kokoro-onnx>=0.5.0",
+    "soundfile>=0.14.0",
 )
 
 _INSTALL_TIMEOUT_S = 1800.0

--- a/quill/io/ocr.py
+++ b/quill/io/ocr.py
@@ -93,7 +93,7 @@ class OcrBackend(Protocol):
 class WindowsOcrBackend:
     """Native ``Windows.Media.Ocr`` backend, fully offline and zero-install (OCR-1).
 
-    Recognition uses the WinRT OCR engine via ``winsdk``/``winrt`` when present.
+    Recognition uses the WinRT OCR engine via the ``winrt-*`` packages when present.
     On a non-Windows machine or without the projection installed,
     :meth:`is_available` returns ``False`` so selection falls back cleanly.
     """

--- a/quill/platform/windows/windows_ocr.py
+++ b/quill/platform/windows/windows_ocr.py
@@ -1,13 +1,18 @@
 """Native Windows OCR recognition via ``Windows.Media.Ocr`` (OCR-1).
 
-H-3-platform: the winsdk imports are now wrapped in a try/except so this
-module can be imported on machines without winsdk installed.  The public
-entry point ``recognize_with_windows_ocr`` raises :class:`OcrUnavailableError`
-at *call* time rather than failing at *import* time.  The caller
-(:func:`quill.io.ocr._import_windows_ocr`) already handles ``Exception``
-during import, but making the module itself importable means ``import``-time
-failures in CI or on non-Windows dev boxes no longer cascade into unrelated
-test failures. No ``wx`` imports.
+H-3-platform: the winrt imports are now wrapped in a try/except so this
+module can be imported on machines without the winrt packages installed.  The
+public entry point ``recognize_with_windows_ocr`` raises
+:class:`OcrUnavailableError` at *call* time rather than failing at *import*
+time.  The caller (:func:`quill.io.ocr._import_windows_ocr`) already handles
+``Exception`` during import, but making the module itself importable means
+``import``-time failures in CI or on non-Windows dev boxes no longer cascade
+into unrelated test failures. No ``wx`` imports.
+
+The backend is the Microsoft pywinrt ``winrt-*`` namespace packages, which
+ship wheels for current CPython (including 3.13). They replace the legacy
+``winsdk`` monolith, whose wheels stopped at cp312; the projected API
+(class and async-method names) is identical, so only the import roots differ.
 """
 
 from __future__ import annotations
@@ -15,19 +20,19 @@ from __future__ import annotations
 from pathlib import Path
 
 try:
-    from winsdk.windows.globalization import Language  # type: ignore[import-not-found]
-    from winsdk.windows.graphics.imaging import (  # type: ignore[import-not-found]
+    from winrt.windows.globalization import Language  # type: ignore[import-not-found]
+    from winrt.windows.graphics.imaging import (  # type: ignore[import-not-found]
         BitmapDecoder,
     )
-    from winsdk.windows.media.ocr import OcrEngine  # type: ignore[import-not-found]
-    from winsdk.windows.storage import (  # type: ignore[import-not-found]
+    from winrt.windows.media.ocr import OcrEngine  # type: ignore[import-not-found]
+    from winrt.windows.storage import (  # type: ignore[import-not-found]
         FileAccessMode,
         StorageFile,
     )
 
-    _WINSDK_AVAILABLE = True
+    _WINRT_AVAILABLE = True
 except ImportError:
-    _WINSDK_AVAILABLE = False
+    _WINRT_AVAILABLE = False
     Language = BitmapDecoder = OcrEngine = FileAccessMode = StorageFile = None  # type: ignore[assignment,misc]
 
 from quill.io.ocr import OcrLine
@@ -35,19 +40,21 @@ from quill.io.ocr import OcrLine
 
 def recognize_with_windows_ocr(
     path: Path, language: str | None
-) -> tuple[str, list[OcrLine]]:  # pragma: no cover - requires Windows + winsdk
+) -> tuple[str, list[OcrLine]]:  # pragma: no cover - requires Windows + winrt
     """Recognize text in ``path`` with the native Windows OCR engine.
 
     Returns the joined text and per-line :class:`OcrLine` records.  Raises
-    :class:`~quill.io.ocr.OcrUnavailableError` when the ``winsdk`` package is
-    not installed so callers degrade gracefully instead of hitting an
+    :class:`~quill.io.ocr.OcrUnavailableError` when the ``winrt`` OCR packages
+    are not installed so callers degrade gracefully instead of hitting an
     ``AttributeError`` on a ``None`` name.
     """
-    if not _WINSDK_AVAILABLE:
+    if not _WINRT_AVAILABLE:
         from quill.io.ocr import OcrUnavailableError
 
         raise OcrUnavailableError(
-            "The 'winsdk' package is not installed. Install it with: pip install winsdk"
+            "The Windows OCR (winrt) packages are not installed. Install them with: "
+            "pip install winrt-Windows.Media.Ocr winrt-Windows.Graphics.Imaging "
+            "winrt-Windows.Globalization winrt-Windows.Storage"
         )
 
     import asyncio

--- a/quill/tools/network_egress_audit.py
+++ b/quill/tools/network_egress_audit.py
@@ -328,7 +328,7 @@ _REVIEWED_EGRESS: dict[str, str] = {
 #   Triggered: Manage Speech Models > Install Vosk, or Tools > Speech > Install Vosk.
 #
 # quill/core/speech/engine_install.py::install_kokoro_onnx
-#   Installs kokoro-onnx>=0.9 and soundfile>=0.12 (~20 MB + onnxruntime transitive).
+#   Installs kokoro-onnx>=0.5.0 and soundfile>=0.14.0 (~20 MB + onnxruntime transitive).
 #   Triggered automatically after the Kokoro model files are downloaded
 #   (Manage Voices > Download Kokoro), or explicitly from Manage Speech Models >
 #   Install Kokoro ONNX, or Tools > Speech > Install Kokoro ONNX.

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,10 +45,10 @@ SpeechRecognition>=3.17.0
 
 # Native Windows OCR (OCR-1) lives in pyproject's [ocr] extra, not here. It is
 # bundled into packaged Windows builds (scripts/build_windows_distribution.py),
-# but the winsdk wheel only ships for stable CPython releases, so listing it in
-# this catch-all requirements file would break `pip install` / tooling envs on
-# newer/older interpreters. Install it explicitly with: pip install winsdk
-# (or `pip install .[ocr]`) on a supported Windows Python.
+# but the winrt-* OCR wheels are Windows-only, so listing them in this
+# catch-all requirements file would break `pip install` / tooling envs on
+# non-Windows interpreters. Install them explicitly with `pip install .[ocr]`
+# on a supported Windows Python.
 
 # Structured document import (Word/PowerPoint/Excel/Pages/PDF fallback).
 # Only the converters Quill actually routes through MarkItDown are pulled in

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -48,14 +48,14 @@ from quill.branding import APP_DISPLAY_NAME, APP_ORGANIZATION  # noqa: E402
 
 # Pinned Windows embeddable Python. Bumping these values is the only
 # thing needed to ship on a new Python point release.
-EMBEDDED_PYTHON_VERSION = "3.12.6"
+EMBEDDED_PYTHON_VERSION = "3.13.14"
 EMBEDDED_PYTHON_URL = (
     f"https://www.python.org/ftp/python/{EMBEDDED_PYTHON_VERSION}/"
     f"python-{EMBEDDED_PYTHON_VERSION}-embed-amd64.zip"
 )
 # SHA-256 of the official embeddable zip. If python.org rotates the file
 # the build will fail loudly rather than ship an unverified runtime.
-EMBEDDED_PYTHON_SHA256 = "a86a2e28870967745d255cc597d1e4d19ae79e65e927cdc324baa0256202231c"
+EMBEDDED_PYTHON_SHA256 = "90b4e5b9898b72d744650524bff92377c367f44bd5fbd09e3148656c080ad907"
 
 DECTALK_RELEASE_ZIP_URL = (
     "https://github.com/dectalk/dectalk/releases/download/2023-10-30/vs2022.zip"
@@ -82,6 +82,25 @@ PIPER_PINNED_URL = (
     "https://github.com/rhasspy/piper/releases/download/2023.11.14-2/piper_windows_amd64.zip"
 )
 PIPER_PINNED_SHA256 = "f3c58906402b24f3a96d92145f58acba6d86c9b5db896d207f78dc80811efcea"
+
+# Kokoro neural-TTS model + voices. Unlike the other engines, Kokoro ships via
+# the generic ..\portable\* installer copy under {app}\kokoro-models -- the exact
+# location the runtime resolves in quill.core.read_aloud._bundled_kokoro_model_dir
+# -- so there is no dedicated installer component (see the test that asserts
+# "speechkokoro" is absent). The filenames mirror KOKORO_ONNX_MODEL_FILENAME /
+# KOKORO_ONNX_VOICES_FILENAME in read_aloud.py; keep them in sync. _stage_kokoro
+# downloads + SHA-256 verifies these unless a local --kokoro-dir is provided.
+KOKORO_MODEL_FILENAME = "kokoro-v1.0.int8.onnx"
+KOKORO_VOICES_FILENAME = "voices-v1.0.bin"
+KOKORO_MODEL_URL = (
+    "https://github.com/thewh1teagle/kokoro-onnx/releases/download/"
+    "model-files-v1.0/kokoro-v1.0.int8.onnx"
+)
+KOKORO_MODEL_SHA256 = "6e742170d309016e5891a994e1ce1559c702a2ccd0075e67ef7157974f6406cb"
+KOKORO_VOICES_URL = (
+    "https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/voices-v1.0.bin"
+)
+KOKORO_VOICES_SHA256 = "bca610b8308e8d99f32e6fe4197e7ec01679264efed0cac9140fe9c29f1fbf7d"
 
 # GLOW is hidden for 0.5.0 (the core.glow feature is locked off), so the heavy
 # `glow` extra (quill-glow-core[glow], not yet on a public index) is NOT bundled
@@ -154,7 +173,12 @@ def main() -> int:
         "--kokoro-dir",
         type=Path,
         default=None,
-        help="Optional local Kokoro voices/models directory to bundle under portable\\tools\\speech\\kokoro.",
+        help=(
+            "Optional local directory holding the Kokoro model files "
+            "(kokoro-v1.0.int8.onnx, voices-v1.0.bin) to stage under "
+            "portable\\kokoro-models. When omitted the files are downloaded from "
+            "the pinned kokoro-onnx release and SHA-256 verified."
+        ),
     )
     parser.add_argument(
         "--whisper-dir",
@@ -202,11 +226,11 @@ def main() -> int:
                 "pandoc": args.pandoc_dir,
                 "speech/dectalk": args.dectalk_dir,
                 "speech/espeak-ng": args.espeak_dir,
-                "speech/kokoro": args.kokoro_dir,
                 "speech/whispercpp": args.whisper_dir,
             }.items()
             if path is not None
         },
+        kokoro_dir=args.kokoro_dir,
         compile_installer=args.compile_installer,
         iscc_path=args.iscc_path,
     )
@@ -225,6 +249,7 @@ def build_windows_distribution(
     bundle_python: bool = False,
     source_root: Path | None = None,
     bundled_tool_dirs: dict[str, Path] | None = None,
+    kokoro_dir: Path | None = None,
     braille_pack_dir: Path | None = None,
     compile_installer: bool = False,
     iscc_path: Path | None = None,
@@ -261,6 +286,9 @@ def build_windows_distribution(
     if "speech/piper" not in effective_bundled_tools:
         effective_bundled_tools["speech/piper"] = _download_and_stage_piper(portable_dir)
     bundled_tools = _stage_bundled_tools(portable_dir, effective_bundled_tools)
+    # Kokoro is staged separately (not via _stage_bundled_tools): it ships under
+    # the bundle-root kokoro-models/ folder the runtime looks for, not tools/.
+    _stage_kokoro(portable_dir, kokoro_dir)
 
     readme = portable_dir / "README.txt"
     readme.write_text(
@@ -1308,6 +1336,47 @@ def _stage_bundled_tools(portable_dir: Path, bundled_tool_dirs: dict[str, Path])
     return sorted(bundled)
 
 
+def _stage_kokoro(portable_dir: Path, source_dir: Path | None) -> bool:
+    """Stage the Kokoro ONNX model + voices into portable/kokoro-models/.
+
+    The runtime (quill.core.read_aloud._bundled_kokoro_model_dir) resolves a
+    bundled Kokoro copy from {app}/kokoro-models, so the two files ship via the
+    generic ..\\portable\\* installer copy rather than a dedicated component.
+
+    When *source_dir* is given (the --kokoro-dir flag) the model and voices are
+    copied from there; otherwise they are downloaded from the pinned kokoro-onnx
+    release and SHA-256 verified. An already-staged pair is reused. Returns True
+    when both files are present after staging.
+    """
+    target = portable_dir / "kokoro-models"
+    target.mkdir(parents=True, exist_ok=True)
+    model_dst = target / KOKORO_MODEL_FILENAME
+    voices_dst = target / KOKORO_VOICES_FILENAME
+    if model_dst.exists() and voices_dst.exists():
+        print("Kokoro models already staged; skipping.")
+        return True
+
+    if source_dir is not None:
+        model_src = source_dir / KOKORO_MODEL_FILENAME
+        voices_src = source_dir / KOKORO_VOICES_FILENAME
+        missing = [str(p) for p in (model_src, voices_src) if not p.exists()]
+        if missing:
+            raise RuntimeError(
+                "Kokoro source directory is missing required files: " + ", ".join(missing)
+            )
+        shutil.copy2(model_src, model_dst)
+        shutil.copy2(voices_src, voices_dst)
+        print(f"Kokoro models copied from {source_dir} to {target}")
+        return True
+
+    print(f"Downloading Kokoro model from {KOKORO_MODEL_URL}...")
+    _download_with_verification(KOKORO_MODEL_URL, model_dst, expected_sha256=KOKORO_MODEL_SHA256)
+    print(f"Downloading Kokoro voices from {KOKORO_VOICES_URL}...")
+    _download_with_verification(KOKORO_VOICES_URL, voices_dst, expected_sha256=KOKORO_VOICES_SHA256)
+    print(f"Kokoro models staged to {target}")
+    return True
+
+
 def _download_and_stage_dectalk_release(portable_dir: Path) -> Path:
     speech_root = portable_dir / "_speech-download" / "dectalk"
     speech_root.mkdir(parents=True, exist_ok=True)
@@ -1349,6 +1418,18 @@ def _speech_asset_manifest(
             "exists": engine_dir.exists(),
             "downloadable": True,
         }
+    # Kokoro lives at the bundle root (kokoro-models/), not under tools/speech,
+    # because that is where the runtime resolves a bundled copy via QUILL_APP_ROOT.
+    kokoro_dir = portable_dir / "kokoro-models"
+    kokoro_ready = (kokoro_dir / KOKORO_MODEL_FILENAME).exists() and (
+        kokoro_dir / KOKORO_VOICES_FILENAME
+    ).exists()
+    manifest["kokoro"] = {
+        "bundled": kokoro_ready,
+        "path": str(kokoro_dir) if kokoro_ready else "",
+        "exists": kokoro_ready,
+        "downloadable": True,
+    }
     return manifest
 
 

--- a/tests/unit/platform/windows/test_windows_ocr.py
+++ b/tests/unit/platform/windows/test_windows_ocr.py
@@ -1,8 +1,9 @@
-"""Tests for windows_ocr.py importability without winsdk (H-3-platform).
+"""Tests for windows_ocr.py importability without the winrt OCR packages.
 
-The winsdk package is a Windows-runtime-only optional dependency.  On CI and
-non-Windows dev boxes it is not installed.  The module must be importable
-regardless and must raise OcrUnavailableError at call time, not at import time.
+H-3-platform: the winrt-* packages are a Windows-runtime-only optional
+dependency.  On CI and non-Windows dev boxes they are not installed.  The module
+must be importable regardless and must raise OcrUnavailableError at call time,
+not at import time.
 """
 
 from __future__ import annotations
@@ -11,24 +12,27 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+# The winrt sub-modules windows_ocr.py imports. Patching these to None in
+# sys.modules simulates the packages being absent so the import falls into the
+# graceful try/except path.
+_WINRT_MODS = [
+    "winrt",
+    "winrt.windows",
+    "winrt.windows.globalization",
+    "winrt.windows.graphics",
+    "winrt.windows.graphics.imaging",
+    "winrt.windows.media",
+    "winrt.windows.media.ocr",
+    "winrt.windows.storage",
+]
 
-def test_module_imports_without_winsdk() -> None:
-    """H-3-platform: windows_ocr imports cleanly when winsdk is absent."""
+
+def test_module_imports_without_winrt() -> None:
+    """H-3-platform: windows_ocr imports cleanly when the winrt packages are absent."""
     # Remove the module from the cache so the import runs fresh.
     mod_name = "quill.platform.windows.windows_ocr"
     cached = sys.modules.pop(mod_name, None)
-    # Patch all winsdk sub-modules to simulate absence.
-    winsdk_mods = [
-        "winsdk",
-        "winsdk.windows",
-        "winsdk.windows.globalization",
-        "winsdk.windows.graphics",
-        "winsdk.windows.graphics.imaging",
-        "winsdk.windows.media",
-        "winsdk.windows.media.ocr",
-        "winsdk.windows.storage",
-    ]
-    with patch.dict(sys.modules, {m: None for m in winsdk_mods}):  # type: ignore[arg-type]
+    with patch.dict(sys.modules, {m: None for m in _WINRT_MODS}):  # type: ignore[arg-type]
         try:
             import importlib
 
@@ -40,33 +44,23 @@ def test_module_imports_without_winsdk() -> None:
                 sys.modules[mod_name] = cached
     # If we got here without ImportError the module is importable.
     assert hasattr(mod, "recognize_with_windows_ocr")
-    assert mod._WINSDK_AVAILABLE is False  # type: ignore[attr-defined]
+    assert mod._WINRT_AVAILABLE is False  # type: ignore[attr-defined]
 
 
-def test_recognize_raises_ocr_unavailable_when_winsdk_missing() -> None:
-    """H-3-platform: recognize_with_windows_ocr raises OcrUnavailableError when winsdk absent."""
+def test_recognize_raises_ocr_unavailable_when_winrt_missing() -> None:
+    """H-3-platform: recognize_with_windows_ocr raises OcrUnavailableError when winrt absent."""
     from quill.io.ocr import OcrUnavailableError
 
     mod_name = "quill.platform.windows.windows_ocr"
     cached = sys.modules.pop(mod_name, None)
-    winsdk_mods = [
-        "winsdk",
-        "winsdk.windows",
-        "winsdk.windows.globalization",
-        "winsdk.windows.graphics",
-        "winsdk.windows.graphics.imaging",
-        "winsdk.windows.media",
-        "winsdk.windows.media.ocr",
-        "winsdk.windows.storage",
-    ]
     import pytest
 
-    with patch.dict(sys.modules, {m: None for m in winsdk_mods}):  # type: ignore[arg-type]
+    with patch.dict(sys.modules, {m: None for m in _WINRT_MODS}):  # type: ignore[arg-type]
         try:
             import importlib
 
             mod = importlib.import_module(mod_name)
-            with pytest.raises(OcrUnavailableError, match="winsdk"):
+            with pytest.raises(OcrUnavailableError, match="winrt"):
                 mod.recognize_with_windows_ocr(Path("dummy.png"), None)
         finally:
             sys.modules.pop(mod_name, None)

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -49,7 +49,17 @@ version = "2.4.6"
         encoding="utf-8",
     )
 
-    bundle = build_windows_distribution(pyproject, tmp_path / "dist")
+    # Kokoro ships ~120 MB of model files; stage them from a local fake dir so
+    # this offline test never downloads them (production downloads when no dir
+    # is given). The two filenames must match _stage_kokoro's expectations.
+    fake_kokoro_dir = tmp_path / "kokoro-src"
+    fake_kokoro_dir.mkdir()
+    (fake_kokoro_dir / "kokoro-v1.0.int8.onnx").write_text("model", encoding="utf-8")
+    (fake_kokoro_dir / "voices-v1.0.bin").write_text("voices", encoding="utf-8")
+
+    bundle = build_windows_distribution(
+        pyproject, tmp_path / "dist", kokoro_dir=fake_kokoro_dir
+    )
 
     portable_dir = tmp_path / "dist" / "portable"
     installer_script = tmp_path / "dist" / "installer" / "quill.iss"
@@ -96,6 +106,11 @@ version = "2.4.6"
     assert manifest["speechAssets"]["dectalk"]["downloadable"] is True
     assert manifest["speechAssets"]["espeak"]["downloadable"] is True
     assert manifest["speechAssets"]["piper"]["downloadable"] is True
+    # Kokoro ships at the bundle root (kokoro-models/), the location the runtime
+    # resolves a bundled copy from, not under tools/speech and not as a component.
+    assert manifest["speechAssets"]["kokoro"]["bundled"] is True
+    assert (portable_dir / "kokoro-models" / "kokoro-v1.0.int8.onnx").exists()
+    assert (portable_dir / "kokoro-models" / "voices-v1.0.bin").exists()
 
     assert installer_script.exists()
     assert bundle["installer_script"] == str(installer_script)
@@ -348,11 +363,16 @@ version = "3.0.0"
     fake_pandoc_dir = tmp_path / "pandoc"
     fake_pandoc_dir.mkdir()
     (fake_pandoc_dir / "pandoc.exe").write_text("binary", encoding="utf-8")
+    fake_kokoro_dir = tmp_path / "kokoro-src"
+    fake_kokoro_dir.mkdir()
+    (fake_kokoro_dir / "kokoro-v1.0.int8.onnx").write_text("model", encoding="utf-8")
+    (fake_kokoro_dir / "voices-v1.0.bin").write_text("voices", encoding="utf-8")
 
     bundle = build_windows_distribution(
         pyproject,
         tmp_path / "dist",
         bundled_tool_dirs={"pandoc": fake_pandoc_dir},
+        kokoro_dir=fake_kokoro_dir,
     )
 
     manifest = json.loads(
@@ -361,6 +381,9 @@ version = "3.0.0"
     assert "pandoc" in manifest["bundledTools"]
     assert "speech/piper" in manifest["bundledTools"]
     assert manifest["speechAssets"]["dectalk"]["bundled"] is True
+    # Kokoro is staged to the bundle root, not tools/, and not via bundledTools.
+    assert manifest["speechAssets"]["kokoro"]["bundled"] is True
+    assert (tmp_path / "dist" / "portable" / "kokoro-models" / "voices-v1.0.bin").exists()
     assert (tmp_path / "dist" / "portable" / "tools" / "pandoc" / "pandoc.exe").exists()
     assert bundle["portable_dir"] == str(tmp_path / "dist" / "portable")
 

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -57,9 +57,7 @@ version = "2.4.6"
     (fake_kokoro_dir / "kokoro-v1.0.int8.onnx").write_text("model", encoding="utf-8")
     (fake_kokoro_dir / "voices-v1.0.bin").write_text("voices", encoding="utf-8")
 
-    bundle = build_windows_distribution(
-        pyproject, tmp_path / "dist", kokoro_dir=fake_kokoro_dir
-    )
+    bundle = build_windows_distribution(pyproject, tmp_path / "dist", kokoro_dir=fake_kokoro_dir)
 
     portable_dir = tmp_path / "dist" / "portable"
     installer_script = tmp_path / "dist" / "installer" / "quill.iss"


### PR DESCRIPTION
## Summary

Moves the bundled Windows runtime to CPython 3.13.14 (was 3.12.6) and clears the one dependency that blocked it.

- **OCR migrated off `winsdk` to the `winrt-*` packages.** `winsdk` ships no wheel past cp312, which blocked 3.13. Replaced with Microsoft's pywinrt namespace packages (`winrt-runtime`, `winrt-Windows.Media.Ocr`, Graphics.Imaging/Globalization/Storage), which have cp313/cp314 wheels. Projected API is identical, so zero-install Windows OCR (OCR-1) is unchanged. Flag `_WINSDK_AVAILABLE` -> `_WINRT_AVAILABLE`; `ocr` extra updated.
- **Kokoro neural voices bundled in the installer.** New `_stage_kokoro` stages the ONNX model + voices under `{app}/kokoro-models` (where the runtime resolves a bundled copy) — copied from `--kokoro-dir` or downloaded + SHA-256 verified from the pinned kokoro-onnx release. Ships via the generic portable copy; no installer component.
- **Fixed an unsatisfiable pin.** `engine_install` requested `kokoro-onnx>=0.9` but the latest release is 0.5.0, so the on-demand install could never resolve. Aligned to the pyproject floor (`>=0.5.0`, `soundfile>=0.14.0`).
- **Embedded Python bumped to 3.13.14** (URL + SHA-256) and 3.13 classifier added. Minimum supported Python stays 3.12. Python 3.14 remains blocked only by kokoro-onnx's `<3.14` cap.

## Validation
- winrt OCR projection imports cleanly on Python 3.13 (`_WINRT_AVAILABLE = True`).
- `pytest` on the affected areas (windows_ocr, io/ocr, engine_install, build_windows_distribution helpers) passes; full unit suite collects (5649 tests).
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)