### PR TITLE
feat(updates): env overrides for release-rehearsal endpoints

### DIFF
--- a/quill/core/updates.py
+++ b/quill/core/updates.py
@@ -22,9 +22,28 @@ GITHUB_RELEASES_API = "https://api.github.com/repos/Community-Access/quill/relea
 _SIGNATURE_SALT = "quill-manifest-signature-v1"
 _MANIFEST_KEY_ENV = "QUILL_UPDATE_MANIFEST_KEY"
 _TRUSTED_HOSTS_ENV = "QUILL_UPDATE_TRUSTED_HOSTS"
+# Test/rehearsal overrides. Both default to the production endpoints and are
+# inert unless explicitly set, so a release can be dry-run against a throwaway
+# repo/feed without touching the public ones. The asset-download path still
+# enforces HTTPS + the trusted-host allowlist, so an override can only redirect
+# *discovery*, never relax download security.
+_API_URL_ENV = "QUILL_UPDATE_API_URL"
+_MANIFEST_URL_ENV = "QUILL_UPDATE_MANIFEST_URL"
 # Pre-release ordering: a final (non-pre-release) build outranks every
 # pre-release of the same major.minor.patch. See _version_tuple / _prerelease_rank.
 _STABLE_PRERELEASE_RANK = (9, 0)
+
+
+def resolve_releases_api_url(default: str = GITHUB_RELEASES_API) -> str:
+    """The GitHub Releases API URL, honouring the QUILL_UPDATE_API_URL override."""
+    override = os.getenv(_API_URL_ENV, "").strip()
+    return override or default
+
+
+def resolve_manifest_url(default: str = DEFAULT_UPDATE_MANIFEST_URL) -> str:
+    """The signed-manifest feed URL, honouring the QUILL_UPDATE_MANIFEST_URL override."""
+    override = os.getenv(_MANIFEST_URL_ENV, "").strip()
+    return override or default
 
 
 def _ssl_context() -> ssl.SSLContext:
@@ -49,9 +68,10 @@ class UpdateManifest:
 
 
 def fetch_update_manifest(
-    url: str = DEFAULT_UPDATE_MANIFEST_URL,
+    url: str | None = None,
     timeout: int = 10,
 ) -> UpdateManifest:
+    url = url or resolve_manifest_url()
     _validate_remote_url(url)
     with urlopen(url, timeout=timeout, context=_ssl_context()) as response:
         payload = response.read().decode("utf-8", errors="strict")
@@ -69,7 +89,7 @@ class GitHubRelease:
 
 def fetch_latest_release(
     include_prereleases: bool = False,
-    api_url: str = GITHUB_RELEASES_API,
+    api_url: str | None = None,
     timeout: int = 10,
 ) -> GitHubRelease | None:
     """Return the newest GitHub release the user is eligible for.
@@ -78,6 +98,7 @@ def fetch_latest_release(
     Beta channel (include_prereleases=True): newest release including prereleases.
     Returns None when no eligible release exists.
     """
+    api_url = api_url or resolve_releases_api_url()
     request = Request(
         api_url,
         headers={
@@ -163,8 +184,9 @@ def _release_from_json(data: dict) -> GitHubRelease:
     )
 
 
-def fetch_releases(api_url: str = GITHUB_RELEASES_API, timeout: int = 10) -> list[GitHubRelease]:
+def fetch_releases(api_url: str | None = None, timeout: int = 10) -> list[GitHubRelease]:
     """All non-draft GitHub releases (newest-first as GitHub returns them)."""
+    api_url = api_url or resolve_releases_api_url()
     request = Request(
         api_url,
         headers={"Accept": "application/vnd.github+json", "User-Agent": "Quill-Updater"},
@@ -374,5 +396,7 @@ __all__ = [
     "fetch_update_manifest",
     "is_newer_version",
     "parse_update_manifest",
+    "resolve_manifest_url",
+    "resolve_releases_api_url",
     "verify_manifest_signature",
 ]

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -19164,9 +19164,10 @@ class MainFrame(
             fetch_error: str | None = None
             try:
                 try:
-                    manifest = fetch_update_manifest(
-                        "https://community-access.github.io/quill/updates/.quill-update-feed-v1.json"
-                    )
+                    # URL resolves the QUILL_UPDATE_MANIFEST_URL override (default:
+                    # the production signed-manifest feed) so a release can be
+                    # rehearsed against a throwaway feed without code changes.
+                    manifest = fetch_update_manifest()
                 except (URLError, ValueError, OSError):
                     pass
                 if manifest is None or not is_newer_version(current_version, manifest.version):

--- a/tests/unit/core/test_updates.py
+++ b/tests/unit/core/test_updates.py
@@ -220,3 +220,59 @@ def test_salt_only_signature_rejected(monkeypatch) -> None:
         signature=salt_sig,
     )
     assert not verify_manifest_signature(m), "salt-only signature must be rejected"
+
+
+def test_resolve_endpoints_default_to_production(monkeypatch) -> None:
+    # Release-rehearsal overrides must be inert unless explicitly set, so a normal
+    # user always hits the production endpoints.
+    from quill.core.updates import (
+        GITHUB_RELEASES_API,
+        resolve_manifest_url,
+        resolve_releases_api_url,
+    )
+
+    monkeypatch.delenv("QUILL_UPDATE_API_URL", raising=False)
+    monkeypatch.delenv("QUILL_UPDATE_MANIFEST_URL", raising=False)
+    assert resolve_releases_api_url() == GITHUB_RELEASES_API
+    assert resolve_manifest_url() == DEFAULT_UPDATE_MANIFEST_URL
+
+
+def test_resolve_endpoints_honour_overrides(monkeypatch) -> None:
+    # Setting the env vars redirects discovery to a throwaway repo/feed.
+    from quill.core.updates import resolve_manifest_url, resolve_releases_api_url
+
+    api = "https://api.github.com/repos/Community-Access/quill-update-selftest/releases"
+    feed = "https://community-access.github.io/quill-update-selftest/feed.json"
+    monkeypatch.setenv("QUILL_UPDATE_API_URL", api)
+    monkeypatch.setenv("QUILL_UPDATE_MANIFEST_URL", feed)
+    assert resolve_releases_api_url() == api
+    assert resolve_manifest_url() == feed
+
+
+def test_fetch_releases_uses_api_override(monkeypatch) -> None:
+    # The override must actually reach the network call, not just the resolver:
+    # fetch_releases() with no explicit api_url queries the overridden endpoint.
+    from quill.core import updates
+
+    override = "https://api.github.com/repos/Community-Access/quill-update-selftest/releases"
+    monkeypatch.setenv("QUILL_UPDATE_API_URL", override)
+
+    seen: dict[str, str] = {}
+
+    class _FakeResponse:
+        def __enter__(self) -> _FakeResponse:
+            return self
+
+        def __exit__(self, *exc: object) -> None:
+            return None
+
+        def read(self) -> bytes:
+            return b"[]"
+
+    def _fake_urlopen(request, *args, **kwargs):  # noqa: ANN001
+        seen["url"] = request.full_url if hasattr(request, "full_url") else str(request)
+        return _FakeResponse()
+
+    monkeypatch.setattr(updates, "urlopen", _fake_urlopen)
+    assert updates.fetch_releases() == []
+    assert seen["url"] == override


### PR DESCRIPTION
## Summary

Adds gated `QUILL_UPDATE_API_URL` / `QUILL_UPDATE_MANIFEST_URL` overrides so a release can be dry-run against a throwaway repo/feed without touching the production endpoints. Both default to today's values and are inert unless set. The asset-download path still enforces HTTPS + the trusted-host allowlist, so an override only redirects discovery, never download security.

## Changes
- `quill/core/updates.py` — `resolve_releases_api_url` / `resolve_manifest_url`; `fetch_releases`, `fetch_latest_release`, `fetch_update_manifest` resolve their endpoint from the override.
- `quill/ui/main_frame.py` — manifest fetch uses the resolver instead of a hardcoded literal.
- `tests/unit/core/test_updates.py` — 3 tests (defaults, overrides honored, override reaches the network call).

## Tests
`pytest tests/unit/core/test_updates.py` — 17 passed. `mypy quill/core/updates.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)