### PR TITLE
fix(menu): create _id_convert_file before the File menu uses it (P0 launch crash)

### DIFF
--- a/quill/ui/main_frame_menu.py
+++ b/quill/ui/main_frame_menu.py
@@ -119,6 +119,11 @@ class MenuBuilderMixin:
         self._id_export_other = wx.NewIdRef()  # "Other Pandoc Format..."
         self._id_batch_convert_import = wx.NewIdRef()
         self._id_batch_convert_export = wx.NewIdRef()
+        # File > Convert File... is appended to the File menu below (~line 362),
+        # so its id must be created here, before that use, not in the later
+        # tools-id block (regression from b28416b caused a launch-time
+        # AttributeError building the File menu).
+        self._id_convert_file = wx.NewIdRef()
         self._sessions_menu = wx.Menu()
         self._open_documents_menu = wx.Menu()
         self._recent_sessions_menu = wx.Menu()
@@ -1374,7 +1379,6 @@ class MenuBuilderMixin:
         self._id_ocr_screen = wx.NewIdRef()
         self._id_describe_image = wx.NewIdRef()
         self._id_regex_helper = wx.NewIdRef()
-        self._id_convert_file = wx.NewIdRef()
         self._id_external_tools = wx.NewIdRef()
         self._id_read_aloud = wx.NewIdRef()
         self._id_read_aloud_stop = wx.NewIdRef()

--- a/tests/unit/ui/test_main_frame_menu_ids.py
+++ b/tests/unit/ui/test_main_frame_menu_ids.py
@@ -1,0 +1,55 @@
+"""Guard against use-before-assignment of menu id-refs in ``_build_menu``.
+
+``MenuBuilderMixin._build_menu`` creates a large batch of ``self._id_*``
+``wx.NewIdRef()`` handles and then appends menu items that reference them. If an
+id is created *after* the menu item that uses it (as happened in b28416b for
+``_id_convert_file`` -> launch-time ``AttributeError`` building the File menu),
+the app crashes on startup. No unit test constructs the real menu, so this
+static check parses the method and asserts every ``self._id_*`` that is both
+assigned and used inside ``_build_menu`` is assigned before its first use.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+
+_MENU_MODULE = Path(__file__).resolve().parents[3] / "quill" / "ui" / "main_frame_menu.py"
+
+
+def _build_menu_node() -> ast.FunctionDef:
+    tree = ast.parse(_MENU_MODULE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "_build_menu":
+            return node
+    raise AssertionError("_build_menu not found in main_frame_menu.py")
+
+
+def test_build_menu_id_refs_assigned_before_first_use() -> None:
+    build = _build_menu_node()
+    stores: dict[str, list[int]] = defaultdict(list)
+    loads: dict[str, list[int]] = defaultdict(list)
+    for node in ast.walk(build):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "self"
+            and node.attr.startswith("_id_")
+        ):
+            if isinstance(node.ctx, ast.Store):
+                stores[node.attr].append(node.lineno)
+            elif isinstance(node.ctx, ast.Load):
+                loads[node.attr].append(node.lineno)
+
+    # Only ids both created and used inside _build_menu are checkable here; ids
+    # created in other methods (run earlier) are out of scope for this guard.
+    offenders = {
+        attr: {"first_use": min(loads[attr]), "first_assign": min(stores[attr])}
+        for attr in loads
+        if attr in stores and min(stores[attr]) > min(loads[attr])
+    }
+    assert not offenders, (
+        "menu id-refs used before they are assigned in _build_menu "
+        f"(create them earlier): {offenders}"
+    )


### PR DESCRIPTION
## Summary

**P0: the shipped 0.8.0 build crashes on launch.** `b28416b` (File > Convert File) added the menu item near the top of `_build_menu` (~line 362) but created `self._id_convert_file` far below in the tools-id block, so building the File menu raises:

```
AttributeError: 'MainFrame' object has no attribute '_id_convert_file'
```

…on every startup. Reproduced from the bundled 0.8.0 Beta installer (crash report in `%APPDATA%\Quill\crash-reports`). CI missed it because no test constructs the menu.

## Fix
- Move the `wx.NewIdRef()` for `_id_convert_file` into the early File-menu id block, before its first use.
- Add `tests/unit/ui/test_main_frame_menu_ids.py`: a fast AST guard asserting every `self._id_*` both assigned and used in `_build_menu` is assigned before first use. Verified it fails on the pre-fix code and passes after.

## Verified
Patched the installed bundle with the fixed file and relaunched the bundled interpreter — app launches clean (no crash). `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)