### PR TITLE
fix(deps): pin llama-cpp-python to the prebuilt CPU wheel (0.3.19)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,11 @@ audio = ["sound_lib>=0.83"]
 ssh = ["paramiko>=5.0.0"]
 # On-device AI for the Ask Quill chat. Windows/Linux use llama.cpp (CPU, GGUF);
 # a GGUF model (e.g. Phi-4-mini Q4) goes in <app data>/models or QUILL_LLAMA_MODEL.
-ai = ["llama-cpp-python>=0.3.31"]
+# Pinned to the newest version with a prebuilt CPU wheel on the abetlen index
+# (see requirements.txt). A higher floor has no wheel and makes pip compile
+# llama.cpp from source. Install via requirements.txt (which carries the
+# --extra-index-url) or pass that index so the wheel resolves.
+ai = ["llama-cpp-python==0.3.19"]
 dictation = ["SpeechRecognition>=3.17.0"]
 # Offline speech-to-text (#617). The whisper.cpp executable + GGML models are
 # managed out-of-band (AI > Speech > Manage Speech Models); this optional extra

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,13 @@ pyenchant>=3.3.0
 # Windows/Linux use llama.cpp (CPU, GGUF) — also download a GGUF model
 # (e.g. Phi-4-mini Q4) into <app data>/models or set QUILL_LLAMA_MODEL.
 # Use llama-cpp-python CPU wheels to avoid source builds and Windows long-path failures.
+# Pin to the newest version with a prebuilt CPU wheel on the index below
+# (currently 0.3.19, cp310-cp313 win_amd64). A higher floor (>=0.3.31) has no
+# prebuilt wheel, so pip silently falls back to the PyPI sdist and compiles
+# llama.cpp from source via CMake -- which hangs. Bump this only when the index
+# publishes a newer wheel for the supported Python versions.
 --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
-llama-cpp-python>=0.3.31
+llama-cpp-python==0.3.19
 
 # Dictation / voice input (mic permission required).
 SpeechRecognition>=3.17.0


### PR DESCRIPTION
## Problem

`python -m pip install -r requirements.txt` hangs on `llama-cpp-python`.

## Root cause

`requirements.txt` and the pyproject `ai` extra pinned `llama-cpp-python>=0.3.31`, but abetlen's prebuilt CPU wheel index (the `--extra-index-url` in requirements.txt) tops out at **0.3.19**. No prebuilt wheel satisfies `>=0.3.31`, so pip falls back to the PyPI source sdist and compiles llama.cpp via CMake — a long source build that looks like a hang, and exactly what the requirements comment says to avoid.

## Fix

Pin both `requirements.txt` and the `ai` extra to `==0.3.19` — the newest version with a prebuilt `cp310`–`cp313` `win_amd64` wheel. `pip install -r requirements.txt` now resolves the wheel instead of building from source.

Verified: `pip install llama-cpp-python==0.3.19 --only-binary=:all: --dry-run --extra-index-url <abetlen cpu>` resolves `llama_cpp_python-0.3.19-cp313-cp313-win_amd64.whl` (no source build).

The packaged Windows build is unaffected — the `ai` group is not bundled into the embedded runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)