### PR TITLE
Story Studio core: project model, binder, compile (wx-free, TDD)

### DIFF
--- a/quill/core/story/__init__.py
+++ b/quill/core/story/__init__.py
@@ -1,0 +1,37 @@
+"""Story Studio — wx-free domain logic for organizing long-form projects.
+
+A *story project* is an ordinary folder of plain-text files plus an advisory
+``project.quillstory.json`` sidecar. This package owns the model, front-matter
+codec, heading-derived manuscript structure, sidecar persistence, binder-tree
+assembly, and manuscript compilation. It imports no ``wx`` and is strict-typed;
+all file IO is injected as callables so the core stays pure and testable.
+
+Convenience re-exports below; submodules may also be imported directly. See
+``docs/planning/quill-story-studio-manuscript-organization-plan.md``.
+"""
+
+from __future__ import annotations
+
+from quill.core.story.binder import BinderNode, build_binder
+from quill.core.story.compile import compile_manuscript
+from quill.core.story.frontmatter import join_front_matter, split_front_matter
+from quill.core.story.manuscript import Heading, iter_headings
+from quill.core.story.model import ElementKind, StoryElement, StoryProject, new_element
+from quill.core.story.storage import PROJECT_FILENAME, load_project, save_project
+
+__all__ = [
+    "PROJECT_FILENAME",
+    "BinderNode",
+    "ElementKind",
+    "Heading",
+    "StoryElement",
+    "StoryProject",
+    "build_binder",
+    "compile_manuscript",
+    "iter_headings",
+    "join_front_matter",
+    "load_project",
+    "new_element",
+    "save_project",
+    "split_front_matter",
+]

--- a/quill/core/story/__init__.py
+++ b/quill/core/story/__init__.py
@@ -6,8 +6,8 @@ codec, heading-derived manuscript structure, sidecar persistence, binder-tree
 assembly, and manuscript compilation. It imports no ``wx`` and is strict-typed;
 all file IO is injected as callables so the core stays pure and testable.
 
-Convenience re-exports below; submodules may also be imported directly. See
-``docs/planning/quill-story-studio-manuscript-organization-plan.md``.
+Convenience re-exports below; submodules may also be imported directly. The
+canonical specification is PRD section 5.89c (Story Studio).
 """
 
 from __future__ import annotations

--- a/quill/core/story/binder.py
+++ b/quill/core/story/binder.py
@@ -1,0 +1,124 @@
+"""Binder-tree assembly (wx-free).
+
+The binder is the navigable home of a project: a tree of groups, manuscript
+files, heading-derived chapters/scenes, and element references. It is *derived*
+from the project plus file contents, never stored, so it can never drift from
+the prose. File contents are supplied by an injected ``read_text`` callable
+(keyed by relative path), keeping this module pure and trivially testable.
+
+A UI renders :class:`BinderNode` into a ``wx.TreeCtrl`` (or any tree control);
+the node types tell it what each row is and how to open it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from quill.core.story.manuscript import Heading, iter_headings
+from quill.core.story.model import ElementKind, StoryProject
+
+__all__ = ["BinderNode", "build_binder"]
+
+#: Element kinds in reading order, with the group label each appears under.
+_GROUP_ORDER: tuple[tuple[ElementKind, str], ...] = (
+    (ElementKind.CHARACTER, "Characters"),
+    (ElementKind.LOCATION, "Places"),
+    (ElementKind.PLOT, "Plot threads"),
+    (ElementKind.RESEARCH, "Research"),
+    (ElementKind.BRAINSTORM, "Brainstorm"),
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BinderNode:
+    """One row in the binder tree.
+
+    ``node_type`` is one of ``root``, ``group``, ``manuscript``, ``heading``,
+    or ``element``. ``path`` is the relative file a node opens (manuscript,
+    heading, element); ``offset``/``level`` describe a heading; ``element_id``
+    links an element node back to its :class:`StoryElement`.
+    """
+
+    label: str
+    node_type: str
+    path: str | None = None
+    offset: int | None = None
+    level: int | None = None
+    element_id: str | None = None
+    children: tuple[BinderNode, ...] = ()
+
+
+def build_binder(project: StoryProject, read_text: Callable[[str], str]) -> BinderNode:
+    """Assemble the binder tree for ``project``, reading files via ``read_text``."""
+    children: list[BinderNode] = [_manuscript_group(project, read_text)]
+    for kind, label in _GROUP_ORDER:
+        members = [element for element in project.elements if element.kind is kind]
+        if not members:
+            continue
+        children.append(
+            BinderNode(
+                label=label,
+                node_type="group",
+                children=tuple(
+                    BinderNode(
+                        label=element.title,
+                        node_type="element",
+                        path=element.path,
+                        element_id=element.id,
+                    )
+                    for element in members
+                ),
+            )
+        )
+    return BinderNode(label=project.title, node_type="root", children=tuple(children))
+
+
+def _manuscript_group(project: StoryProject, read_text: Callable[[str], str]) -> BinderNode:
+    files = tuple(
+        BinderNode(
+            label=path,
+            node_type="manuscript",
+            path=path,
+            children=_nest_headings(path, iter_headings(read_text(path))),
+        )
+        for path in project.manuscript
+    )
+    return BinderNode(label="Manuscript", node_type="group", children=files)
+
+
+def _nest_headings(path: str, headings: list[Heading]) -> tuple[BinderNode, ...]:
+    """Nest a flat heading list into a tree by level (Part > Chapter > Scene)."""
+    roots: list[_MutableNode] = []
+    stack: list[_MutableNode] = []
+    for heading in headings:
+        node = _MutableNode(heading=heading)
+        while stack and stack[-1].heading.level >= heading.level:
+            stack.pop()
+        if stack:
+            stack[-1].children.append(node)
+        else:
+            roots.append(node)
+        stack.append(node)
+    return tuple(_freeze(node, path) for node in roots)
+
+
+class _MutableNode:
+    """Scratch node used only while nesting headings."""
+
+    __slots__ = ("heading", "children")
+
+    def __init__(self, heading: Heading) -> None:
+        self.heading = heading
+        self.children: list[_MutableNode] = []
+
+
+def _freeze(node: _MutableNode, path: str) -> BinderNode:
+    return BinderNode(
+        label=node.heading.title,
+        node_type="heading",
+        path=path,
+        offset=node.heading.offset,
+        level=node.heading.level,
+        children=tuple(_freeze(child, path) for child in node.children),
+    )

--- a/quill/core/story/compile.py
+++ b/quill/core/story/compile.py
@@ -1,0 +1,27 @@
+"""Compile a project's manuscript into one document (wx-free).
+
+Walks the manuscript spine in order, strips each file's front matter, and joins
+the bodies with a separator. The result is plain text suitable for QUILL's
+existing export pipeline (``quill/io/export.py``) — Story Studio adds no new
+export engine, it only decides *what* prose goes in and in *what* order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from quill.core.story.frontmatter import split_front_matter
+from quill.core.story.model import StoryProject
+
+__all__ = ["compile_manuscript"]
+
+
+def compile_manuscript(
+    project: StoryProject,
+    read_text: Callable[[str], str],
+    *,
+    separator: str = "\n\n",
+) -> str:
+    """Return the manuscript files joined in order, front matter removed."""
+    bodies = [split_front_matter(read_text(path))[1] for path in project.manuscript]
+    return separator.join(bodies)

--- a/quill/core/story/frontmatter.py
+++ b/quill/core/story/frontmatter.py
@@ -1,0 +1,101 @@
+"""Front-matter codec for story element files (wx-free, dependency-free).
+
+An element file may carry an optional leading block, fenced by ``---`` lines,
+holding light structured fields (a character's goal, a plot thread's status,
+tags). The body below is ordinary prose. The codec round-trips both:
+``join_front_matter(*split_front_matter(text))`` reproduces the text.
+
+This is a deliberately small subset of YAML — ``key: value`` scalars and simple
+``- item`` lists — so Story Studio adds no third-party dependency for a format
+it fully controls. The block stays human-readable and hand-editable; values are
+read as plain strings (no type coercion), and a key whose value is an indented
+or dashed list becomes a list of strings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+__all__ = ["split_front_matter", "join_front_matter"]
+
+_FENCE = "---"
+
+
+def split_front_matter(text: str) -> tuple[dict[str, Any], str]:
+    """Return ``(fields, body)`` for ``text``.
+
+    When ``text`` opens with a ``---`` fenced block, its ``key: value`` / list
+    entries are returned as ``fields`` and everything after the closing fence as
+    ``body``. Otherwise ``fields`` is empty and ``body`` is ``text`` unchanged.
+    A block with no closing fence is treated as "no front matter" so a stray
+    ``---`` never swallows the prose.
+    """
+    if not text.startswith(_FENCE + "\n"):
+        return {}, text
+    lines = text.split("\n")
+    for index in range(1, len(lines)):
+        if lines[index].strip() == _FENCE:
+            fields = _parse_block(lines[1:index])
+            body = "\n".join(lines[index + 1 :])
+            return fields, body
+    return {}, text
+
+
+def join_front_matter(fields: Mapping[str, Any], body: str) -> str:
+    """Serialize ``fields`` as a leading ``---`` block prepended to ``body``.
+
+    Returns ``body`` unchanged when ``fields`` is empty. Insertion order is
+    preserved (no sorting) so a file the user arranged stays arranged.
+    """
+    if not fields:
+        return body
+    out: list[str] = [_FENCE]
+    for key, value in fields.items():
+        if isinstance(value, (list, tuple)):
+            out.append(f"{key}:")
+            out.extend(f"- {_emit_scalar(str(item))}" for item in value)
+        else:
+            out.append(f"{key}: {_emit_scalar(str(value))}")
+    out.append(_FENCE)
+    return "\n".join(out) + "\n" + body
+
+
+def _parse_block(block_lines: list[str]) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    current_list_key: str | None = None
+    for raw in block_lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        if stripped == "-" or stripped.startswith("- "):
+            item = stripped[1:].strip()
+            if current_list_key is not None and isinstance(fields.get(current_list_key), list):
+                fields[current_list_key].append(_read_scalar(item))
+            continue
+        key, sep, value = raw.partition(":")
+        if not sep:
+            continue  # not a key line; ignore rather than corrupt the rest
+        key = key.strip()
+        value = value.strip()
+        if value == "":
+            fields[key] = []
+            current_list_key = key
+        else:
+            fields[key] = _read_scalar(value)
+            current_list_key = None
+    return fields
+
+
+def _read_scalar(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def _emit_scalar(value: str) -> str:
+    # Quote only when a bare value would not round-trip: empty, surrounding
+    # whitespace, or a leading character a reader could mistake for structure.
+    if value == "" or value != value.strip() or value[:1] in ("-", "'", '"', "#"):
+        return '"' + value.replace('"', '\\"') + '"'
+    return value

--- a/quill/core/story/manuscript.py
+++ b/quill/core/story/manuscript.py
@@ -1,0 +1,39 @@
+"""Heading-derived manuscript structure (wx-free).
+
+A manuscript file uses ordinary Markdown ATX headings (``#`` .. ``######``) for
+its parts, chapters, and scenes. The binder reflects that structure rather than
+storing a parallel copy, so the two never drift: edit a heading and the binder
+follows. ``iter_headings`` returns each heading's level, title, and character
+offset (so a UI can open the file at that point).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = ["Heading", "iter_headings"]
+
+# ATX heading: up to three leading spaces, 1-6 hashes, at least one space, then
+# a non-space. Mirrors quill.core.navigation._heading_starts so manuscript
+# structure matches the editor's heading navigation.
+_HEADING_RE = re.compile(r"^[ \t]{0,3}(#{1,6})[ \t]+(\S.*?)[ \t]*#*[ \t]*$", re.MULTILINE)
+
+
+@dataclass(frozen=True, slots=True)
+class Heading:
+    """One manuscript heading: its depth, text, and character offset."""
+
+    level: int
+    title: str
+    offset: int
+
+
+def iter_headings(text: str) -> list[Heading]:
+    """Return every Markdown ATX heading in ``text``, in document order."""
+    headings: list[Heading] = []
+    for match in _HEADING_RE.finditer(text):
+        headings.append(
+            Heading(level=len(match.group(1)), title=match.group(2).strip(), offset=match.start())
+        )
+    return headings

--- a/quill/core/story/model.py
+++ b/quill/core/story/model.py
@@ -1,0 +1,140 @@
+"""Story Studio data model (wx-free, strict-typed).
+
+The persisted shape of a project is a small, forgiving document: a title, an
+ordered list of manuscript file paths (chapters are derived from their
+headings, not stored), and a list of non-manuscript *elements* (characters,
+places, plot threads, research, brainstorming). Loading is corrupt-tolerant in
+the spirit of :mod:`quill.core.settings_migration`: a bad entry is dropped and
+the rest is kept, so a hand-edited or partially-written sidecar never discards
+good data. Paths are relative POSIX strings, so a project folder stays portable.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+__all__ = ["ElementKind", "StoryElement", "StoryProject", "new_element"]
+
+
+class ElementKind(StrEnum):
+    """The non-manuscript element types a project can hold."""
+
+    CHARACTER = "character"
+    LOCATION = "location"
+    PLOT = "plot"
+    RESEARCH = "research"
+    BRAINSTORM = "brainstorm"
+
+    @classmethod
+    def coerce(cls, value: object) -> ElementKind:
+        """Return the matching kind, or RESEARCH for anything unrecognized."""
+        if isinstance(value, ElementKind):
+            return value
+        try:
+            return cls(str(value))
+        except ValueError:
+            return cls.RESEARCH
+
+
+@dataclass(frozen=True, slots=True)
+class StoryElement:
+    """One non-manuscript element backed by a plain-text file."""
+
+    id: str
+    kind: ElementKind
+    title: str
+    path: str
+    tags: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "title": self.title,
+            "path": self.path,
+            "tags": list(self.tags),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> StoryElement | None:
+        """Build an element, or return None when required fields are missing.
+
+        ``id``, ``title``, and ``path`` are required (a binder node is useless
+        without them). ``kind`` falls back to RESEARCH; ``tags`` defaults empty.
+        """
+        if not isinstance(data, dict):
+            return None
+        element_id = data.get("id")
+        title = data.get("title")
+        path = data.get("path")
+        if not (isinstance(element_id, str) and element_id):
+            return None
+        if not (isinstance(title, str) and title):
+            return None
+        if not (isinstance(path, str) and path):
+            return None
+        raw_tags = data.get("tags", [])
+        tags = (
+            tuple(str(tag) for tag in raw_tags if isinstance(tag, str))
+            if isinstance(raw_tags, list)
+            else ()
+        )
+        return cls(
+            id=element_id,
+            kind=ElementKind.coerce(data.get("kind")),
+            title=title,
+            path=path,
+            tags=tags,
+        )
+
+
+def new_element(
+    kind: ElementKind, title: str, path: str, tags: tuple[str, ...] = ()
+) -> StoryElement:
+    """Create an element with a freshly minted unique id."""
+    return StoryElement(id=uuid.uuid4().hex, kind=kind, title=title, path=path, tags=tags)
+
+
+@dataclass(frozen=True, slots=True)
+class StoryProject:
+    """A whole project: title, manuscript spine, and non-manuscript elements."""
+
+    #: Bump when the on-disk document shape changes incompatibly.
+    SCHEMA_VERSION = 1
+
+    title: str = "Untitled Project"
+    manuscript: tuple[str, ...] = ()
+    elements: tuple[StoryElement, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "title": self.title,
+            "manuscript": list(self.manuscript),
+            "elements": [element.to_dict() for element in self.elements],
+        }
+
+    @classmethod
+    def from_dict(cls, data: Any) -> StoryProject:
+        """Build a project from any mapping, dropping individually-invalid parts."""
+        if not isinstance(data, dict):
+            return cls()
+        raw_title = data.get("title")
+        title = raw_title if isinstance(raw_title, str) and raw_title else "Untitled Project"
+        raw_manuscript = data.get("manuscript", [])
+        manuscript = (
+            tuple(item for item in raw_manuscript if isinstance(item, str) and item)
+            if isinstance(raw_manuscript, list)
+            else ()
+        )
+        raw_elements = data.get("elements", [])
+        elements: list[StoryElement] = []
+        if isinstance(raw_elements, list):
+            for entry in raw_elements:
+                element = StoryElement.from_dict(entry)
+                if element is not None:
+                    elements.append(element)
+        return cls(title=title, manuscript=manuscript, elements=tuple(elements))

--- a/quill/core/story/storage.py
+++ b/quill/core/story/storage.py
@@ -1,0 +1,56 @@
+"""Sidecar persistence for a story project (wx-free).
+
+The project lives in ``project.quillstory.json`` beside the writer's files,
+written atomically (temp + ``os.replace``) through :mod:`quill.core.storage`.
+The sidecar is *advisory*: when it is absent, the folder is still a project —
+:func:`load_project` synthesizes one by listing the plain-text files as the
+manuscript spine, so deleting the sidecar never loses any writing. A corrupt
+sidecar falls back to an empty project rather than raising.
+
+Only relative POSIX paths are stored, so a project folder is portable across
+machines and sync services.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from quill.core.storage import read_json, write_json_atomic
+from quill.core.story.model import StoryProject
+
+__all__ = ["PROJECT_FILENAME", "load_project", "save_project"]
+
+PROJECT_FILENAME = "project.quillstory.json"
+
+#: File suffixes treated as manuscript text when synthesizing a project from a
+#: bare folder (no sidecar).
+_TEXT_SUFFIXES = (".md", ".markdown", ".txt")
+
+
+def load_project(folder: Path) -> StoryProject:
+    """Load the project in ``folder``.
+
+    Reads ``project.quillstory.json`` when present (corrupt files fall back to an
+    empty project). When absent, synthesizes a project from the folder's
+    plain-text files, sorted by name, as the manuscript spine.
+    """
+    sidecar = folder / PROJECT_FILENAME
+    if sidecar.exists():
+        return StoryProject.from_dict(read_json(sidecar, {}))
+    return _project_from_folder_scan(folder)
+
+
+def save_project(folder: Path, project: StoryProject) -> None:
+    """Write the project's sidecar into ``folder`` atomically."""
+    write_json_atomic(folder / PROJECT_FILENAME, project.to_dict())
+
+
+def _project_from_folder_scan(folder: Path) -> StoryProject:
+    names = sorted(
+        entry.name
+        for entry in folder.iterdir()
+        if entry.is_file()
+        and entry.name != PROJECT_FILENAME
+        and entry.suffix.lower() in _TEXT_SUFFIXES
+    )
+    return StoryProject(title=folder.name, manuscript=tuple(names))

--- a/quill/tools/persistence_audit.py
+++ b/quill/tools/persistence_audit.py
@@ -119,6 +119,7 @@ _REVIEWED_PERSISTENCE: dict[str, str] = {
     "core/inline_notes.py::save": "content",
     "core/macros.py::save": "content",
     "core/notebook_store.py::save_notebook": "content",
+    "core/story/storage.py::save_project": "content",
     "core/prompt_library.py::_save": "content",
     "core/skill_store.py::_save_state": "content",
     "core/sessions.py::save_session": "content",

--- a/tests/unit/core/story/test_binder.py
+++ b/tests/unit/core/story/test_binder.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from quill.core.story.binder import build_binder
+from quill.core.story.model import ElementKind, StoryProject, new_element
+
+
+def _reader(files: dict[str, str]):
+    return lambda path: files.get(path, "")
+
+
+def test_empty_project_has_only_an_empty_manuscript_group() -> None:
+    root = build_binder(StoryProject(title="My Book"), _reader({}))
+    assert root.label == "My Book"
+    assert root.node_type == "root"
+    assert [c.label for c in root.children] == ["Manuscript"]
+    assert root.children[0].children == ()
+
+
+def test_manuscript_headings_nest_by_level() -> None:
+    text = "# Part One\n\n## Chapter 1\n\n### Scene A\n\n## Chapter 2\n"
+    root = build_binder(
+        StoryProject(title="B", manuscript=("manuscript.md",)),
+        _reader({"manuscript.md": text}),
+    )
+    manuscript_group = root.children[0]
+    file_node = manuscript_group.children[0]
+    assert file_node.node_type == "manuscript"
+    assert file_node.path == "manuscript.md"
+    part = file_node.children[0]
+    assert part.label == "Part One"
+    assert [c.label for c in part.children] == ["Chapter 1", "Chapter 2"]
+    assert part.children[0].children[0].label == "Scene A"
+
+
+def test_heading_nodes_carry_level_and_offset() -> None:
+    text = "## Chapter 1\n"
+    root = build_binder(
+        StoryProject(title="B", manuscript=("m.md",)), _reader({"m.md": text})
+    )
+    heading = root.children[0].children[0].children[0]
+    assert heading.node_type == "heading"
+    assert heading.level == 2
+    assert heading.offset == 0
+    assert heading.path == "m.md"
+
+
+def test_elements_group_under_labelled_groups_in_order() -> None:
+    project = StoryProject(
+        title="B",
+        elements=(
+            new_element(ElementKind.PLOT, "The Betrayal", "plots/b.md"),
+            new_element(ElementKind.CHARACTER, "Elena", "characters/e.md"),
+            new_element(ElementKind.LOCATION, "Harbor", "places/h.md"),
+        ),
+    )
+    root = build_binder(project, _reader({}))
+    # Manuscript first, then element groups in a fixed reading order; empty
+    # groups (Research, Brainstorm) are omitted.
+    assert [c.label for c in root.children] == [
+        "Manuscript",
+        "Characters",
+        "Places",
+        "Plot threads",
+    ]
+    characters = next(c for c in root.children if c.label == "Characters")
+    elena = characters.children[0]
+    assert elena.node_type == "element"
+    assert elena.label == "Elena"
+    assert elena.path == "characters/e.md"
+    assert elena.element_id
+
+
+def test_a_manuscript_file_with_no_headings_is_a_leaf() -> None:
+    root = build_binder(
+        StoryProject(title="B", manuscript=("flat.md",)),
+        _reader({"flat.md": "Just prose, no headings.\n"}),
+    )
+    file_node = root.children[0].children[0]
+    assert file_node.path == "flat.md"
+    assert file_node.children == ()

--- a/tests/unit/core/story/test_binder.py
+++ b/tests/unit/core/story/test_binder.py
@@ -34,9 +34,7 @@ def test_manuscript_headings_nest_by_level() -> None:
 
 def test_heading_nodes_carry_level_and_offset() -> None:
     text = "## Chapter 1\n"
-    root = build_binder(
-        StoryProject(title="B", manuscript=("m.md",)), _reader({"m.md": text})
-    )
+    root = build_binder(StoryProject(title="B", manuscript=("m.md",)), _reader({"m.md": text}))
     heading = root.children[0].children[0].children[0]
     assert heading.node_type == "heading"
     assert heading.level == 2

--- a/tests/unit/core/story/test_compile.py
+++ b/tests/unit/core/story/test_compile.py
@@ -30,7 +30,5 @@ def test_empty_manuscript_compiles_to_empty_string() -> None:
 
 def test_custom_separator_is_used() -> None:
     project = StoryProject(title="B", manuscript=("a.md", "b.md"))
-    out = compile_manuscript(
-        project, _reader({"a.md": "A", "b.md": "B"}), separator="\n\n---\n\n"
-    )
+    out = compile_manuscript(project, _reader({"a.md": "A", "b.md": "B"}), separator="\n\n---\n\n")
     assert out == "A\n\n---\n\nB"

--- a/tests/unit/core/story/test_compile.py
+++ b/tests/unit/core/story/test_compile.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from quill.core.story.compile import compile_manuscript
+from quill.core.story.model import StoryProject
+
+
+def _reader(files: dict[str, str]):
+    return lambda path: files.get(path, "")
+
+
+def test_concatenates_manuscript_files_in_order() -> None:
+    project = StoryProject(title="B", manuscript=("one.md", "two.md"))
+    out = compile_manuscript(
+        project, _reader({"one.md": "# One\n\nAlpha.", "two.md": "# Two\n\nBeta."})
+    )
+    assert out == "# One\n\nAlpha.\n\n# Two\n\nBeta."
+
+
+def test_strips_front_matter_from_each_file() -> None:
+    project = StoryProject(title="B", manuscript=("ch.md",))
+    out = compile_manuscript(
+        project, _reader({"ch.md": "---\ntype: scene\n---\n# Chapter\n\nProse."})
+    )
+    assert out == "# Chapter\n\nProse."
+
+
+def test_empty_manuscript_compiles_to_empty_string() -> None:
+    assert compile_manuscript(StoryProject(title="B"), _reader({})) == ""
+
+
+def test_custom_separator_is_used() -> None:
+    project = StoryProject(title="B", manuscript=("a.md", "b.md"))
+    out = compile_manuscript(
+        project, _reader({"a.md": "A", "b.md": "B"}), separator="\n\n---\n\n"
+    )
+    assert out == "A\n\n---\n\nB"

--- a/tests/unit/core/story/test_frontmatter.py
+++ b/tests/unit/core/story/test_frontmatter.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from quill.core.story.frontmatter import join_front_matter, split_front_matter
+
+
+def test_split_returns_empty_fields_when_absent() -> None:
+    fields, body = split_front_matter("Just prose, no front matter.\n")
+    assert fields == {}
+    assert body == "Just prose, no front matter.\n"
+
+
+def test_split_parses_leading_yaml_block() -> None:
+    text = "---\ntype: character\nrole: protagonist\n---\nElena is brave.\n"
+    fields, body = split_front_matter(text)
+    assert fields == {"type": "character", "role": "protagonist"}
+    assert body == "Elena is brave.\n"
+
+
+def test_split_preserves_unknown_keys_and_lists() -> None:
+    text = "---\ntype: character\ntags:\n  - pov\n  - act-one\nmood: wistful\n---\nBody\n"
+    fields, _body = split_front_matter(text)
+    assert fields["tags"] == ["pov", "act-one"]
+    assert fields["mood"] == "wistful"
+
+
+def test_join_empty_fields_leaves_body_unchanged() -> None:
+    assert join_front_matter({}, "Body text\n") == "Body text\n"
+
+
+def test_join_emits_fenced_yaml_then_body() -> None:
+    out = join_front_matter({"type": "character", "role": "protagonist"}, "Elena is brave.\n")
+    assert out.startswith("---\n")
+    assert "type: character" in out
+    assert out.endswith("Elena is brave.\n")
+
+
+def test_round_trip_preserves_fields_and_body() -> None:
+    text = "---\ntype: plot\nstatus: unresolved\ntags:\n- a\n- b\n---\nThe betrayal unfolds.\n"
+    fields, body = split_front_matter(text)
+    again_fields, again_body = split_front_matter(join_front_matter(fields, body))
+    assert again_fields == fields
+    assert again_body == body
+
+
+def test_field_order_is_preserved_on_serialize() -> None:
+    out = join_front_matter({"z": "1", "a": "2", "m": "3"}, "body\n")
+    assert out.index("z:") < out.index("a:") < out.index("m:")

--- a/tests/unit/core/story/test_manuscript.py
+++ b/tests/unit/core/story/test_manuscript.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from quill.core.story.manuscript import Heading, iter_headings
+
+
+def test_no_headings_returns_empty() -> None:
+    assert iter_headings("Just a paragraph.\nAnd another.\n") == []
+
+
+def test_levels_titles_and_offsets() -> None:
+    text = "# Part One\n\nIntro.\n\n## Chapter 1\n\nText.\n### Scene A\n"
+    headings = iter_headings(text)
+    assert headings == [
+        Heading(level=1, title="Part One", offset=0),
+        Heading(level=2, title="Chapter 1", offset=text.index("## Chapter 1")),
+        Heading(level=3, title="Scene A", offset=text.index("### Scene A")),
+    ]
+
+
+def test_trailing_hashes_and_extra_spaces_are_trimmed() -> None:
+    headings = iter_headings("##   Chapter Two   ##\n")
+    assert headings == [Heading(level=2, title="Chapter Two", offset=0)]
+
+
+def test_hash_without_space_is_not_a_heading() -> None:
+    # "#notatag" is not an ATX heading (needs a space); "#" channels in prose
+    # must not be mistaken for structure.
+    assert iter_headings("#nothashtag\nplain # in the middle\n") == []
+
+
+def test_indented_up_to_three_spaces_still_counts() -> None:
+    headings = iter_headings("   ## Indented\n")
+    assert headings == [Heading(level=2, title="Indented", offset=0)]

--- a/tests/unit/core/story/test_model.py
+++ b/tests/unit/core/story/test_model.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from quill.core.story.model import ElementKind, StoryElement, StoryProject, new_element
+
+
+def test_new_element_mints_a_nonempty_id() -> None:
+    a = new_element(ElementKind.CHARACTER, "Elena", "characters/elena.md")
+    b = new_element(ElementKind.CHARACTER, "Elena", "characters/elena.md")
+    assert a.id and b.id and a.id != b.id
+    assert a.kind is ElementKind.CHARACTER
+    assert a.title == "Elena"
+    assert a.path == "characters/elena.md"
+    assert a.tags == ()
+
+
+def test_element_round_trips_through_dict() -> None:
+    element = StoryElement(
+        id="x1", kind=ElementKind.PLOT, title="The Betrayal", path="plots/betrayal.md",
+        tags=("act-one", "pov"),
+    )
+    assert StoryElement.from_dict(element.to_dict()) == element
+
+
+def test_element_from_dict_defaults_missing_tags_and_unknown_kind() -> None:
+    element = StoryElement.from_dict({"id": "y", "title": "Mystery", "path": "a.md"})
+    assert element.tags == ()
+    # An unrecognized/absent kind falls back to RESEARCH rather than raising.
+    assert element.kind is ElementKind.RESEARCH
+
+
+def test_project_round_trips_through_dict() -> None:
+    project = StoryProject(
+        title="The Novel",
+        manuscript=("manuscript.md", "epilogue.md"),
+        elements=(
+            new_element(ElementKind.CHARACTER, "Elena", "characters/elena.md"),
+            new_element(ElementKind.LOCATION, "Old Harbor", "places/harbor.md"),
+        ),
+    )
+    restored = StoryProject.from_dict(project.to_dict())
+    assert restored == project
+
+
+def test_project_to_dict_stamps_schema_version() -> None:
+    data = StoryProject(title="T").to_dict()
+    assert data["schema_version"] == StoryProject.SCHEMA_VERSION
+    assert data["title"] == "T"
+
+
+def test_project_from_dict_tolerates_garbage_and_keeps_good_elements() -> None:
+    data = {
+        "title": "T",
+        "manuscript": ["a.md", 5, "b.md"],          # non-str dropped
+        "elements": [
+            {"id": "ok", "kind": "character", "title": "Good", "path": "g.md"},
+            "not-a-dict",                              # dropped
+            {"kind": "location"},                      # missing id/title/path -> dropped
+        ],
+    }
+    project = StoryProject.from_dict(data)
+    assert project.manuscript == ("a.md", "b.md")
+    assert [e.id for e in project.elements] == ["ok"]
+
+
+def test_project_from_dict_empty_is_all_defaults() -> None:
+    project = StoryProject.from_dict({})
+    assert project.title == "Untitled Project"
+    assert project.manuscript == ()
+    assert project.elements == ()

--- a/tests/unit/core/story/test_model.py
+++ b/tests/unit/core/story/test_model.py
@@ -15,7 +15,10 @@ def test_new_element_mints_a_nonempty_id() -> None:
 
 def test_element_round_trips_through_dict() -> None:
     element = StoryElement(
-        id="x1", kind=ElementKind.PLOT, title="The Betrayal", path="plots/betrayal.md",
+        id="x1",
+        kind=ElementKind.PLOT,
+        title="The Betrayal",
+        path="plots/betrayal.md",
         tags=("act-one", "pov"),
     )
     assert StoryElement.from_dict(element.to_dict()) == element
@@ -50,11 +53,11 @@ def test_project_to_dict_stamps_schema_version() -> None:
 def test_project_from_dict_tolerates_garbage_and_keeps_good_elements() -> None:
     data = {
         "title": "T",
-        "manuscript": ["a.md", 5, "b.md"],          # non-str dropped
+        "manuscript": ["a.md", 5, "b.md"],  # non-str dropped
         "elements": [
             {"id": "ok", "kind": "character", "title": "Good", "path": "g.md"},
-            "not-a-dict",                              # dropped
-            {"kind": "location"},                      # missing id/title/path -> dropped
+            "not-a-dict",  # dropped
+            {"kind": "location"},  # missing id/title/path -> dropped
         ],
     }
     project = StoryProject.from_dict(data)

--- a/tests/unit/core/story/test_storage.py
+++ b/tests/unit/core/story/test_storage.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from quill.core.story.model import ElementKind, StoryProject, new_element
+from quill.core.story.storage import PROJECT_FILENAME, load_project, save_project
+
+
+def test_save_then_load_round_trips(tmp_path: Path) -> None:
+    project = StoryProject(
+        title="The Novel",
+        manuscript=("manuscript.md",),
+        elements=(new_element(ElementKind.CHARACTER, "Elena", "characters/elena.md"),),
+    )
+    save_project(tmp_path, project)
+    assert (tmp_path / PROJECT_FILENAME).is_file()
+    assert load_project(tmp_path) == project
+
+
+def test_load_without_sidecar_scans_folder_for_manuscript(tmp_path: Path) -> None:
+    (tmp_path / "02-two.md").write_text("# Two\n", encoding="utf-8")
+    (tmp_path / "01-one.md").write_text("# One\n", encoding="utf-8")
+    (tmp_path / "notes.txt").write_text("notes\n", encoding="utf-8")
+    (tmp_path / "cover.png").write_bytes(b"\x89PNG")
+    project = load_project(tmp_path)
+    # Sorted by name, text files only, the PNG ignored.
+    assert project.manuscript == ("01-one.md", "02-two.md", "notes.txt")
+    assert project.title == tmp_path.name
+    assert project.elements == ()
+
+
+def test_load_ignores_the_sidecar_file_itself_when_scanning(tmp_path: Path) -> None:
+    # An empty/garbage sidecar still takes the "parse" path, not the scan path.
+    (tmp_path / "chapter.md").write_text("# Ch\n", encoding="utf-8")
+    save_project(tmp_path, StoryProject(title="Saved", manuscript=("chapter.md",)))
+    assert PROJECT_FILENAME not in load_project(tmp_path).manuscript
+
+
+def test_load_corrupt_sidecar_falls_back_to_defaults(tmp_path: Path) -> None:
+    (tmp_path / PROJECT_FILENAME).write_text("{not valid json", encoding="utf-8")
+    project = load_project(tmp_path)
+    assert isinstance(project, StoryProject)
+    assert project.manuscript == ()
+
+
+def test_saved_paths_are_relative_posix(tmp_path: Path) -> None:
+    save_project(tmp_path, StoryProject(title="T", manuscript=("sub/ch1.md",)))
+    raw = (tmp_path / PROJECT_FILENAME).read_text(encoding="utf-8")
+    assert "sub/ch1.md" in raw
+    assert str(tmp_path) not in raw  # no absolute path leaks into the sidecar

--- a/tests/unit/ui/test_main_frame_menu_contract.py
+++ b/tests/unit/ui/test_main_frame_menu_contract.py
@@ -210,9 +210,7 @@ def test_publishing_menu_is_split_into_read_and_locked_send_halves() -> None:
     # mirroring the core.glow pattern (ids stay unconditional; only .Append()
     # is gated).
     source = _menu_source()
-    assert (
-        'publishing_read_enabled = self._feature_enabled("future.publishing_read")' in source
-    )
+    assert 'publishing_read_enabled = self._feature_enabled("future.publishing_read")' in source
     assert 'publishing_send_enabled = self._feature_enabled("future.publishing")' in source
     assert (
         "if publishing_read_enabled or publishing_send_enabled:\n"


### PR DESCRIPTION
## What

The foundation for **Story Studio** (planning spec in #781): a screen-reader-first way to organize a book-length project — manuscript, characters, places, plot threads, brainstorming. This PR is the pure, strict-typed, fully-tested **core** (no `wx`); the UI binder/forms are the follow-up.

## New package: `quill/core/story/`

| Module | Responsibility |
| --- | --- |
| `model.py` | `StoryProject` / `StoryElement` / `ElementKind`; corrupt-tolerant `from_dict`/`to_dict` (drops bad entries, keeps the rest), relative POSIX paths only |
| `frontmatter.py` | Dependency-free codec for the optional leading `---` block (`key: value` scalars + simple `- item` lists); round-trips, preserves field order |
| `manuscript.py` | `iter_headings` — derive chapters/scenes from Markdown ATX headings (level, title, offset) so the binder never drifts from the prose |
| `storage.py` | Load/save `project.quillstory.json` atomically; **no sidecar = still a project** (scan text files), so deleting it never loses writing; corrupt → defaults |
| `binder.py` | `build_binder` — the navigable tree (Manuscript group with heading nesting by level; element groups Characters/Places/Plot threads/Research/Brainstorm). IO injected as a `read_text` callable, so the tree is pure |
| `compile.py` | `compile_manuscript` — concatenate the spine in order, front matter stripped, for the existing export pipeline (no new export engine) |

## Design notes

- **wx-free and strict-typed**, in keeping with the `quill/core` boundary; all file IO is injected, so every unit is testable without disk or a UI.
- **Dependency-light:** PyYAML is not a declared QUILL dependency, so the front-matter codec is hand-rolled for the small subset the format needs, rather than adding a mandatory core dep.
- **Plain-text-first:** the project is a folder of readable files plus an advisory sidecar of relative paths; nothing locks the manuscript in.

## Tests & gates

- 33 unit tests across the six modules, written test-first (red→green per module).
- `ruff check`, `ruff format --check`, scoped `mypy quill/core/story`, banned-pattern gate, and GATE-11 module-size budget all green.

## Not in this PR (next steps)

- The `wx` binder (`TreeCtrl`), element details form, menu/command wiring, and compile-to-export hookup.
- A user-facing CHANGELOG entry lands with the UI, when the feature becomes reachable.

Depends conceptually on the plan in #781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)