### PR TITLE
feat(updates): release notes in update dialog + Help > What's New

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -106,7 +106,7 @@ jobs:
           python scripts/generate_update_feed.py \
             --output docs/site/updates/.quill-update-feed-v1.json \
             --tag "${{ github.ref_name }}" \
-            --notes "$(awk '/^## '"${{ github.ref_name }}"'$/{flag=1; next} /^## /{flag=0} flag' CHANGELOG.md | head -c 800)"
+            --notes "$(python scripts/extract_release_body.py --version '${{ github.ref_name }}' --max-chars 800)"
       - name: Commit update feed
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -122,6 +122,15 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Build release body from CHANGELOG
+        run: |
+          python scripts/extract_release_body.py \
+            --version "${{ github.ref_name }}" \
+            --output release-body.md \
+            --fallback-full
       - name: Download installer artifact
         uses: actions/download-artifact@v8
         with:
@@ -151,7 +160,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           name: "QUILL for All ${{ github.ref_name }} Beta"
-          body_path: CHANGELOG.md
+          body_path: release-body.md
           files: |
             release-assets/installer/Quill-for-All-Setup-*.exe
             release-assets/Quill-Portable-*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.8.0 Beta 2 (in development)
+
+Second public beta. Rolls up 0.8.0 Beta 1 plus the changes below. This section
+doubles as the in-app release notes: the same text appears when you **Check for
+Updates** and any time from **Help > What's New**.
+
+### What's New in this beta
+
+- **Release notes now show when you check for updates.** When an update is found, QUILL presents an abbreviated, screen-reader-friendly summary of what changed in a read-only multi-line edit (the same control help text and wizards use), alongside **Download**, **Skip this version**, and **Later**. The notes are sourced from this changelog, so every release carries a short "what's new" list.
+- **New: Help > What's New.** See the current build's release notes on demand, between updates, in the same accessible control — so the format is familiar when an update lands.
+- **Faster, simpler update prompt.** The update dialog no longer waits on a one-time WebView2 warm-up before it can appear.
+
 ## 0.8.0 Beta 1 (in development)
 
 Next public beta. Rolls up the 0.7.0 line plus subsequent fixes. The GitHub Pages update feed is intentionally left pointed at the prior release so existing testers are not prompted to update until 0.8.0 is published as a release.

--- a/quill/core/release_notes.py
+++ b/quill/core/release_notes.py
@@ -1,0 +1,146 @@
+"""Abbreviated, per-release "What's New" notes sourced from ``CHANGELOG.md``.
+
+The changelog is the single source of truth. This module slices out a single
+version's section and flattens it to plain text suitable for a read-only
+multi-line ``TextCtrl`` (the same control help text and wizards use), so the
+Check-for-Updates dialog and the Help > What's New command can show users a
+short, screen-reader-friendly summary of what a release contains.
+
+Pure domain logic: no ``wx`` imports, safe to call from unit tests and from
+the release pipeline (``scripts/extract_release_body.py``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from quill.core.text_utils import strip_md_to_plain
+
+_HEADING = re.compile(r"^##\s+(?P<title>.+?)\s*$")
+_BASE_VERSION = re.compile(r"\d+\.\d+(?:\.\d+)?")
+
+
+def _canon(value: str) -> str:
+    """Canonical comparison form for a version string or heading title.
+
+    Drops a trailing ``(...)`` annotation and a leading ``v``, lower-cases,
+    treats ``-``/``_`` as spaces, splits letter/digit runs (``beta1`` ->
+    ``beta 1``), and collapses whitespace. This makes a git tag
+    (``v0.8.0-beta1``), the running build's short version (``0.8.0 Beta 1``),
+    and the changelog heading (``0.8.0 Beta 1 (in development)``) all canonical
+    to ``0.8.0 beta 1``.
+    """
+    text = value.split("(", 1)[0].strip().lower()
+    if text.startswith("v"):
+        text = text[1:]
+    text = re.sub(r"[-_]", " ", text)
+    text = re.sub(r"(?<=[a-z])(?=\d)", " ", text)
+    text = re.sub(r"(?<=\d)(?=[a-z])", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _base_version(value: str) -> str:
+    """The ``major.minor[.patch]`` core of a version string, or ``""``."""
+    match = _BASE_VERSION.search(value)
+    return match.group(0) if match else ""
+
+
+def _find_section_start(lines: list[str], version: str) -> int | None:
+    """Index of the ``## `` heading naming ``version``, or ``None``.
+
+    An exact (canonicalized) match always wins, so ``0.8.0 Beta 1`` resolves to
+    its own section even when a newer ``0.8.0 Beta 2`` section sits above it.
+    Only when no exact match exists does a bare ``major.minor.patch`` prefix
+    match the newest section sharing that core version.
+    """
+    target = _canon(version)
+    base = _base_version(target)
+    headings: list[tuple[int, str]] = [
+        (index, _canon(match.group("title")))
+        for index, line in enumerate(lines)
+        if (match := _HEADING.match(line))
+    ]
+    for index, head in headings:
+        if head == target:
+            return index
+    if base:
+        for index, head in headings:
+            if head.startswith(base):
+                return index
+    return None
+
+
+def extract_version_section(changelog_text: str, version: str) -> str:
+    """Return the body of the ``## <version>`` section, heading line excluded.
+
+    Everything from just after the matching ``## `` heading up to (but not
+    including) the next ``## `` heading is returned, trimmed. Returns ``""``
+    when no section matches ``version``.
+    """
+    lines = changelog_text.splitlines()
+    start = _find_section_start(lines, version)
+    if start is None:
+        return ""
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if _HEADING.match(line):
+            break
+        body.append(line)
+    return "\n".join(body).strip()
+
+
+def find_changelog() -> Path | None:
+    """Locate ``CHANGELOG.md`` in a packaged build or a dev checkout.
+
+    Frozen builds stage a copy beside the package root (``quill/CHANGELOG.md``);
+    development checkouts keep it at the repository root. The first existing
+    candidate wins.
+    """
+    here = Path(__file__).resolve()
+    candidates = [
+        here.parents[1] / "CHANGELOG.md",  # quill/CHANGELOG.md (packaged build)
+        here.parents[2] / "CHANGELOG.md",  # repository root (dev checkout)
+        here.parents[3] / "CHANGELOG.md",
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def load_changelog_text() -> str:
+    """Read the bundled/checked-out changelog, or ``""`` when unavailable."""
+    path = find_changelog()
+    if path is None:
+        return ""
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def release_notes_for(version: str) -> str:
+    """Plain-text "What's New" for ``version``, flattened from the changelog.
+
+    Returns ``""`` when the changelog is missing or has no matching section so
+    callers can fall back to their own message.
+    """
+    section = extract_version_section(load_changelog_text(), version)
+    return strip_md_to_plain(section) if section else ""
+
+
+def current_release_notes() -> str:
+    """Plain-text "What's New" for the running build's version."""
+    from quill import build_info
+
+    return release_notes_for(build_info.get_short_version())
+
+
+__all__ = [
+    "current_release_notes",
+    "extract_version_section",
+    "find_changelog",
+    "load_changelog_text",
+    "release_notes_for",
+]

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -19276,14 +19276,7 @@ class MainFrame(
                 self._record_notification(f"Update {target.version} found; downloading", "update")
                 self._download_update_release(target)
                 return
-            # #179: defer the WebView2 update dialog if the warm-up has not
-            # finished so the UI thread does not block for tens of seconds.
-            if self._webview_warm:
-                action = self._show_update_available_dialog(current_version, target)
-            else:
-                self._set_status("Preparing update dialog... (one-time WebView2 setup)")
-                self._wx.CallAfter(self._show_update_available_dialog, current_version, target)
-                action = "deferred"
+            action = self._show_update_available_dialog(current_version, target)
             if action == "download":
                 self._download_update_release(target)
             elif action == "skip":
@@ -19339,12 +19332,7 @@ class MainFrame(
         save_settings(self.settings)
         self._set_status("Switched to the beta update channel")
         self._announce("Beta updates enabled")
-        if self._webview_warm:
-            action = self._show_update_available_dialog(current_version, release)
-        else:
-            self._set_status("Preparing update dialog... (one-time WebView2 setup)")
-            self._wx.CallAfter(self._show_update_available_dialog, current_version, release)
-            action = "deferred"
+        action = self._show_update_available_dialog(current_version, release)
         if action == "download":
             self._download_update_release(release)
         elif action == "skip":
@@ -19472,40 +19460,122 @@ class MainFrame(
         finally:
             dialog.Destroy()
 
+    def _present_release_notes(
+        self,
+        *,
+        title: str,
+        header: str,
+        notes_plain: str,
+        buttons: list[tuple[str, int]],
+        affirmative_id: int,
+        escape_id: int,
+    ) -> int:
+        """Show release notes in a read-only multi-line edit (help-text style).
+
+        ``header`` is a short label above the notes; ``notes_plain`` is the
+        flattened changelog section shown in a scrollable, screen-reader-friendly
+        ``TextCtrl``. Returns the id of the button the user pressed.
+        """
+        wx = self._wx
+        dialog = wx.Dialog(
+            self.frame, title=title, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
+        )
+        dialog.SetSize((560, 520))
+        sizer = wx.BoxSizer(wx.VERTICAL)
+        if header:
+            heading = wx.StaticText(dialog, label=header)
+            sizer.Add(heading, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.TOP, 12)
+        notes_label = wx.StaticText(dialog, label="Release &notes:")
+        sizer.Add(notes_label, 0, wx.LEFT | wx.RIGHT | wx.TOP, 12)
+        body = wx.TextCtrl(
+            dialog,
+            value=notes_plain,
+            style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_AUTO_URL | wx.TE_RICH2,
+            name="release_notes",
+        )
+        body.SetName("Release notes")
+        sizer.Add(body, 1, wx.EXPAND | wx.ALL, 12)
+        btn_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        btn_sizer.AddStretchSpacer()
+        for label, return_id in buttons:
+            button = wx.Button(dialog, return_id, label=label)
+            button.Bind(wx.EVT_BUTTON, lambda _e, r=return_id: dialog.EndModal(r))
+            if return_id == affirmative_id:
+                button.SetDefault()
+            btn_sizer.Add(button, 0, wx.RIGHT, 6)
+        sizer.Add(btn_sizer, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 12)
+        dialog.SetSizer(sizer)
+        apply_modal_ids(dialog, affirmative_id=affirmative_id, escape_id=escape_id)
+        # Land focus on the notes so screen-reader users enter on the text.
+        wx.CallAfter(body.SetFocus)
+        try:
+            return self._show_modal_dialog(dialog, title)
+        finally:
+            dialog.Destroy()
+
     def _show_update_available_dialog(self, current_version: str, release: GitHubRelease) -> str:
         """Present an available update. Returns one of ``"download"``,
         ``"skip"`` (don't offer this version again) or ``"later"``."""
-        from quill.ui.preview_dialog import HtmlMessageDialog
-
         wx = self._wx
         self._announce(f"Update available: {release.version}")
         channel = "Beta / prerelease" if release.prerelease else "Stable"
-        notes = release.notes or "_(no release notes provided)_"
-        if len(notes) > 600:
-            notes = notes[:600] + "…"
-        published = f"**Published:** {release.published_at}  \n" if release.published_at else ""
-        body = self._render_html(
-            f"# Update available: {release.version}\n\n"
-            f"**Channel:** {channel}  \n"
-            f"{published}"
-            f"**Current version:** {current_version}\n\n"
-            "## Release notes\n\n" + notes
+        raw = (release.notes or "").strip()
+        notes = (
+            _strip_md_to_plain(raw)
+            if raw
+            else "(No release notes were provided for this version.)"
         )
-        result = HtmlMessageDialog(
-            self.frame,
-            "Check for Updates",
-            body,
-            [
-                ("Skip this version", wx.ID_IGNORE),
+        published = f"Published: {release.published_at}\n" if release.published_at else ""
+        header = (
+            f"Update available: {release.version}\n"
+            f"Channel: {channel}\n"
+            f"{published}"
+            f"Current version: {current_version}"
+        )
+        result = self._present_release_notes(
+            title="Check for Updates",
+            header=header,
+            notes_plain=notes,
+            buttons=[
                 ("Later", wx.ID_CANCEL),
+                ("Skip this version", wx.ID_IGNORE),
                 ("Download update", wx.ID_OK),
             ],
-        ).show_modal()
+            affirmative_id=wx.ID_OK,
+            escape_id=wx.ID_CANCEL,
+        )
         if result == wx.ID_OK:
             return "download"
         if result == wx.ID_IGNORE:
             return "skip"
         return "later"
+
+    def show_whats_new(self) -> None:
+        """Show the running build's abbreviated release notes on demand.
+
+        Lets users see the same notes the Check-for-Updates dialog shows, even
+        between updates, so the format is familiar when an update lands.
+        """
+        from quill import build_info
+        from quill.core.release_notes import current_release_notes
+
+        wx = self._wx
+        version = build_info.get_short_version()
+        notes = current_release_notes()
+        if not notes:
+            notes = (
+                "Release notes are not bundled with this build.\n\n"
+                "See the changelog on the project site for what's new."
+            )
+        self._present_release_notes(
+            title="What's New",
+            header=f"What's new in QUILL {version}",
+            notes_plain=notes,
+            buttons=[("Close", wx.ID_CLOSE)],
+            affirmative_id=wx.ID_CLOSE,
+            escape_id=wx.ID_CLOSE,
+        )
+        self._set_status("Showed What's New")
 
     def _skip_update_version(self, version: str) -> None:
         """Remember a version the user chose to skip so we stop offering it."""

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -19521,9 +19521,7 @@ class MainFrame(
         channel = "Beta / prerelease" if release.prerelease else "Stable"
         raw = (release.notes or "").strip()
         notes = (
-            _strip_md_to_plain(raw)
-            if raw
-            else "(No release notes were provided for this version.)"
+            _strip_md_to_plain(raw) if raw else "(No release notes were provided for this version.)"
         )
         published = f"Published: {release.published_at}\n" if release.published_at else ""
         header = (

--- a/quill/ui/main_frame_menu.py
+++ b/quill/ui/main_frame_menu.py
@@ -1415,6 +1415,7 @@ class MenuBuilderMixin:
         self._id_shell_remove = wx.NewIdRef()
         self._id_notifications = wx.NewIdRef()
         self._id_check_updates = wx.NewIdRef()
+        self._id_whats_new = wx.NewIdRef()
         self._id_check_glow_updates = wx.NewIdRef()
         self._id_status_bar_settings = wx.NewIdRef()
         self._id_share_export = wx.NewIdRef()
@@ -2303,6 +2304,7 @@ class MenuBuilderMixin:
         # "Check for Updates on Startup" lives in Settings now (removed the
         # duplicate Help-menu toggle).
         help_menu.Append(self._id_check_updates, _("Check for &Updates..."))
+        help_menu.Append(self._id_whats_new, _("&What's New..."))
         if self._feature_enabled("core.glow"):
             help_menu.Append(self._id_check_glow_updates, _("Check for &GLOW Updates..."))
         help_menu.Append(self._id_about_quill, _("&About Quill"))
@@ -3655,6 +3657,11 @@ class MenuBuilderMixin:
             wx.EVT_MENU,
             lambda _e: self.check_for_updates(),
             id=self._id_check_updates,
+        )
+        self.frame.Bind(
+            wx.EVT_MENU,
+            lambda _e: self.show_whats_new(),
+            id=self._id_whats_new,
         )
         self.frame.Bind(
             wx.EVT_MENU,

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -1182,6 +1182,13 @@ def bundle_embedded_python(
     print(f"Copying Quill package source from {quill_source} into runtime...")
     shutil.copytree(quill_source, site_packages / "quill", dirs_exist_ok=True)
 
+    # Stage the changelog inside the package so the running build can show
+    # abbreviated "What's New" / Check-for-Updates release notes offline
+    # (quill.core.release_notes.find_changelog reads quill/CHANGELOG.md).
+    changelog_src = source_root / "CHANGELOG.md"
+    if changelog_src.is_file():
+        shutil.copy2(changelog_src, site_packages / "quill" / "CHANGELOG.md")
+
     _install_vendored_glow(python_exe, source_root)
     _prune_embedded_runtime(site_packages)
 

--- a/scripts/extract_release_body.py
+++ b/scripts/extract_release_body.py
@@ -1,0 +1,67 @@
+"""Extract a single version's section from CHANGELOG.md for the release pipeline.
+
+Reuses :func:`quill.core.release_notes.extract_version_section` so the GitHub
+release body, the signed update-feed ``notes`` field, and the in-app
+What's New / Check-for-Updates dialogs all show the same abbreviated text.
+
+Usage::
+
+    python scripts/extract_release_body.py --version v0.8.0-beta1 \
+        --output release-body.md --fallback-full
+
+Pure stdlib + the wx-free ``quill.core`` helpers, so it runs in CI without a
+full editable install (``PYTHONPATH=.`` is enough).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from quill.core.release_notes import extract_version_section
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract a release's CHANGELOG section.")
+    parser.add_argument("--version", required=True, help="Release version or git tag.")
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"))
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Write the section here (default: print to stdout).",
+    )
+    parser.add_argument(
+        "--max-chars",
+        type=int,
+        default=0,
+        help="Truncate to this many characters (0 = no limit).",
+    )
+    parser.add_argument(
+        "--fallback-full",
+        action="store_true",
+        help="When no matching section is found, emit the whole changelog "
+        "instead of an empty string (keeps a release body from being blank).",
+    )
+    args = parser.parse_args()
+
+    text = args.changelog.read_text(encoding="utf-8")
+    section = extract_version_section(text, args.version)
+    if not section and args.fallback_full:
+        section = text.strip()
+    if args.max_chars > 0:
+        section = section[: args.max_chars]
+
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(section + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(section)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/core/test_release_notes.py
+++ b/tests/unit/core/test_release_notes.py
@@ -1,0 +1,104 @@
+"""Tests for the abbreviated release-notes extractor (quill.core.release_notes)."""
+
+from __future__ import annotations
+
+from quill.core.release_notes import (
+    extract_version_section,
+    release_notes_for,
+)
+
+CHANGELOG = """\
+# Changelog
+
+## 0.8.0 Beta 1 (in development)
+
+Top summary line.
+
+### Section A
+
+- **Bold** feature with `code`.
+- Another change.
+
+## 0.7.0
+
+Older release.
+
+### Things
+
+- Old item.
+"""
+
+
+def test_extracts_section_body_without_heading() -> None:
+    section = extract_version_section(CHANGELOG, "0.8.0 Beta 1")
+    assert section.startswith("Top summary line.")
+    assert "Another change." in section
+    # Stops before the next ## heading.
+    assert "Older release." not in section
+    assert "## 0.8.0" not in section
+
+
+def test_matches_git_tag_form() -> None:
+    # A git tag (v0.8.0-beta1) must resolve to the human "0.8.0 Beta 1" heading.
+    section = extract_version_section(CHANGELOG, "v0.8.0-beta1")
+    assert "Top summary line." in section
+    assert "Older release." not in section
+
+
+def test_matches_by_base_version() -> None:
+    section = extract_version_section(CHANGELOG, "0.7.0")
+    assert "Older release." in section
+    assert "Top summary line." not in section
+
+
+# A changelog with two prereleases of the same base version; the newer one
+# sits on top, exactly like CHANGELOG.md during the Beta 2 cycle.
+TWO_BETAS = """\
+# Changelog
+
+## 0.8.0 Beta 2 (in development)
+
+Beta two body.
+
+## 0.8.0 Beta 1 (in development)
+
+Beta one body.
+"""
+
+
+def test_exact_match_wins_over_newer_same_base_section() -> None:
+    # The running Beta 1 build must get Beta 1 notes even though Beta 2 is on top.
+    assert "Beta one body." in extract_version_section(TWO_BETAS, "0.8.0 Beta 1")
+    assert "Beta two body." not in extract_version_section(TWO_BETAS, "0.8.0 Beta 1")
+    # ...and the Beta 1 git-tag form resolves the same way.
+    assert "Beta one body." in extract_version_section(TWO_BETAS, "v0.8.0-beta1")
+
+
+def test_beta2_resolves_to_its_own_section() -> None:
+    for version in ("0.8.0 Beta 2", "v0.8.0-beta2"):
+        assert "Beta two body." in extract_version_section(TWO_BETAS, version)
+        assert "Beta one body." not in extract_version_section(TWO_BETAS, version)
+
+
+def test_bare_base_version_picks_newest_same_base() -> None:
+    # A stable-looking 0.8.0 with no exact heading falls back to the newest 0.8.0.x.
+    assert "Beta two body." in extract_version_section(TWO_BETAS, "0.8.0")
+
+
+def test_unknown_version_returns_empty() -> None:
+    assert extract_version_section(CHANGELOG, "9.9.9") == ""
+
+
+def test_release_notes_for_flattens_markdown(monkeypatch) -> None:
+    monkeypatch.setattr("quill.core.release_notes.load_changelog_text", lambda: CHANGELOG)
+    notes = release_notes_for("0.8.0 Beta 1")
+    # Markdown emphasis/code markers are stripped for the plain-text edit.
+    assert "**" not in notes
+    assert "`" not in notes
+    assert "Bold feature with code." in notes
+    assert "Section A" in notes
+
+
+def test_release_notes_for_unknown_is_empty(monkeypatch) -> None:
+    monkeypatch.setattr("quill.core.release_notes.load_changelog_text", lambda: CHANGELOG)
+    assert release_notes_for("9.9.9") == ""

--- a/tests/unit/ui/fixtures/dialog_inventory.json
+++ b/tests/unit/ui/fixtures/dialog_inventory.json
@@ -78,6 +78,7 @@
   "quill/ui/main_frame.py::MainFrame._offer_post_download_actions::wx.Dialog": "hardened_custom",
   "quill/ui/main_frame.py::MainFrame._open_find_replace::wx.FindReplaceDialog": "native",
   "quill/ui/main_frame.py::MainFrame._present_quick_nav::wx.Dialog": "hardened_custom",
+  "quill/ui/main_frame.py::MainFrame._present_release_notes::wx.Dialog": "hardened_custom",
   "quill/ui/main_frame.py::MainFrame._prompt_code_language::wx.TextEntryDialog": "native",
   "quill/ui/main_frame.py::MainFrame._prompt_file_search::wx.Dialog": "hardened_custom",
   "quill/ui/main_frame.py::MainFrame._prompt_migration_summary::wx.MessageDialog": "native",

--- a/tests/unit/ui/fixtures/main_frame_public_surface.json
+++ b/tests/unit/ui/fixtures/main_frame_public_surface.json
@@ -472,6 +472,7 @@
   "show_thesaurus",
   "show_thesaurus_or_lookup",
   "show_watch_folder_status",
+  "show_whats_new",
   "show_whisperer_about_page",
   "show_word_count",
   "show_word_prediction",


### PR DESCRIPTION
## Summary

Show an abbreviated, screen-reader-friendly release-notes summary when an update is found, and add a Help > What's New command to see the running build's notes on demand.

- Check-for-Updates dialog now renders notes in a read-only multi-line edit (the control help text and wizards use), with Download / Skip this version / Later. Drops the WebView2 warm-up dependency for this dialog.
- New **Help > What's New** shows the current build's notes between updates, in the same control.
- Notes come from the per-version `CHANGELOG.md` section (single source of truth). New wx-free `quill/core/release_notes.py` slices a version's section and flattens it to plain text; exact-version matching wins over a base-version fallback so Beta 1 and Beta 2 each resolve to their own section.
- Build stages `CHANGELOG.md` into the package so frozen builds read notes offline.
- Release workflow sets the GitHub release body and signed-feed notes from the same per-version section (the old `awk` never matched the human `## 0.8.0 Beta 1` headings, so feed notes were empty).
- Adds a `0.8.0 Beta 2` CHANGELOG section for real-world update testing.

## To edit the notes

Edit the version's section in `CHANGELOG.md` (markdown). The top heading must equal the build version or GATE-VC fails.

## Tests / checks

- `pytest tests/unit/tools tests/unit/core/test_release_notes.py tests/unit/ui/test_main_frame_characterization.py tests/unit/structure` — 241 passed (gates, structure, dialog/surface, release notes).
- GATE-VC OK at 0.8.0 Beta 2; ruff + scoped mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)