### PR TITLE
fix(a11y): don't alarm screen-reader users about a benign self-voice failure (#749)

### DIFF
--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -6811,14 +6811,17 @@ class MainFrame(
                 self.editor.WriteText("![image]()")
 
     def _check_tts_fallback_on_startup(self) -> None:
-        """When SAPI 5 self-voicing fails to initialise, record it -- and only
-        *speak* it when no screen reader is handling speech.
+        """When SAPI 5 self-voicing fails to initialise, surface it appropriately.
 
         SAPI 5 is QUILL's own fallback voice, used only when no screen reader is
-        present. When a reader is doing the talking, a SAPI failure is benign, so
-        announcing "TTS failed" is alarming noise. We always log a diagnostic
-        note; we speak a (corrected) prompt only when the user would otherwise
-        have no voice at all.
+        present. When a reader (NVDA/JAWS/Narrator) is doing the talking, a SAPI
+        failure is benign, so it must not surface as an alarming accessibility
+        error or a spoken "no voice" prompt -- the screen-reader user is not
+        affected and has nothing to fix. We therefore decide the surface *before*
+        recording anything: a detected reader gets only a quiet, unspoken status
+        note plus a benign informational breadcrumb; without a reader the
+        self-voice was the only voice, so the failure is spoken and recorded as a
+        real accessibility problem (#749).
         """
         try:
             from quill.platform.windows.prism_bridge import tts_init_failed
@@ -6826,20 +6829,26 @@ class MainFrame(
             return
         if not tts_init_failed():
             return
-        self._record_notification(
-            "Text-to-speech (the SAPI 5 self-voice) did not start. If you use a "
-            "screen reader, QUILL speaks through it and no action is needed. To "
-            "use QUILL's own voice instead, run Tools > Retry TTS Engine.",
-            "accessibility",
-        )
         if self._screen_reader_handling_speech():
-            # The screen reader is doing the talking; the self-voice is not
-            # needed. Show a quiet, unspoken note rather than announcing a failure.
+            # The screen reader is doing the talking; the self-voice is not needed.
+            # Keep only a benign, informational breadcrumb (category "info", not
+            # "accessibility") and a quiet, unspoken status note -- never an alarm.
+            self._record_notification(
+                "QUILL's optional SAPI 5 self-voice did not start. You are using a "
+                "screen reader, so this has no effect on speech and no action is "
+                "needed.",
+                "info",
+            )
             self._set_status_quiet("Speaking through your screen reader.")
             return
         # No screen reader: the self-voice was the only voice, so this is a real
-        # problem the user must hear. (F8 toggles overwrite mode -- the retry is
+        # problem the user must hear and may want to revisit. (The retry is
         # Tools > Retry TTS Engine.)
+        self._record_notification(
+            "Text-to-speech (the SAPI 5 self-voice) did not start. Run "
+            "Tools > Retry TTS Engine to try again.",
+            "accessibility",
+        )
         self._set_status(
             "Text-to-speech failed to start, so QUILL has no voice. "
             "Run Tools > Retry TTS Engine to try again."

--- a/tests/unit/ui/test_tts_fallback.py
+++ b/tests/unit/ui/test_tts_fallback.py
@@ -40,13 +40,22 @@ def test_no_failure_means_no_message(monkeypatch: pytest.MonkeyPatch) -> None:
     assert stub.spoken == [] and stub.quiet == [] and stub.notes == []
 
 
-def test_failure_with_screen_reader_is_logged_not_spoken(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_failure_with_screen_reader_is_benign_not_alarming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(prism_bridge, "tts_init_failed", lambda: True)
     stub = _Stub(backend="accessible_output2")  # a reader is voicing announcements
     stub._check_tts_fallback_on_startup()
     assert stub.spoken == []  # the benign failure is never spoken
     assert len(stub.quiet) == 1  # quiet, unspoken status note
-    assert len(stub.notes) == 1  # diagnostic recorded
+    # The breadcrumb is informational (category "info", not an alarming
+    # "accessibility" error) and tells the screen-reader user nothing is wrong (#749).
+    assert len(stub.notes) == 1
+    message, category = stub.notes[0]
+    assert category == "info"
+    assert "no action is needed" in message
+    assert "no effect" in message
+    assert "no voice" not in message.lower()
 
 
 def test_failure_without_screen_reader_speaks_correct_retry(


### PR DESCRIPTION
## What

Stop alarming screen-reader users about QUILL's SAPI 5 self-voice failing at startup. Fixes #749.

## Why

When the SAPI 5 self-voice fails to initialize and a screen reader (NVDA/JAWS/Narrator) is voicing QUILL, the self-voice is irrelevant — the user has nothing to fix. The spoken "no voice" alarm was already gated behind `_screen_reader_handling_speech()` (the earlier "John's report: JAWS announced a benign failure" fix), **but** `_check_tts_fallback_on_startup` still recorded the failure as an **"accessibility"** notification *unconditionally*, before the screen-reader check. So a screen-reader user saw an alarming "Text-to-speech (the SAPI 5 self-voice) did not start" item at launch for a problem that did not affect them — which is what the reporter (JAWS 2026) hit while setting up a Piper Read Aloud voice.

The Piper voice itself is healthy: QUILL's self-voice is SAPI-only, so Read Aloud via Piper keeps working. This is purely about not raising a false alarm.

## What changed

- `quill/ui/main_frame.py` — `_check_tts_fallback_on_startup` now decides the surface **before** recording anything:
  - Screen reader present: a benign, informational (`"info"`) breadcrumb that says no action is needed, plus the quiet, unspoken status note. No accessibility error, no spoken alarm.
  - No screen reader: unchanged — the failure is spoken ("…QUILL has no voice…") and recorded as a real accessibility problem with the Tools > Retry TTS Engine path.
- `tests/unit/ui/test_tts_fallback.py` — the screen-reader case now asserts the breadcrumb is `"info"` (not `"accessibility"`), says "no action is needed" / "no effect", and never contains "no voice". The no-screen-reader case is unchanged.

## Scope / honesty

This kills the bad UX (the false alarm) for screen-reader users regardless of *why* SAPI failed. It does **not** investigate the underlying SAPI init failure on a per-machine install (the comtypes codegen path documented in `sapi5._redirect_comtypes_gen_dir`); if that turns out to be the real defect for some users, it's a separate fix. The reporter's relayed detail (JAWS 2026) and the existing detection (`jfw.exe`) mean the screen-reader gate already identifies their reader, so the breadcrumb path is what they'll now get.

## Tests

- `ruff check`: pass. `pytest tests/unit/ui/test_tts_fallback.py`: 4 passed.
- Module-size budget (GATE-11): OK. `py_compile` main_frame.py: ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
