### PR TITLE
feat(installer): make bundled Kokoro an optional component

### DIFF
--- a/installer/quill.iss
+++ b/installer/quill.iss
@@ -15,7 +15,7 @@ AppPublisher={#AppPublisher}
 AppPublisherURL={#AppURL}
 AppSupportURL={#AppURL}
 AppUpdatesURL={#AppURL}
-VersionInfoVersion=0.8.0.2
+VersionInfoVersion=0.8.0.1
 VersionInfoCompany={#AppPublisher}
 VersionInfoDescription={#AppName} accessible writing environment
 DefaultDirName={autopf}\{#AppName}
@@ -83,6 +83,7 @@ Name: "speechpiper"; Description: "Install bundled Piper neural TTS runtime"; Ty
 Name: "speechwhisper"; Description: "Install the offline speech engine (whisper.cpp) for private, on-device transcription and dictation (Tools > Speech > Whisperer)"; Types: full custom; Flags: checkablealone
 Name: "nodejs"; Description: "Install portable Node.js runtime for Node Quillins and the Developer Console TypeScript interface (~30 MB); not required for Python Quillins"; Flags: checkablealone
 Name: "braillepack"; Description: "Install QUILL Braille Pack (liblouis translation engine, UEB, Standard American English, and international braille profiles, ~15 MB)"; Types: full custom; Flags: checkablealone
+Name: "speechkokoro"; Description: "Install bundled Kokoro neural TTS voices (~120 MB, high-quality offline speech). If you skip this, you can download Kokoro later from Manage Voices / Speech Hub"; Types: full custom; Flags: checkablealone
 
 [InstallDelete]
 ; Upgrade hygiene -- the single most important fix for reliable upgrades.
@@ -114,10 +115,15 @@ Type: filesandordirs; Name: "{app}\__pycache__"
 ; needed now that migration protects the data.
 
 [Files]
-Source: "..\portable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "docs\QUILL-PRD.md,tools\pandoc\*,tools\speech\dectalk\*,tools\speech\espeak-ng\*,tools\speech\piper\*,tools\speech\whispercpp\*,tools\nodejs\*,vendor\braille-pack\*,_tool-download\*,_speech-download\*"
+Source: "..\portable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "docs\QUILL-PRD.md,tools\pandoc\*,tools\speech\dectalk\*,tools\speech\espeak-ng\*,tools\speech\piper\*,tools\speech\whispercpp\*,tools\nodejs\*,vendor\braille-pack\*,kokoro-models\*,_tool-download\*,_speech-download\*"
 ; QUILL Braille Pack: liblouis runtime, translation tables, and BRF profiles.
 ; Installed to vendor\braille-pack so QUILL detects it automatically via QUILL_APP_ROOT.
 Source: "..\portable\vendor\braille-pack\*"; DestDir: "{app}\vendor\braille-pack"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: braillepack
+; Kokoro neural TTS models (~120 MB). Optional component; the runtime
+; resolves {app}\kokoro-models (QUILL_APP_ROOT). When skipped, QUILL
+; downloads them on demand to %APPDATA%\Quill\kokoro-models, which the
+; runtime prefers over the bundled copy (read_aloud.default_kokoro_model_dir).
+Source: "..\portable\kokoro-models\*"; DestDir: "{app}\kokoro-models"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: speechkokoro
 Source: "..\portable\tools\pandoc\*"; DestDir: "{app}\tools\pandoc"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: pandoc
 ; All DECtalk voices ship when the DECtalk component is selected.
 Source: "..\portable\tools\speech\dectalk\*"; DestDir: "{app}\tools\speech\dectalk"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: speechdectalk

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -83,13 +83,17 @@ PIPER_PINNED_URL = (
 )
 PIPER_PINNED_SHA256 = "f3c58906402b24f3a96d92145f58acba6d86c9b5db896d207f78dc80811efcea"
 
-# Kokoro neural-TTS model + voices. Unlike the other engines, Kokoro ships via
-# the generic ..\portable\* installer copy under {app}\kokoro-models -- the exact
-# location the runtime resolves in quill.core.read_aloud._bundled_kokoro_model_dir
-# -- so there is no dedicated installer component (see the test that asserts
-# "speechkokoro" is absent). The filenames mirror KOKORO_ONNX_MODEL_FILENAME /
-# KOKORO_ONNX_VOICES_FILENAME in read_aloud.py; keep them in sync. _stage_kokoro
-# downloads + SHA-256 verifies these unless a local --kokoro-dir is provided.
+# Kokoro neural-TTS model + voices. Always STAGED into the portable bundle under
+# kokoro-models/, but the INSTALLER gates the copy behind the optional
+# "speechkokoro" component (Types: full custom) -- so Full installs still ship it
+# while Custom installs can drop ~120 MB; the generic ..\portable\* copy excludes
+# kokoro-models\* to avoid installing it unconditionally. The runtime resolves
+# {app}\kokoro-models (quill.core.read_aloud._bundled_kokoro_model_dir) and, when
+# skipped, downloads on demand to %APPDATA%\Quill\kokoro-models, which it prefers
+# over the bundled copy (default_kokoro_model_dir). The filenames mirror
+# KOKORO_ONNX_MODEL_FILENAME / KOKORO_ONNX_VOICES_FILENAME in read_aloud.py; keep
+# them in sync. _stage_kokoro downloads + SHA-256 verifies these unless a local
+# --kokoro-dir is provided.
 KOKORO_MODEL_FILENAME = "kokoro-v1.0.int8.onnx"
 KOKORO_VOICES_FILENAME = "voices-v1.0.bin"
 KOKORO_MODEL_URL = (
@@ -679,6 +683,10 @@ def build_inno_setup_script(
         " (liblouis translation engine, UEB, Standard American English,"
         ' and international braille profiles, ~15 MB)";'
         " Types: full custom; Flags: checkablealone",
+        'Name: "speechkokoro"; Description: "Install bundled Kokoro neural TTS voices'
+        " (~120 MB, high-quality offline speech). If you skip this, you can download"
+        ' Kokoro later from Manage Voices / Speech Hub";'
+        " Types: full custom; Flags: checkablealone",
         "",
         "[InstallDelete]",
         "; Upgrade hygiene -- the single most important fix for reliable upgrades.",
@@ -712,12 +720,19 @@ def build_inno_setup_script(
         "[Files]",
         'Source: "..\\portable\\*"; DestDir: "{app}";'
         " Flags: ignoreversion recursesubdirs createallsubdirs;"
-        ' Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,_tool-download\\*,_speech-download\\*"',
+        ' Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*"',
         "; QUILL Braille Pack: liblouis runtime, translation tables, and BRF profiles.",
         "; Installed to vendor\\braille-pack so QUILL detects it automatically via QUILL_APP_ROOT.",
         'Source: "..\\portable\\vendor\\braille-pack\\*"; DestDir: "{app}\\vendor\\braille-pack";'
         " Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist;"
         " Components: braillepack",
+        "; Kokoro neural TTS models (~120 MB). Optional component; the runtime",
+        "; resolves {app}\\kokoro-models (QUILL_APP_ROOT). When skipped, QUILL",
+        "; downloads them on demand to %APPDATA%\\Quill\\kokoro-models, which the",
+        "; runtime prefers over the bundled copy (read_aloud.default_kokoro_model_dir).",
+        'Source: "..\\portable\\kokoro-models\\*"; DestDir: "{app}\\kokoro-models";'
+        " Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist;"
+        " Components: speechkokoro",
         'Source: "..\\portable\\tools\\pandoc\\*"; DestDir: "{app}\\tools\\pandoc";'
         " Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist;"
         " Components: pandoc",

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -104,8 +104,9 @@ version = "2.4.6"
     assert manifest["speechAssets"]["dectalk"]["downloadable"] is True
     assert manifest["speechAssets"]["espeak"]["downloadable"] is True
     assert manifest["speechAssets"]["piper"]["downloadable"] is True
-    # Kokoro ships at the bundle root (kokoro-models/), the location the runtime
-    # resolves a bundled copy from, not under tools/speech and not as a component.
+    # Kokoro is always STAGED at the portable bundle root (kokoro-models/), the
+    # location the runtime resolves a bundled copy from; the installer gates the
+    # copy behind the optional speechkokoro component (asserted separately).
     assert manifest["speechAssets"]["kokoro"]["bundled"] is True
     assert (portable_dir / "kokoro-models" / "kokoro-v1.0.int8.onnx").exists()
     assert (portable_dir / "kokoro-models" / "voices-v1.0.bin").exists()
@@ -158,10 +159,15 @@ def test_build_inno_setup_script_mentions_portable_bundle() -> None:
     # Tools > Speech > Whisperer.
     assert 'Name: "speechwhisper"; Description: "Install the offline speech engine' in script
     assert "(Tools > Speech > Whisperer)" in script
-    assert "speechkokoro" not in script
+    # Kokoro is an optional component (Types: full custom): Full installs ship it,
+    # Custom installs can drop ~120 MB and download it later. It is excluded from
+    # the unconditional copy and gated behind its own [Files] entry.
+    assert 'Name: "speechkokoro"; Description: "Install bundled Kokoro neural TTS voices' in script
+    assert 'Source: "..\\portable\\kokoro-models\\*"; DestDir: "{app}\\kokoro-models";' in script
+    assert "Components: speechkokoro" in script
     assert "speechopenvoice" not in script
     assert (
-        'Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,_tool-download\\*,_speech-download\\*"'
+        'Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*"'
         in script
     )
     assert 'Source: "..\\portable\\tools\\pandoc\\*"; DestDir: "{app}\\tools\\pandoc";' in script


### PR DESCRIPTION
## Summary

Kokoro's ~120 MB of neural-TTS models (`kokoro-v1.0.int8.onnx` + `voices-v1.0.bin`) were copied unconditionally by the generic `..\portable\*` → `{app}` file copy — the single largest bundled asset, with no way to opt out. Gate them behind a new optional `speechkokoro` component (`Types: full custom`), mirroring DECtalk/Piper:

- **Full installation (recommended)** still ships Kokoro → no regression for typical users.
- **Custom** installs can deselect it to save ~120 MB.

Safe to skip: the runtime downloads Kokoro on demand to `%APPDATA%\Quill\kokoro-models` (Manage Voices / Speech Hub / Tools → Speech → Install Kokoro ONNX) and prefers that copy over the bundled one (`read_aloud.default_kokoro_model_dir`).

## Changes
- `build_windows_distribution.py`: add the `speechkokoro` component; exclude `kokoro-models\*` from the unconditional copy; add a gated `[Files]` entry; update the design comment.
- `installer/quill.iss`: regenerated.
- Tests: flip the assertion that `speechkokoro` was absent → assert it's present + gated; update the excludes assertion and a stale comment.

## Tests
`pytest tests/unit/scripts/test_build_windows_distribution.py` — 20 passed (incl. iss-sync). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)