### PR TITLE
chore(deps): batch the open dependabot version bumps (#730-#739)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,9 +28,9 @@ dependencies = [
     "platform_utils>=1.6.2",
     # Windows has no system IANA timezone database, so stdlib zoneinfo needs
     # this package to resolve real zone names (publishing schedule dialog).
-    "tzdata>=2025.1",
+    "tzdata>=2026.2",
     # Native .docx reading/writing without requiring Pandoc.
-    "python-docx>=1.1.2",
+    "python-docx>=1.2.0",
 ]
 
 [project.optional-dependencies]
@@ -41,12 +41,12 @@ ui = [
     "wx-accessible-webview>=0.2.0",
     # Windows SAPI 5 text-to-speech (Read Aloud system voice + self-voicing
     # announcement fallback). Windows-only at runtime; harmless elsewhere.
-    "comtypes>=1.4; sys_platform == 'win32'",
+    "comtypes>=1.4.16; sys_platform == 'win32'",
     # CA bundle for verified HTTPS update checks (macOS Python lacks trusted roots).
     "certifi>=2026.6.17",
     # Prism screen-reader speech bridge (Windows) — routes announcements to
     # NVDA/JAWS/Narrator instead of speaking over them.
-    "prismatoid>=0.16.6; sys_platform == 'win32'",
+    "prismatoid>=0.16.7; sys_platform == 'win32'",
     # accessible_output2: fallback screen-reader speech bridge (Windows). Its
     # per-reader is_active() detection is used when Prism cannot acquire a live
     # backend, before resorting to the SAPI self-voice. Pulls in libloader.
@@ -76,25 +76,25 @@ ssh = ["paramiko>=5.0.0"]
 # (see requirements.txt). A higher floor has no wheel and makes pip compile
 # llama.cpp from source. Install via requirements.txt (which carries the
 # --extra-index-url) or pass that index so the wheel resolves.
-ai = ["llama-cpp-python==0.3.19"]
+ai = ["llama-cpp-python==0.3.31"]
 dictation = ["SpeechRecognition>=3.17.0"]
 # Offline speech-to-text (#617). The whisper.cpp executable + GGML models are
 # managed out-of-band (AI > Speech > Manage Speech Models); this optional extra
 # adds microphone capture for offline dictate-at-cursor via PortAudio.
-speech = ["sounddevice>=0.4"]
+speech = ["sounddevice>=0.5.5"]
 # Optional higher-throughput offline speech engine (#617 S4). Faster Whisper is
 # a CTranslate2-based library that uses the GPU when available; huggingface_hub
 # fetches its CTranslate2 model repositories. Users opt in via AI > Speech >
 # Manage Speech Models > Speech Engine; the bundled whisper.cpp engine remains
 # the default and needs none of this.
-fasterwhisper = ["faster-whisper>=1.0", "huggingface_hub>=0.20"]
+fasterwhisper = ["faster-whisper>=1.2.1", "huggingface_hub>=1.21.0"]
 # Optional very-low-resource offline English engine: Vosk (Kaldi) (#669). Tiny
 # CPU-only models (~40 MB) for old/constrained machines. Models download from
 # alphacephei.com via Manage Speech Models; no GPU needed.
 vosk = ["vosk>=0.3.45"]
 # MP3 chapter markers for batch document-to-speech (§4.8): mutagen writes the
 # ID3v2.3 CHAP/CTOC frames. Imported lazily in quill/core/speech/chapters.py.
-mp3 = ["mutagen>=1.47"]
+mp3 = ["mutagen>=1.48.1"]
 # Native Word (.docx) export with full formatting fidelity (font family, point
 # size, color, highlight, paragraph alignment) for the hidden-codes feature
 # (docs/rich-text-formatting-hidden-codes-design.md). Optional: when absent,
@@ -105,7 +105,7 @@ docx = ["python-docx>=1.1.0"]
 # Optional: the ElevenLabs AI Voice provider is inert unless this is installed and
 # an "ElevenLabs API key" credential is configured. All calls go through the
 # host-owned gateway quill/core/ai/elevenlabs_tts.py (the only importer of the SDK).
-elevenlabs = ["elevenlabs>=1.0.0"]
+elevenlabs = ["elevenlabs>=2.54.0"]
 # Native Windows OCR (OCR-1): thin pip wheels projecting the Windows.Media.Ocr
 # WinRT APIs that ship inside Windows 10/11. The OCR engine itself is a built-in
 # OS component, so end users install nothing extra — bundling these wheels makes

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,7 +43,7 @@ pyenchant>=3.3.0
 # llama.cpp from source via CMake -- which hangs. Bump this only when the index
 # publishes a newer wheel for the supported Python versions.
 --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cpu
-llama-cpp-python==0.3.19
+llama-cpp-python==0.3.31
 
 # Dictation / voice input (mic permission required).
 SpeechRecognition>=3.17.0


### PR DESCRIPTION
Consolidates the ten open dependabot PRs into one change, so the `pyproject.toml` floor bumps don't cascade-conflict when merged individually (each touches the same file, and main just moved with the 0.8.0 Beta 2 merge).

Bumps applied (and `requirements.txt` for the llama pin):
- tzdata >=2025.1 → >=2026.2 (#732)
- python-docx >=1.1.2 → >=1.2.0 (#737)
- comtypes >=1.4 → >=1.4.16 (#734)
- prismatoid >=0.16.6 → >=0.16.7 (#735)
- llama-cpp-python ==0.3.19 → ==0.3.31 (#738)
- sounddevice >=0.4 → >=0.5.5 (#730)
- faster-whisper >=1.0 → >=1.2.1 (#733)
- huggingface_hub >=0.20 → >=1.21.0 (#736)
- mutagen >=1.47 → >=1.48.1 (#731)
- elevenlabs >=1.0.0 → >=2.54.0 (#739)

The individual dependabot PRs #730–#739 are superseded by this and will be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)