### PR TITLE
chore(about): credit herwigfelix for the macOS launch fix (#755)

### DIFF
--- a/quill/core/about_info.py
+++ b/quill/core/about_info.py
@@ -69,6 +69,10 @@ _DEFAULT_GITHUB_LINKS: tuple[tuple[str, str], ...] = (
         "wx-accessible-webview on GitHub",
         "https://github.com/Community-Access/wx-accessible-webview",
     ),
+    (
+        "herwigfelix: macOS app launch fix (#755)",
+        "https://github.com/herwigfelix",
+    ),
 )
 
 _OVERVIEW_PARAGRAPHS: tuple[str, ...] = (


### PR DESCRIPTION
Adds a GitHub profile link for @herwigfelix to the About dialog's **Links** tab (the "Project on GitHub" group), thanking them for diagnosing and verifying the macOS py2app launch fix (#755).

Placed in the curated `_DEFAULT_GITHUB_LINKS` in `quill/core/about_info.py` rather than the auto-regenerated `CONTRIBUTORS` list (which only tracks commit authors), so the credit persists across contributor-list refreshes.

Tests: ruff clean; `tests/unit/core/test_about_info.py` 18 passed; verified the link surfaces in `gather_about_info().github_links`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)