### PR TITLE
docs(site): add macOS .dmg to download links

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -21,8 +21,9 @@
             <details class="nav-dropdown">
               <summary>Download</summary>
               <ul>
-                <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-for-All-Setup-0.8.0.Beta.1.exe">System Installer</a></li>
-                <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-Portable-v0.8.0-beta.1.zip">Portable ZIP</a></li>
+                <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-for-All-Setup-0.8.0.Beta.1.exe">Windows: System Installer</a></li>
+                <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-Portable-v0.8.0-beta.1.zip">Windows: Portable ZIP</a></li>
+                <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-macOS-0.8.0-beta.1.dmg">macOS: Disk Image (.dmg)</a></li>
               </ul>
             </details>
           </li>
@@ -55,10 +56,11 @@
         <div class="cta">
           <a class="btn" href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-for-All-Setup-0.8.0.Beta.1.exe">Download QUILL 0.8.0 Beta 1 - System Installer</a>
           <a class="btn" href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-Portable-v0.8.0-beta.1.zip">Download QUILL 0.8.0 Beta 1 - Portable</a>
+          <a class="btn" href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-macOS-0.8.0-beta.1.dmg">Download QUILL 0.8.0 Beta 1 - macOS</a>
           <a class="btn secondary" href="/docs/release0.8.0-beta1.html">What's new in 0.8.0 Beta 1</a>
           <a class="btn secondary" href="/docs/userguide.html">User guide</a>
         </div>
-        <p class="req-note">Windows 10 or later, 64-bit. System installer: installs to Program Files, approximately 240&nbsp;MB. Portable: extract the ZIP and run from any folder, no installation required. Both include the Python runtime.</p>
+        <p class="req-note">Windows 10 or later, 64-bit. System installer: installs to Program Files, approximately 240&nbsp;MB. Portable: extract the ZIP and run from any folder, no installation required. macOS 12 or later: download the disk image (.dmg), approximately 205&nbsp;MB, and drag QUILL to Applications. All builds include the Python runtime.</p>
       </div>
     </div>
 
@@ -251,10 +253,11 @@
         <div class="cards">
           <div class="card">
             <h3>Download QUILL 0.8.0 Beta 1</h3>
-            <p>Windows 10 or later, 64-bit. Includes Python runtime - no separate install required.</p>
+            <p>Windows 10 or later, 64-bit, or macOS 12 or later. Includes Python runtime - no separate install required.</p>
             <ul class="doc-links">
               <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-for-All-Setup-0.8.0.Beta.1.exe">Windows: System installer (~240 MB, installs to Program Files)</a></li>
               <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-Portable-v0.8.0-beta.1.zip">Windows: Portable ZIP (extract and run from any folder)</a></li>
+              <li><a href="https://github.com/Community-Access/quill/releases/download/v0.8.0-beta.1/Quill-macOS-0.8.0-beta.1.dmg">macOS: Disk Image (~205 MB, drag to Applications)</a></li>
             </ul>
             <span class="more"><a href="https://github.com/Community-Access/quill/releases/tag/v0.8.0-beta.1">View the full release on GitHub <span aria-hidden="true">&rarr;</span></a></span>
           </div>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>QUILL - Screen-reader-first writing environment</title>
-  <meta name="description" content="QUILL 0.8.0 Beta 1 is available now for Windows. A screen-reader-first writing environment: every command announces its outcome, everything works from the keyboard, and your document never leaves your device without your say-so.">
+  <meta name="description" content="QUILL 0.8.0 Beta 1 is available now for Windows and macOS. A screen-reader-first writing environment: every command announces its outcome, everything works from the keyboard, and your document never leaves your device without your say-so.">
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
@@ -42,7 +42,7 @@
       <div class="wrap">
         <h1>Writing software built around your screen reader.</h1>
         <p class="lede">
-          QUILL is a screen-reader-first writing environment for Windows. Every command announces
+          QUILL is a screen-reader-first writing environment for Windows and macOS. Every command announces
           its outcome. Everything works from the keyboard. Your document never leaves your device
           without your explicit say-so. Version 0.8.0 Beta 1 is available now.
         </p>
@@ -305,7 +305,7 @@
       <p class="note">
         <strong class="quill" style="color:var(--accent)">QUILL</strong> -
         Quality, Usable, Inclusive, Lightweight, Literate. A screen-reader-first
-        writing environment for Windows.
+        writing environment for Windows and macOS.
       </p>
       <nav aria-label="Documentation">
         <h4>Documentation</h4>


### PR DESCRIPTION
The 0.8.0 Beta 1 release now ships a macOS disk image (`Quill-macOS-0.8.0-beta.1.dmg`, ~205 MB). This surfaces it on the GitHub Pages site everywhere the Windows builds appear:

- Nav **Download** dropdown (the expandable menu)
- Hero download buttons
- Requirements note (adds "macOS 12 or later")
- "Start here" download list

Links point at the published release asset on `v0.8.0-beta.1`. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)