### PR TITLE
chore(deps): add python-docx as a runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     # Windows has no system IANA timezone database, so stdlib zoneinfo needs
     # this package to resolve real zone names (publishing schedule dialog).
     "tzdata>=2025.1",
+    # Native .docx reading/writing without requiring Pandoc.
+    "python-docx>=1.1.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Adds `python-docx>=1.1.2` to the base `[project.dependencies]` so it is installed in the bundled Windows runtime (picked up by `bundled_runtime_dependencies`) and for editable dev installs — enabling native `.docx` read/write without requiring Pandoc.

Verified: `bundled_runtime_dependencies(pyproject.toml)` now includes `python-docx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)