### PR TITLE
fix(ci): repair formatting and update-manifest test stubs

### DIFF
--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -904,7 +904,7 @@ def build_inno_setup_script(
         "",
         "// -- Uninstall: discover a custom data location ----------------------------",
         "// When the user chose a custom data folder, save_storage_mode writes",
-        "// {\"mode\":\"custom\",\"path\":\"...\"} into storage-mode.json under",
+        '// {"mode":"custom","path":"..."} into storage-mode.json under',
         "// %APPDATA%\\Quill (quill.core.storage_mode). The pointer therefore lives",
         "// INSIDE the folder the uninstaller deletes, so it must be read first --",
         "// otherwise the custom directory is silently orphaned on 'remove all data'.",

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -275,7 +275,7 @@ def test_uninstaller_offers_to_remove_custom_data_location() -> None:
     assert "function ReadCustomDataDir(): String;" in code
     assert "storage-mode.json" in code
     # Only an explicit custom mode is honoured (appdata/portable carry no path).
-    assert '\'"custom"\'' in code
+    assert "'\"custom\"'" in code
     assert "IsSafeCustomDataDir(CustomDir)" in code
     assert "DelTree(CustomDir, True, True, True);" in code
     # The pointer read must precede the %APPDATA%\Quill deletion, or the file

--- a/tests/unit/ui/test_main_frame_feedback.py
+++ b/tests/unit/ui/test_main_frame_feedback.py
@@ -295,7 +295,7 @@ def test_check_for_updates_can_close_app_before_installer(monkeypatch) -> None:
     monkeypatch.setattr(
         main_frame_module,
         "fetch_update_manifest",
-        lambda _url: UpdateManifest(
+        lambda *_a, **_k: UpdateManifest(
             version="0.1.1",
             download_url="https://example.com/Quill-Setup-0.1.1.exe",
             published_at="2026-05-30T00:00:00Z",
@@ -331,7 +331,7 @@ def test_check_for_updates_allows_download_without_immediate_exit(monkeypatch) -
     monkeypatch.setattr(
         main_frame_module,
         "fetch_update_manifest",
-        lambda _url: UpdateManifest(
+        lambda *_a, **_k: UpdateManifest(
             version="0.1.1",
             download_url="https://example.com/Quill-Setup-0.1.1.exe",
             published_at="2026-05-30T00:00:00Z",
@@ -391,7 +391,7 @@ def test_check_for_updates_silent_honors_skipped_version(monkeypatch) -> None:
     monkeypatch.setattr(
         main_frame_module,
         "fetch_update_manifest",
-        lambda _url: (_ for _ in ()).throw(main_frame_module.URLError("offline")),
+        lambda *_a, **_k: (_ for _ in ()).throw(main_frame_module.URLError("offline")),
     )
     release = GitHubRelease(
         version="9.9.9",


### PR DESCRIPTION
## Summary

Repairs two CI breakages on main that landed because #717 and #718 were admin-merged without PR CI:

1. **ruff format** — `scripts/build_windows_distribution.py` and its test had string-quote normalization (from the uninstaller change, #717) that `ruff format --check` flags.
2. **unit-tests** — the manifest-feed override (#718) made the UI call `fetch_update_manifest()` with no positional URL, but three stubs in `test_main_frame_feedback.py` used `lambda _url:`, raising a missing-argument error that derailed the update flow. Widened to `lambda *_a, **_k:`.

## Tests
- `ruff format --check .` clean.
- `pytest tests/unit/ui/test_main_frame_feedback.py tests/unit/core/test_updates.py tests/unit/scripts/test_build_windows_distribution.py` — 53 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)