### PR TITLE
fix(speech): offer MP3 and other ffmpeg formats in Generate Speech Audio (#750)

### DIFF
--- a/quill/core/speech/ffmpeg.py
+++ b/quill/core/speech/ffmpeg.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import os
 import shutil
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -92,6 +92,33 @@ def find_ffprobe() -> str | None:
 def ffmpeg_available() -> bool:
     """True when QUILL can convert arbitrary audio/video for transcription."""
     return find_ffmpeg() is not None
+
+
+def resolve_export_format(
+    typed_suffix: str, filter_index: int, ordered_exts: Sequence[str]
+) -> tuple[str, bool]:
+    """Pick the output format for the Generate Speech Audio save dialog (#750).
+
+    ``ordered_exts`` is the list of format ids shown as named filters in order
+    (e.g. ``["wav", "mp3", ...]``); the trailing "All files" filter occupies
+    index ``len(ordered_exts)``. ``typed_suffix`` is the suffix the user typed
+    (``output_path.suffix``), ``filter_index`` is the dialog's selected filter.
+
+    Returns ``(format_id, normalize_suffix)``:
+
+    - A recognized typed extension wins, so ``song.mp3`` typed under "All files"
+      still makes an MP3 and the user's name is kept (``normalize_suffix`` False).
+    - Otherwise the selected named filter decides and the path suffix should be
+      normalized to it (``normalize_suffix`` True).
+    - An unknown extension under "All files" falls back to WAV.
+    """
+    typed = typed_suffix.lower().lstrip(".")
+    known = set(ordered_exts)
+    if typed in known:
+        return typed, False
+    if 0 <= filter_index < len(ordered_exts):
+        return ordered_exts[filter_index], True
+    return "wav", typed != "wav"
 
 
 def build_probe_duration_command(ffprobe: str, path: Path) -> list[str]:

--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -17557,18 +17557,44 @@ class MainFrame(
             self._set_status("Nothing to synthesize")
             return
 
+        # WAV is always available (the engines emit it directly). The compressed
+        # listening formats (MP3, M4A/M4B, OGG, Opus, FLAC) need ffmpeg to encode
+        # the synthesized WAV, so they only appear when ffmpeg is installed (#750).
+        from quill.core.speech.ffmpeg import ffmpeg_available, resolve_export_format
+
+        formats: list[tuple[str, str]] = [("wav", "Wave file")]
+        if ffmpeg_available():
+            formats += [
+                ("mp3", "MP3 audio"),
+                ("m4a", "M4A audio"),
+                ("m4b", "M4B audiobook"),
+                ("ogg", "OGG audio"),
+                ("opus", "Opus audio"),
+                ("flac", "FLAC audio"),
+            ]
+        wildcard = "|".join(f"{label} (*.{ext})|*.{ext}" for ext, label in formats)
+        wildcard += "|All files (*.*)|*.*"
+
         with wx.FileDialog(
             self.frame,
             _TITLE,
-            wildcard="Wave file (*.wav)|*.wav|All files (*.*)|*.*",
+            wildcard=wildcard,
             style=wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT,
         ) as dlg:
             if self._show_modal_dialog(dlg, _TITLE) != wx.ID_OK:
                 self._set_status("Speech generation cancelled")
                 return
             output_path = Path(dlg.GetPath())
-        if output_path.suffix.lower() != ".wav":
-            output_path = output_path.with_suffix(".wav")
+            filter_index = dlg.GetFilterIndex()
+
+        # Pick the target format: a recognized typed extension wins (so "song.mp3"
+        # under "All files" still makes an MP3); otherwise the selected filter
+        # decides and the extension is normalized to match (see resolve_export_format).
+        target_fmt, _normalize_suffix = resolve_export_format(
+            output_path.suffix, filter_index, [ext for ext, _ in formats]
+        )
+        if _normalize_suffix:
+            output_path = output_path.with_suffix(f".{target_fmt}")
 
         engine = self.settings.read_aloud_engine.strip().lower() or "sapi5"
         s = self.settings
@@ -17653,17 +17679,30 @@ class MainFrame(
         _espeak_voice = s.read_aloud_espeak_voice
         _espeak_rate = s.read_aloud_espeak_rate
         _out = output_path
+        _target_fmt = target_fmt
 
         def work(progress: Callable[[str, int, int], None]) -> object:
+            import tempfile
+
+            from quill.core.speech.ffmpeg import transcode_audio
+
             progress(f"Starting {_engine}", 0, 1)
+            # The synthesis engines only emit WAV. For a compressed target, render
+            # to a temporary WAV first, then encode it to the chosen format (#750).
+            tmp_dir: str | None = None
+            if _target_fmt == "wav":
+                wav_target = _out
+            else:
+                tmp_dir = tempfile.mkdtemp(prefix="quill-speech-")
+                wav_target = Path(tmp_dir) / f"{_out.stem}.wav"
             if _engine == "sapi5":
                 synthesize_to_file_with_sapi5(
-                    _out_text, _out, voice=_voice, rate=_rate, volume=_vol
+                    _out_text, wav_target, voice=_voice, rate=_rate, volume=_vol
                 )
             elif _engine == "dectalk":
                 synthesize_to_file_with_dectalk(
                     _out_text,
-                    _out,
+                    wav_target,
                     executable_path=dectalk_exe_snap,
                     voice=_dectalk_voice,
                     rate=_dectalk_rate,
@@ -17671,20 +17710,33 @@ class MainFrame(
             elif _engine == "piper":
                 synthesize_with_piper(
                     _out_text,
-                    _out,
+                    wav_target,
                     executable_path=piper_exe_snap,
                     model_path=piper_model_snap,
                 )
             elif _engine == "kokoro":
-                synthesize_with_kokoro(_out_text, _out, voice=_kokoro_voice, speed=_kokoro_speed)
+                synthesize_with_kokoro(
+                    _out_text, wav_target, voice=_kokoro_voice, speed=_kokoro_speed
+                )
             elif _engine == "espeak":
                 synthesize_with_espeak(
                     _out_text,
-                    _out,
+                    wav_target,
                     executable_path=espeak_exe_snap,
                     voice=_espeak_voice,
                     rate=_espeak_rate,
                 )
+            if _target_fmt != "wav":
+                progress(f"Encoding {_target_fmt.upper()}", 1, 1)
+                try:
+                    transcode_audio(wav_target, _out, _target_fmt)
+                finally:
+                    wav_target.unlink(missing_ok=True)
+                    if tmp_dir:
+                        try:
+                            Path(tmp_dir).rmdir()
+                        except OSError:
+                            pass
             progress("Finalizing output", 1, 1)
             return str(_out)
 

--- a/tests/unit/core/speech/test_ffmpeg.py
+++ b/tests/unit/core/speech/test_ffmpeg.py
@@ -8,6 +8,36 @@ import pytest
 from quill.core.speech import ffmpeg
 
 
+def test_resolve_export_format_named_filter_normalizes_suffix() -> None:
+    # User left the typed name extensionless and picked the MP3 filter (index 1):
+    # choose mp3 and signal the suffix should be normalized.
+    exts = ["wav", "mp3", "m4a", "ogg", "opus", "flac"]
+    fmt, normalize = ffmpeg.resolve_export_format("", 1, exts)
+    assert (fmt, normalize) == ("mp3", True)
+
+
+def test_resolve_export_format_typed_extension_wins_and_keeps_name() -> None:
+    # "song.mp3" typed under the "All files" filter (trailing index) still makes
+    # an MP3, and the user's name is preserved (no normalization).
+    exts = ["wav", "mp3", "flac"]
+    fmt, normalize = ffmpeg.resolve_export_format(".mp3", len(exts), exts)
+    assert (fmt, normalize) == ("mp3", False)
+
+
+def test_resolve_export_format_unknown_under_all_files_falls_back_to_wav() -> None:
+    exts = ["wav", "mp3"]
+    # Unknown extension under "All files" -> wav, normalize on.
+    assert ffmpeg.resolve_export_format(".xyz", len(exts), exts) == ("wav", True)
+    # Already .wav under "All files" -> wav, no normalization needed.
+    assert ffmpeg.resolve_export_format(".wav", len(exts), exts) == ("wav", False)
+
+
+def test_resolve_export_format_wav_filter_selected() -> None:
+    # Selecting the WAV filter (index 0) with no typed extension stays wav.
+    exts = ["wav", "mp3"]
+    assert ffmpeg.resolve_export_format("", 0, exts) == ("wav", True)
+
+
 def test_build_transcode_command_targets_16k_mono_wav() -> None:
     args = ffmpeg.build_transcode_command("ffmpeg", Path("in.mp3"), Path("out.wav"))
     assert args[0] == "ffmpeg"


### PR DESCRIPTION
## What

Make MP3 (and the other ffmpeg listening formats) selectable in **Generate Speech Audio**. Fixes #750.

## Why

`MainFrame.generate_speech_audio` hardcoded the save wildcard to `Wave file (*.wav)|*.wav|All files (*.*)|*.*` and then forced a `.wav` suffix on whatever the user typed — so MP3 was impossible from this dialog regardless of whether ffmpeg was installed. The encode capability already existed (`ffmpeg.transcode_audio` + `ENCODE_FORMATS`) but was only wired into the batch document-to-speech export, not this single-document path.

## What changed

- `quill/ui/main_frame.py` — build the save wildcard dynamically: WAV is always offered; **MP3, M4A, M4B, OGG, Opus, FLAC** appear when `ffmpeg_available()`. The synthesis engines still emit WAV, so for a compressed target the work thread renders to a temporary WAV and `transcode_audio`s it to the chosen format, cleaning up the temp file (and temp dir) afterward.
- `quill/core/speech/ffmpeg.py` — new pure `resolve_export_format(typed_suffix, filter_index, ordered_exts) -> (format_id, normalize_suffix)`: a recognized typed extension wins (so `song.mp3` typed under "All files" still makes an MP3 and keeps the user's name); otherwise the selected named filter decides and the suffix is normalized to it; an unknown name under "All files" falls back to WAV.
- `tests/unit/core/speech/test_ffmpeg.py` — 4 cases for the helper (named-filter normalize, typed-extension-wins, unknown-falls-back-to-wav, wav-filter). The dialog method itself is wx-bound; the decision logic is extracted so it is unit-tested directly.

## Notes / follow-ups (not in this PR)

- ffmpeg resolution is `QUILL_APP_ROOT/tools/ffmpeg` -> `<data>/tools/ffmpeg` -> PATH and is `@lru_cache`d per process, so a user who installs ffmpeg while QUILL is running, or whose ffmpeg is not on PATH, won't see the formats until restart. A "Download/locate FFmpeg" affordance is worth a separate issue (flagged on #750).

## Tests

- `ruff check`: pass. `mypy quill/core/speech/ffmpeg.py`: clean. `py_compile` main_frame.py: ok.
- `pytest tests/unit/core/speech/test_ffmpeg.py`: 11 passed (4 new).
- Module-size budget (GATE-11): OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
