### PR TITLE
fix(packaging): bundle the whisper.cpp engine in the build (#742)

### DIFF
--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -83,6 +83,24 @@ PIPER_PINNED_URL = (
 )
 PIPER_PINNED_SHA256 = "f3c58906402b24f3a96d92145f58acba6d86c9b5db896d207f78dc80811efcea"
 
+# Pinned whisper.cpp Windows release. _download_and_stage_whisper() tries the
+# latest GitHub release first and falls back to these if the API is unreachable.
+# The CPU x64 zip ships whisper-cli.exe alongside its whisper.dll / ggml*.dll
+# dependencies -- the offline speech engine (#617, #742). whisper.cpp is the
+# DEFAULT offline transcription/dictation provider, so unlike the other speech
+# engines it MUST ship: the build raises rather than producing an installer whose
+# selected "speechwhisper" component has no payload.
+#
+# NOTE: the pinned fallback SHA-256 is a placeholder. Release CI reaches the
+# GitHub API and uses the latest-release path (sha256=None, matching the other
+# engines), so the fallback only fires when the API is unreachable. Fill this in
+# (download the asset once and record its SHA-256) before relying on an offline
+# build; until then _download_and_stage_whisper refuses the unverified fallback.
+WHISPERCPP_PINNED_URL = (
+    "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.4/whisper-bin-x64.zip"
+)
+WHISPERCPP_PINNED_SHA256 = "<REPLACE_WITH_WHISPER_BIN_X64_SHA256>"
+
 # Kokoro neural-TTS model + voices. Always STAGED into the portable bundle under
 # kokoro-models/, but the INSTALLER gates the copy behind the optional
 # "speechkokoro" component (Types: full custom) -- so Full installs still ship it
@@ -300,6 +318,8 @@ def build_windows_distribution(
         effective_bundled_tools["speech/espeak-ng"] = _download_and_stage_espeak(portable_dir)
     if "speech/piper" not in effective_bundled_tools:
         effective_bundled_tools["speech/piper"] = _download_and_stage_piper(portable_dir)
+    if "speech/whispercpp" not in effective_bundled_tools:
+        effective_bundled_tools["speech/whispercpp"] = _download_and_stage_whisper(portable_dir)
     bundled_tools = _stage_bundled_tools(portable_dir, effective_bundled_tools)
     # Kokoro is staged separately (not via _stage_bundled_tools): it ships under
     # the bundle-root kokoro-models/ folder the runtime looks for, not tools/.
@@ -1634,6 +1654,7 @@ def _speech_asset_manifest(
         "dectalk": "dectalk",
         "espeak": "espeak-ng",
         "piper": "piper",
+        "whispercpp": "whispercpp",
     }
     for engine, dir_name in engine_dirs.items():
         engine_dir = speech_root / dir_name
@@ -1800,6 +1821,66 @@ def _download_and_stage_piper(portable_dir: Path) -> Path:
     shutil.copytree(piper_root, stage_dir, dirs_exist_ok=True)
     archive.unlink(missing_ok=True)
     print(f"Piper staged to {stage_dir}")
+    return stage_dir
+
+
+def _download_and_stage_whisper(portable_dir: Path) -> Path:
+    """Download the whisper.cpp engine for Windows and return a staging directory.
+
+    Tries the latest ggml-org/whisper.cpp GitHub release first; falls back to the
+    pinned version. Stages to portable/_tool-download/whispercpp/stage/ so
+    _stage_bundled_tools() copies it to tools/speech/whispercpp/. Re-uses a prior
+    download. The staged folder keeps whisper-cli.exe alongside its whisper.dll /
+    ggml*.dll dependencies so resolve_whisper_executable() finds a runnable engine.
+
+    whisper.cpp is the default offline transcription/dictation provider (#617), so
+    this download is not optional: a failure raises rather than letting the build
+    produce an installer whose selected "speechwhisper" component ships no engine
+    (the empty-component regression behind #742).
+    """
+    stage_dir = portable_dir / "_tool-download" / "whispercpp" / "stage"
+    if (stage_dir / "whisper-cli.exe").exists() or (stage_dir / "main.exe").exists():
+        print("whisper.cpp already downloaded; skipping.")
+        return stage_dir
+
+    url = (
+        _fetch_latest_github_asset_url("ggml-org", "whisper.cpp", "-bin-x64.zip")
+        or WHISPERCPP_PINNED_URL
+    )
+    if url == WHISPERCPP_PINNED_URL and WHISPERCPP_PINNED_SHA256.startswith("<"):
+        raise RuntimeError(
+            "Could not reach the whisper.cpp releases API and the pinned fallback "
+            "SHA-256 is still a placeholder. Set WHISPERCPP_PINNED_URL / "
+            "WHISPERCPP_PINNED_SHA256 to a verified release before building offline, "
+            "or supply --whisper-dir with a local engine."
+        )
+    sha256 = WHISPERCPP_PINNED_SHA256 if url == WHISPERCPP_PINNED_URL else None
+
+    tmp_dir = portable_dir / "_tool-download" / "whispercpp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    archive = tmp_dir / "whisper-bin-x64.zip"
+    print(f"Downloading whisper.cpp from {url}...")
+    _download_with_verification(url, archive, expected_sha256=sha256)
+
+    extract_dir = tmp_dir / "extracted"
+    if extract_dir.exists():
+        shutil.rmtree(extract_dir)
+    extract_dir.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(archive) as zf:
+        zf.extractall(extract_dir)
+
+    # Newer releases ship whisper-cli.exe; older ones shipped main.exe. Either is
+    # on resolve_whisper_executable()'s allowlist, so accept whichever is present.
+    exe_candidates = list(extract_dir.rglob("whisper-cli.exe")) or list(
+        extract_dir.rglob("main.exe")
+    )
+    if not exe_candidates:
+        raise RuntimeError("whisper.cpp zip did not contain whisper-cli.exe or main.exe")
+    engine_root = exe_candidates[0].parent
+    stage_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(engine_root, stage_dir, dirs_exist_ok=True)
+    archive.unlink(missing_ok=True)
+    print(f"whisper.cpp staged to {stage_dir}")
     return stage_dir
 
 

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -85,21 +85,15 @@ PIPER_PINNED_SHA256 = "f3c58906402b24f3a96d92145f58acba6d86c9b5db896d207f78dc808
 
 # Pinned whisper.cpp Windows release. _download_and_stage_whisper() tries the
 # latest GitHub release first and falls back to these if the API is unreachable.
-# The CPU x64 zip ships whisper-cli.exe alongside its whisper.dll / ggml*.dll
-# dependencies -- the offline speech engine (#617, #742). whisper.cpp is the
-# DEFAULT offline transcription/dictation provider, so unlike the other speech
-# engines it MUST ship: the build raises rather than producing an installer whose
-# selected "speechwhisper" component has no payload.
-#
-# NOTE: the pinned fallback SHA-256 is a placeholder. Release CI reaches the
-# GitHub API and uses the latest-release path (sha256=None, matching the other
-# engines), so the fallback only fires when the API is unreachable. Fill this in
-# (download the asset once and record its SHA-256) before relying on an offline
-# build; until then _download_and_stage_whisper refuses the unverified fallback.
+# The plain CPU x64 zip ships whisper-cli.exe (under Release/) alongside its
+# whisper.dll / ggml*.dll dependencies -- the offline speech engine (#617, #742).
+# whisper.cpp is the DEFAULT offline transcription/dictation provider, so unlike
+# the other speech engines it MUST ship: the build raises rather than producing
+# an installer whose selected "speechwhisper" component has no payload.
 WHISPERCPP_PINNED_URL = (
-    "https://github.com/ggml-org/whisper.cpp/releases/download/v1.7.4/whisper-bin-x64.zip"
+    "https://github.com/ggml-org/whisper.cpp/releases/download/v1.9.1/whisper-bin-x64.zip"
 )
-WHISPERCPP_PINNED_SHA256 = "<REPLACE_WITH_WHISPER_BIN_X64_SHA256>"
+WHISPERCPP_PINNED_SHA256 = "7d8be46ecd31828e1eb7a2ecdd0d6b314feafd82163038ab6092594b0a063539"
 
 # Kokoro neural-TTS model + voices. Always STAGED into the portable bundle under
 # kokoro-models/, but the INSTALLER gates the copy behind the optional

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -99,11 +99,16 @@ version = "2.4.6"
         "speech/dectalk",
         "speech/espeak-ng",
         "speech/piper",
+        "speech/whispercpp",
     ]
     assert manifest["docs"] == [r"docs\userguide.md"]
     assert manifest["speechAssets"]["dectalk"]["downloadable"] is True
     assert manifest["speechAssets"]["espeak"]["downloadable"] is True
     assert manifest["speechAssets"]["piper"]["downloadable"] is True
+    # whisper.cpp is the default offline transcription/dictation engine, so the
+    # build always stages it (#742 regression: a selected component with no
+    # payload). It is bundled, not merely downloadable on demand.
+    assert manifest["speechAssets"]["whispercpp"]["bundled"] is True
     # Kokoro is always STAGED at the portable bundle root (kokoro-models/), the
     # location the runtime resolves a bundled copy from; the installer gates the
     # copy behind the optional speechkokoro component (asserted separately).
@@ -404,6 +409,7 @@ def test_portable_bundle_flattens_runtime_to_root(tmp_path: Path, monkeypatch) -
         "speech/dectalk": "say.exe",
         "speech/espeak-ng": "espeak-ng.exe",
         "speech/piper": "piper.exe",
+        "speech/whispercpp": "whisper-cli.exe",
     }.items():
         d = tmp_path / tool_id.replace("/", "_")
         d.mkdir()


### PR DESCRIPTION
## What

Bundle the whisper.cpp offline speech engine in the Windows build so the default transcription/dictation provider actually ships. Fixes #742.

## Why

whisper.cpp is the default offline transcription/dictation engine, but the released 0.8.0 Beta 1 installer shipped it empty:

- The build auto-downloads pandoc, DECtalk, eSpeak-NG, and Piper inline in `build_windows_distribution()` (lines ~293-302). whisper.cpp was the **one engine missing** from that block — it only staged when a build was invoked with `--whisper-dir`.
- Release CI (`.github/workflows/windows-release.yml`) does not pass `--whisper-dir`, and no other step fetched the engine.
- The installer's `tools\speech\whispercpp` `[Files]` copy uses `skipifsourcedoesntexist`, so an absent source silently shipped an **empty** `speechwhisper` component — which is *selected by default* (`Types: full custom`, `full` is the recommended install type).

Result: `resolve_whisper_executable()` found nothing, so users got "whisper binary not found" and Ctrl+F9 reported "dictation is not set up." Re-running the installer and enabling the component did not help, because the component had no payload.

## What changed

- `scripts/build_windows_distribution.py`
  - New `_download_and_stage_whisper()`, modeled on `_download_and_stage_piper()`: tries the latest `ggml-org/whisper.cpp` release, falls back to a pinned URL, extracts `whisper-cli.exe` (or legacy `main.exe`) with its `whisper.dll`/`ggml*.dll` deps, stages it for `_stage_bundled_tools()`.
  - Wired into the inline engine-download block so **every** build ships the engine. A download failure raises rather than producing an empty component — the empty-component regression can't recur silently.
  - Surfaced whisper in `_speech_asset_manifest()` alongside the other engines.
- `tests/unit/scripts/test_build_windows_distribution.py`
  - Extended the heavy build test's `bundledTools` / `speechAssets` assertions to include `speech/whispercpp`.
  - Staged a fake whisper engine in the offline flatten test so it stays network-free.

## Action required before merge/release

The pinned **fallback** SHA-256 (`WHISPERCPP_PINNED_SHA256`) is a placeholder. Release CI reaches the GitHub API and uses the latest-release path (`sha256=None`, exactly like the other four engines), so the fallback only fires if the API is unreachable — and then the function refuses the unverified download until the SHA is filled in. To make the offline fallback usable, download the pinned `whisper-bin-x64.zip` once and record its SHA-256 (and confirm `WHISPERCPP_PINNED_URL` points at the whisper.cpp build you want to ship). This matches how the other engines pin their fallbacks.

## Tests

- `ruff check` / `ruff format --check`: pass.
- Offline subset (`flattens_runtime`, `inno_setup_script_mentions`, `iss in_sync`): 3 passed. The iss-sync guard confirms the generated installer script is unchanged.
- Offline smoke test of `_download_and_stage_whisper` (stubbed network): extracts `whisper-cli.exe` + DLLs, co-stages deps, and short-circuits on re-run.
- Not run here (require network, ~tens of MB, 180s): `test_build_windows_distribution_writes_portable_and_installer_files` and `test_build_windows_distribution_can_bundle_external_tools` — these already download the other engines and now also download whisper; assertions updated/compatible. They run in CI.

## Note on #740

The related python313.dll bug (#740) is already fixed on `main` (runtime flattened to root + `sitecustomize` self-run) and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
