### PR TITLE
chore(rehearsal): batch harness for update-process testing

### DIFF
--- a/docs/release/upgrade-test/README.md
+++ b/docs/release/upgrade-test/README.md
@@ -1,0 +1,57 @@
+# QUILL update-process rehearsal harness
+
+A simple, repeatable way to verify QUILL's in-app self-update (discover ->
+download -> install-over) **without touching production or any real user**.
+
+## How the isolation works
+
+QUILL's updater reads the `QUILL_UPDATE_API_URL` environment variable (added in
+`quill/core/updates.py`). Unset, it queries the production endpoint
+(`Community-Access/quill`). Set, it queries whatever repo you point it at. These
+scripts point it at a throwaway public repo, `Community-Access/quill-update-selftest`,
+which holds rehearsal-only prereleases. Production releases and the GitHub Pages
+update feed are never involved, so no user ever sees these builds.
+
+The override only redirects update *discovery*. Asset downloads still enforce
+HTTPS + the trusted-host allowlist, so this cannot weaken update security. The
+override lives only in the environment variable on this machine and in the test
+repo -- it is **not** baked into any installer (the same installer ships to
+production unchanged).
+
+## The installers
+
+Put the installers you want to test in `installers\` (gitignored). Expected names:
+
+- `installers\Quill-for-All-Setup-0.8.0 Beta 1.exe`
+- `installers\Quill-for-All-Setup-0.8.0 Beta 2.exe`
+
+Build them with `scripts/build_windows_distribution.py --bundle-python --compile-installer`
+(bump `build/version.toml` `prerelease_number` between the two), then copy from
+`windows-distribution\installer\Output\` into `installers\`.
+
+## Simple path
+
+1. `install-beta1.cmd` - silently installs 0.8.0 Beta 1 (per-user, no elevation).
+2. `launch-quill.cmd` - launches QUILL with the rehearsal endpoint active for that
+   run. In QUILL: **Help > Check for Updates**. Expect 0.8.0 Beta 2 -> **Install now**.
+3. After the upgrade, confirm **Help > About** shows 0.8.0 Beta 2 and your
+   settings/sessions survived.
+4. `reset-to-production.cmd` - removes the override so this machine returns to the
+   production update endpoint. Run this when you are done.
+
+## Other scripts
+
+- `set-test-endpoint.cmd` - persist the rehearsal endpoint for your user (survives
+  restarts; useful if you want repeated checks). `reset-to-production.cmd` undoes it.
+- `install-beta2.cmd` - silently install Beta 2 directly (to reset state or test the
+  installer alone).
+- `status.cmd` - show the current/persisted override and whether QUILL is installed.
+
+## What this validates vs. not
+
+Validates the real production path: GitHub Releases discovery, version ordering
+(Beta 2 > Beta 1), platform `.exe` asset selection, download from
+`objects.githubusercontent.com`, and the Inno in-place upgrade (data in
+`%APPDATA%\Quill` preserved, first-run wizard re-runs). It does **not** exercise
+the signed-manifest feed (needs `QUILL_UPDATE_MANIFEST_KEY`) or the app_updater
+delta path.

--- a/docs/release/upgrade-test/install-beta1.cmd
+++ b/docs/release/upgrade-test/install-beta1.cmd
@@ -1,0 +1,14 @@
+@echo off
+rem Silently install QUILL 0.8.0 Beta 1 (per-user, no elevation) for the
+rem update rehearsal. The installer is in installers\ (gitignored).
+setlocal
+set "EXE=%~dp0installers\Quill-for-All-Setup-0.8.0 Beta 1.exe"
+if not exist "%EXE%" (
+  echo ERROR: "%EXE%" not found.
+  echo Copy the built Beta 1 installer into the installers\ folder first.
+  exit /b 1
+)
+echo Installing QUILL 0.8.0 Beta 1 silently...
+"%EXE%" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+echo Exit code %errorlevel%.
+endlocal

--- a/docs/release/upgrade-test/install-beta2.cmd
+++ b/docs/release/upgrade-test/install-beta2.cmd
@@ -1,0 +1,14 @@
+@echo off
+rem Silently install QUILL 0.8.0 Beta 2 (per-user, no elevation). Use to reset
+rem state or to test the Beta 2 installer on its own.
+setlocal
+set "EXE=%~dp0installers\Quill-for-All-Setup-0.8.0 Beta 2.exe"
+if not exist "%EXE%" (
+  echo ERROR: "%EXE%" not found.
+  echo Copy the built Beta 2 installer into the installers\ folder first.
+  exit /b 1
+)
+echo Installing QUILL 0.8.0 Beta 2 silently...
+"%EXE%" /VERYSILENT /SUPPRESSMSGBOXES /NORESTART
+echo Exit code %errorlevel%.
+endlocal

--- a/docs/release/upgrade-test/installers/.gitignore
+++ b/docs/release/upgrade-test/installers/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/docs/release/upgrade-test/launch-quill.cmd
+++ b/docs/release/upgrade-test/launch-quill.cmd
@@ -1,0 +1,19 @@
+@echo off
+rem Launch the installed QUILL with the rehearsal updater endpoint active for
+rem THIS run, so Help > Check for Updates queries the throwaway test repo even
+rem if a persisted setx has not yet propagated to already-running programs.
+setlocal
+set "QUILL_UPDATE_API_URL=https://api.github.com/repos/Community-Access/quill-update-selftest/releases"
+set "APP=%LOCALAPPDATA%\Programs\QUILL for All\quill.exe"
+if not exist "%APP%" (
+  echo ERROR: QUILL not installed at "%APP%".
+  echo Run install-beta1.cmd first.
+  exit /b 1
+)
+echo Launching QUILL with the rehearsal updater endpoint:
+echo   %QUILL_UPDATE_API_URL%
+start "" "%APP%" -m quill
+echo.
+echo Next, in QUILL:  Help  ^>  Check for Updates
+echo Expect "0.8.0 Beta 2 is available" -^> choose Install now.
+endlocal

--- a/docs/release/upgrade-test/reset-to-production.cmd
+++ b/docs/release/upgrade-test/reset-to-production.cmd
@@ -1,0 +1,9 @@
+@echo off
+rem Remove the rehearsal override so QUILL uses the PRODUCTION update endpoint
+rem (Community-Access/quill) again. Run this when rehearsal testing is done.
+setx QUILL_UPDATE_API_URL "" >nul
+reg delete HKCU\Environment /v QUILL_UPDATE_API_URL /f >nul 2>&1
+set "QUILL_UPDATE_API_URL="
+echo Cleared QUILL_UPDATE_API_URL.
+echo Open a NEW terminal to confirm it is gone (echo %%QUILL_UPDATE_API_URL%%).
+echo QUILL will now check the production update endpoint.

--- a/docs/release/upgrade-test/set-test-endpoint.cmd
+++ b/docs/release/upgrade-test/set-test-endpoint.cmd
@@ -1,0 +1,12 @@
+@echo off
+rem Persist the rehearsal updater endpoint for your Windows user so every QUILL
+rem launch checks the throwaway test repo (not production). Undo with
+rem reset-to-production.cmd. Only redirects discovery; downloads still enforce
+rem the HTTPS trusted-host allowlist.
+set "URL=https://api.github.com/repos/Community-Access/quill-update-selftest/releases"
+setx QUILL_UPDATE_API_URL "%URL%" >nul
+echo Persisted QUILL_UPDATE_API_URL for your user:
+echo   %URL%
+echo.
+echo Open a NEW terminal (or use launch-quill.cmd) for it to take effect.
+echo Run reset-to-production.cmd when you are finished.

--- a/docs/release/upgrade-test/status.cmd
+++ b/docs/release/upgrade-test/status.cmd
@@ -1,0 +1,9 @@
+@echo off
+rem Show the current/persisted rehearsal override and whether QUILL is installed.
+echo === QUILL update-rehearsal status ===
+echo QUILL_UPDATE_API_URL (this session): "%QUILL_UPDATE_API_URL%"
+set "PERSISTED="
+for /f "tokens=2,*" %%a in ('reg query HKCU\Environment /v QUILL_UPDATE_API_URL 2^>nul ^| findstr /i QUILL_UPDATE_API_URL') do set "PERSISTED=%%b"
+if defined PERSISTED (echo QUILL_UPDATE_API_URL (persisted^): %PERSISTED%) else (echo QUILL_UPDATE_API_URL (persisted^): ^<not set^>)
+set "APP=%LOCALAPPDATA%\Programs\QUILL for All\quill.exe"
+if exist "%APP%" (echo Installed: "%APP%") else (echo Installed: NO)


### PR DESCRIPTION
## Summary

Adds a small, repeatable batch harness under `docs/release/upgrade-test/` to rehearse QUILL's in-app self-update against the throwaway `Community-Access/quill-update-selftest` repo via the `QUILL_UPDATE_API_URL` override — no production release or feed involved, no user impact.

- `install-beta1.cmd` / `install-beta2.cmd` — silent per-user installs.
- `set-test-endpoint.cmd` / `reset-to-production.cmd` — point the updater at the test repo, then restore production.
- `launch-quill.cmd` — launch QUILL with the rehearsal endpoint active for one run.
- `status.cmd` — show current/persisted override + install state.
- `README.md` — the simple path and what it validates.
- `installers/` stays gitignored (large `.exe` assets local-only).

No production code changes; docs/scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)