### PR TITLE
fix(macos): repair the py2app launch failure (#755)

### DIFF
--- a/quill/platform/macos/macos_app.py
+++ b/quill/platform/macos/macos_app.py
@@ -1,6 +1,56 @@
-"""Entry point for the macOS .app bundle (used by scripts/setup_macos.py / py2app)."""
+"""Entry point for the macOS .app bundle (used by scripts/setup_macos.py / py2app).
 
-from quill.__main__ import main
+Wraps QUILL's startup so a failure in *our* code — anything after py2app's own
+bootstrap has handed control to ``quill.__main__.main`` — writes the real
+traceback to ``~/Library/Logs/Quill/startup-error.log`` and shows a native
+alert, instead of leaving the user staring at py2app's opaque error screen
+(#755). Failures *inside* py2app's bootstrap (e.g. a missing @rpath dylib)
+happen before this runs and are addressed in scripts/build_macos.sh.
+"""
+
+from __future__ import annotations
+
+
+def _log_startup_error(exc: BaseException) -> str:
+    """Write the traceback to the user Logs dir; return the log path (best effort)."""
+    import traceback
+    from pathlib import Path
+
+    log_path = Path.home() / "Library" / "Logs" / "Quill" / "startup-error.log"
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        log_path.write_text("".join(traceback.format_exception(exc)), encoding="utf-8")
+    except Exception:  # noqa: BLE001 - never let error logging raise
+        pass
+    return str(log_path)
+
+
+def _show_native_error(message: str) -> None:
+    """Show a native macOS alert via osascript. Best effort; never raises."""
+    import subprocess
+
+    escaped = message.replace("\\", "\\\\").replace('"', '\\"')
+    script = f'display alert "QUILL could not start" message "{escaped}" as critical'
+    try:
+        subprocess.run(["osascript", "-e", script], check=False, timeout=30)
+    except Exception:  # noqa: BLE001 - a missing/again-failing osascript must not mask the error
+        pass
+
+
+def _main() -> int:
+    try:
+        from quill.__main__ import main
+
+        return main()
+    except SystemExit:
+        raise
+    except BaseException as exc:  # noqa: BLE001 - capture *any* startup failure for the user
+        log_path = _log_startup_error(exc)
+        _show_native_error(
+            f"QUILL hit an error while starting. The details were written to {log_path}"
+        )
+        return 1
+
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(_main())

--- a/scripts/build_macos.sh
+++ b/scripts/build_macos.sh
@@ -22,15 +22,57 @@ DMG="dist/Quill.dmg"
 # package py2app's finder can't resolve. Extract any top-level package that
 # carries a native binary into the on-disk site dir (already on sys.path) and
 # drop it from the zip, so the inside-out signing pass below reaches the .so.
-ZIP="$APP/Contents/Resources/lib/python311.zip"
-SITE="$APP/Contents/Resources/lib/python3.11"
+# Derive the bundled Python version from the interpreter that built the app
+# (py2app bundles whatever Python ran setup_macos.py; that script now enforces
+# >=3.12, #755). This was hard-coded to 3.11 / "311", which on any other version
+# silently skipped both the native-lib lift below and the framework codesign.
+PYVER="$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+PYTAG="${PYVER//./}"
+
+ZIP="$APP/Contents/Resources/lib/python${PYTAG}.zip"
+SITE="$APP/Contents/Resources/lib/python${PYVER}"
 if [[ -f "$ZIP" ]]; then
   NATIVE_PKGS=$(unzip -Z1 "$ZIP" | grep -iE '\.(so|dylib)$' | grep -v '\.dSYM/' \
     | cut -d/ -f1 | sort -u)
   for pkg in $NATIVE_PKGS; do
-    echo "==> Lifting native package '$pkg' out of python311.zip"
-    ( cd "$SITE" && unzip -oq "../python311.zip" "$pkg/*" )
+    echo "==> Lifting native package '$pkg' out of python${PYTAG}.zip"
+    ( cd "$SITE" && unzip -oq "../python${PYTAG}.zip" "$pkg/*" )
     zip -dq "$ZIP" "$pkg/*"
+  done
+fi
+
+# Bundle @rpath dylibs that macholib did not follow. CPython C-extensions
+# (_ctypes->libffi, _ssl->libssl/libcrypto, _hashlib, _sqlite3, _lzma, _bz2,
+# expat, tcl/tk, z, ...) link their libraries as @rpath/lib*.dylib. With a
+# non-framework Python (Homebrew/conda) those dylibs live in <prefix>/lib and
+# py2app does not copy them, so the .app dlopen-fails inside py2app's own
+# bootstrap, before any QUILL code runs — the launch hang in #755. Copy each
+# missing @rpath dylib from the build interpreter's lib dir into Resources/lib,
+# looping to a fixpoint so transitive deps (libssl->libcrypto) are caught. The
+# newly copied dylibs are themselves rescanned each pass. A framework Python
+# already ships these, so this is a no-op there.
+PYLIBDIR="$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR") or "")')"
+RES_LIB="$APP/Contents/Resources/lib"
+if [[ -n "$PYLIBDIR" && -d "$RES_LIB" ]]; then
+  echo "==> Bundling missing @rpath dylibs (build libdir: $PYLIBDIR)"
+  while : ; do
+    missing=""
+    # Process substitution (< <(...)) keeps the loop body in the current shell,
+    # so 'missing' accumulates across iterations (a piped while would not).
+    while IFS= read -r -d '' macho; do
+      while IFS= read -r ref; do
+        name="${ref#@rpath/}"
+        if [[ ! -e "$RES_LIB/$name" && -e "$PYLIBDIR/$name" ]]; then
+          missing+="$name"$'\n'
+        fi
+      done < <(otool -L "$macho" 2>/dev/null | awk '/@rpath\/.*\.dylib/{print $1}')
+    done < <(find "$APP" -type f \( -name '*.so' -o -name '*.dylib' \) -print0)
+    missing="$(printf '%s' "$missing" | sed '/^$/d' | sort -u)"
+    [[ -z "$missing" ]] && break
+    while IFS= read -r name; do
+      echo "    + $name"
+      cp "$PYLIBDIR/$name" "$RES_LIB/$name"
+    done <<< "$missing"
   done
 fi
 
@@ -43,9 +85,9 @@ if [[ -n "${IDENTITY:-}" ]]; then
   # interpreter needs (JIT, unsigned executable memory, library validation off).
   find "$APP" \( -name "*.so" -o -name "*.dylib" \) -print0 \
     | xargs -0 -P 6 -I{} codesign --force --timestamp --options runtime --sign "$IDENTITY" "{}"
-  if [[ -e "$APP/Contents/Frameworks/Python.framework/Versions/3.11/Python" ]]; then
+  if [[ -e "$APP/Contents/Frameworks/Python.framework/Versions/$PYVER/Python" ]]; then
     codesign --force --timestamp --options runtime --sign "$IDENTITY" \
-      "$APP/Contents/Frameworks/Python.framework/Versions/3.11/Python"
+      "$APP/Contents/Frameworks/Python.framework/Versions/$PYVER/Python"
   fi
   for exe in "$APP/Contents/MacOS/"*; do
     codesign --force --timestamp --options runtime --entitlements "$ENTITLEMENTS" \

--- a/scripts/setup_macos.py
+++ b/scripts/setup_macos.py
@@ -11,6 +11,21 @@ Produces dist/Quill.app.
 import sys
 from pathlib import Path
 
+# py2app bundles whatever interpreter runs this build, so the build Python *is*
+# the app's Python. QUILL's source uses PEP 695 generics (e.g. ``def name[T]``
+# in quill/core/storage.py and versioned_store.py) that only parse on 3.12+, and
+# pyproject requires >=3.12. Building on 3.11 produced a bundle that raised a
+# SyntaxError on the first QUILL import and hung on py2app's error screen (#755).
+# Abort loudly here so a too-old interpreter can never ship that bundle again.
+if sys.version_info < (3, 12):
+    raise SystemExit(
+        "QUILL's macOS app must be built with Python 3.12 or newer "
+        f"(py2app bundles the interpreter it runs under; this is "
+        f"{sys.version_info.major}.{sys.version_info.minor}). QUILL's source uses "
+        "PEP 695 generics a 3.11 bundle cannot parse, so the app would crash on "
+        "launch (#755). Re-run with Python 3.12+."
+    )
+
 # This build script lives in scripts/ (build tooling, deliberately outside the
 # bundled `quill` package), yet it imports the first-party `quill` package and
 # points py2app at the in-package macOS entry point. Running it as

--- a/scripts/setup_macos.py
+++ b/scripts/setup_macos.py
@@ -17,7 +17,9 @@ from pathlib import Path
 # pyproject requires >=3.12. Building on 3.11 produced a bundle that raised a
 # SyntaxError on the first QUILL import and hung on py2app's error screen (#755).
 # Abort loudly here so a too-old interpreter can never ship that bundle again.
-if sys.version_info < (3, 12):
+# noqa rationale: UP036 assumes the running Python is >= the project's 3.12
+# target, but this guards the *build* interpreter, which can be an older 3.11.
+if sys.version_info < (3, 12):  # noqa: UP036
     raise SystemExit(
         "QUILL's macOS app must be built with Python 3.12 or newer "
         f"(py2app bundles the interpreter it runs under; this is "

--- a/tests/unit/platform/macos/test_macos_app.py
+++ b/tests/unit/platform/macos/test_macos_app.py
@@ -1,12 +1,40 @@
 from __future__ import annotations
 
-from quill.__main__ import main as _canonical_main
+import quill.__main__ as qmain
 from quill.platform.macos import macos_app
 
 
-def test_macos_app_reexports_canonical_main() -> None:
+def test_macos_app_entry_delegates_to_canonical_main(monkeypatch) -> None:
     # scripts/setup_macos.py points the py2app bundle's APP at this module, so
-    # the .app entry point must dispatch to the single canonical CLI entry
-    # point — the same `main` behind the `quill` console script — keeping the
-    # bundle and the command line on identical startup behaviour.
-    assert macos_app.main is _canonical_main
+    # the .app entry point must dispatch to the single canonical CLI entry point
+    # — the same `main` behind the `quill` console script — keeping the bundle
+    # and the command line on identical startup behaviour. The entry is now a
+    # thin wrapper (_main) that defers the import of `main` so a failure anywhere
+    # in QUILL's startup is captured rather than dropped on py2app's screen (#755).
+    calls: list[bool] = []
+
+    def fake_main() -> int:
+        calls.append(True)
+        return 0
+
+    monkeypatch.setattr(qmain, "main", fake_main)
+    assert macos_app._main() == 0
+    assert calls == [True]
+
+
+def test_macos_app_entry_logs_and_survives_startup_failure(monkeypatch, tmp_path) -> None:
+    # A failure in QUILL's own startup writes the real traceback to the user Logs
+    # dir and returns non-zero, instead of raising into py2app's opaque error
+    # screen (#755). The native alert is stubbed so the test pops no UI.
+    def boom() -> int:
+        raise RuntimeError("kaboom-startup")
+
+    monkeypatch.setattr(qmain, "main", boom)
+    monkeypatch.setattr(macos_app, "_show_native_error", lambda *_a, **_k: None)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))  # Path.home() on Windows CI
+
+    assert macos_app._main() == 1
+    log = tmp_path / "Library" / "Logs" / "Quill" / "startup-error.log"
+    assert log.is_file()
+    assert "kaboom-startup" in log.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Fix the macOS `.app` launch failure (app opens, never shows a window, space bar opens the py2app debugging page). Fixes #755.

## Root cause (two independent build-pipeline defects)

Diagnosed by @herwigfelix on #755, verified by building the `.app` and running the compiled binary. Both defects fire **before any QUILL code runs**, which is why no in-app handler could catch them:

- **A — too-old bundled Python.** `pyproject` requires `>=3.12` and the source uses PEP 695 generics (`def retry_on_transient_lock[T]` in `quill/core/storage.py`, `load_with_migration[T]` in `versioned_store.py`) — a hard `SyntaxError` on 3.11. But `scripts/build_macos.sh` was pinned to 3.11 (`python311.zip`, `Versions/3.11`), so a 3.11 interpreter bundled an `.app` that crashed on the first QUILL import. (I confirmed both the PEP 695 usage and the 3.11 hard-coding in the tree.)
- **B — missing `@rpath` dylibs.** CPython C-extensions link their libs as `@rpath/lib*.dylib` (`_ctypes`→libffi, `_ssl`→libssl/libcrypto, `_hashlib`, `_sqlite3`, `_lzma`, `_bz2`, expat, tcl/tk, z). With a non-framework Python those live in `<prefix>/lib` and macholib doesn't follow the `@rpath` ref to copy them, so the bundle dlopen-fails inside py2app's own `_setup_ctypes()` bootstrap.

## Changes (build/entry layer only — no app-logic change)

1. `scripts/setup_macos.py` — abort the build on Python < 3.12 (py2app bundles the interpreter it runs under), with a clear message. A 3.11 bundle can't be produced again.
2. `scripts/build_macos.sh` —
   - derive the bundled Python version dynamically (`PYVER`/`PYTAG`) instead of hard-coding `3.11`/`311` (the stale paths also silently skipped the native-lib lift and the framework codesign on any non-3.11 build);
   - after build / before codesign, walk every bundled Mach-O and copy each missing `@rpath/<name>.dylib` from the build interpreter's `LIBDIR` into `Resources/lib`, looping to a fixpoint so transitive deps (libssl→libcrypto) and the newly copied dylibs are rescanned. No-op on a framework Python.
3. `quill/platform/macos/macos_app.py` — wrap the entry so a failure in QUILL's own startup (after py2app's bootstrap) writes the traceback to `~/Library/Logs/Quill/startup-error.log` and shows a native alert, instead of the opaque py2app screen.

## Verification

- This machine is Windows, so I could not run the macOS build. I verified: `py_compile` of both `.py` files, `bash -n scripts/build_macos.sh` (syntax OK), the `<3.12` guard logic, and the two root-cause facts in the tree (PEP 695 generics + 3.11 hard-coding).
- @herwigfelix reports the equivalent fix verified end-to-end on a clean Python 3.12.13 env: full `scripts/build_macos.sh` exits 0 and produces `Quill.dmg`, the dylib step bundles all 10 missing libraries, and the compiled binary's `Quill --version` (0.8.1) and `Quill --dump-stacks` (imports the whole wx UI) both exit 0 with the hang gone.
- **Please run one macOS build from this branch to confirm before merge** — the shell `@rpath` logic in particular benefits from a real build check on the target platform.

## Notes

The `@rpath` dylib-bundling makes Homebrew/conda Python builds work too; the supported/recommended path remains a python.org framework build (where step 2's copy loop is a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
