### PR TITLE
chore(build): exclude _tool-download/__pycache__ scratch from portable ZIP and installer

### DIFF
--- a/installer/quill.iss
+++ b/installer/quill.iss
@@ -119,7 +119,7 @@ Type: filesandordirs; Name: "{app}\python"
 ; needed now that migration protects the data.
 
 [Files]
-Source: "..\portable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "docs\QUILL-PRD.md,tools\pandoc\*,tools\speech\dectalk\*,tools\speech\espeak-ng\*,tools\speech\piper\*,tools\speech\whispercpp\*,tools\nodejs\*,vendor\braille-pack\*,kokoro-models\*,_tool-download\*,_speech-download\*"
+Source: "..\portable\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: "docs\QUILL-PRD.md,tools\pandoc\*,tools\speech\dectalk\*,tools\speech\espeak-ng\*,tools\speech\piper\*,tools\speech\whispercpp\*,tools\nodejs\*,vendor\braille-pack\*,kokoro-models\*,_tool-download\*,_speech-download\*,*\__pycache__\*"
 ; QUILL Braille Pack: liblouis runtime, translation tables, and BRF profiles.
 ; Installed to vendor\braille-pack so QUILL detects it automatically via QUILL_APP_ROOT.
 Source: "..\portable\vendor\braille-pack\*"; DestDir: "{app}\vendor\braille-pack"; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist; Components: braillepack

--- a/scripts/build_portable_zip.py
+++ b/scripts/build_portable_zip.py
@@ -19,6 +19,16 @@ import sys
 import zipfile
 from pathlib import Path
 
+# Build-only scratch that must never ship in the portable ZIP: the staging area
+# where downloaded tool archives are unpacked before being copied into tools/
+# (a duplicate ~376 MB), and Python bytecode caches. Matched against any path
+# component so nested caches are excluded too.
+_EXCLUDED_DIRS = frozenset({"_tool-download", "__pycache__"})
+
+
+def _is_scratch(path: Path, root: Path) -> bool:
+    return any(part in _EXCLUDED_DIRS for part in path.relative_to(root).parts)
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
@@ -42,13 +52,19 @@ def main() -> int:
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     file_count = 0
+    skipped = 0
     with zipfile.ZipFile(args.output, "w", compression=zipfile.ZIP_DEFLATED, compresslevel=6) as zf:
         for path in sorted(args.source_dir.rglob("*")):
-            if path.is_file():
-                arcname = path.relative_to(args.source_dir.parent)
-                zf.write(path, arcname)
-                file_count += 1
-    print(f"Wrote {args.output} ({file_count} files)")
+            if not path.is_file():
+                continue
+            if _is_scratch(path, args.source_dir):
+                skipped += 1
+                continue
+            arcname = path.relative_to(args.source_dir.parent)
+            zf.write(path, arcname)
+            file_count += 1
+    note = f" (skipped {skipped} build-scratch files)" if skipped else ""
+    print(f"Wrote {args.output} ({file_count} files){note}")
     return 0
 
 

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -840,7 +840,7 @@ def build_inno_setup_script(
         "[Files]",
         'Source: "..\\portable\\*"; DestDir: "{app}";'
         " Flags: ignoreversion recursesubdirs createallsubdirs;"
-        ' Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*"',
+        ' Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*,*\\__pycache__\\*"',
         "; QUILL Braille Pack: liblouis runtime, translation tables, and BRF profiles.",
         "; Installed to vendor\\braille-pack so QUILL detects it automatically via QUILL_APP_ROOT.",
         'Source: "..\\portable\\vendor\\braille-pack\\*"; DestDir: "{app}\\vendor\\braille-pack";'

--- a/tests/unit/scripts/test_build_portable_zip.py
+++ b/tests/unit/scripts/test_build_portable_zip.py
@@ -1,0 +1,49 @@
+"""Tests for the portable-distribution ZIP builder (scratch exclusion)."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import Path
+
+from scripts.build_portable_zip import main
+
+
+def _build(tmp_path: Path) -> list[str]:
+    src = tmp_path / "portable"
+    # Shipped payload.
+    (src / "python").mkdir(parents=True)
+    (src / "python" / "python.exe").write_bytes(b"exe")
+    (src / "tools" / "pandoc").mkdir(parents=True)
+    (src / "tools" / "pandoc" / "pandoc.exe").write_bytes(b"pandoc")
+    (src / "run-quill.cmd").write_text("run")
+    # Build-only scratch that must be excluded.
+    (src / "_tool-download" / "piper" / "stage").mkdir(parents=True)
+    (src / "_tool-download" / "piper" / "stage" / "piper.exe").write_bytes(b"dup")
+    (src / "quill" / "__pycache__").mkdir(parents=True)
+    (src / "quill" / "__pycache__" / "x.pyc").write_bytes(b"cache")
+
+    out = tmp_path / "Quill-Portable.zip"
+    argv = sys.argv
+    sys.argv = ["build_portable_zip.py", "--source-dir", str(src), "--output", str(out)]
+    try:
+        assert main() == 0
+    finally:
+        sys.argv = argv
+    with zipfile.ZipFile(out) as zf:
+        return zf.namelist()
+
+
+def test_scratch_is_excluded_from_the_zip(tmp_path: Path) -> None:
+    names = _build(tmp_path)
+    joined = "\n".join(names)
+    assert "_tool-download" not in joined  # the ~376 MB staging duplicate
+    assert "__pycache__" not in joined  # Python bytecode caches
+
+
+def test_shipped_payload_is_present(tmp_path: Path) -> None:
+    names = _build(tmp_path)
+    joined = "\n".join(names).replace("\\", "/")
+    assert any(n.endswith("python/python.exe") for n in [x.replace("\\", "/") for x in names])
+    assert "portable/run-quill.cmd" in joined
+    assert any("tools/pandoc/pandoc.exe" in n.replace("\\", "/") for n in names)

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -180,7 +180,7 @@ def test_build_inno_setup_script_mentions_portable_bundle() -> None:
     assert 'DestDir: "{app}\\kokoro-models"' not in script
     assert "speechopenvoice" not in script
     assert (
-        'Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*"'
+        'Excludes: "docs\\QUILL-PRD.md,tools\\pandoc\\*,tools\\speech\\dectalk\\*,tools\\speech\\espeak-ng\\*,tools\\speech\\piper\\*,tools\\speech\\whispercpp\\*,tools\\nodejs\\*,vendor\\braille-pack\\*,kokoro-models\\*,_tool-download\\*,_speech-download\\*,*\\__pycache__\\*"'
         in script
     )
     assert 'Source: "..\\portable\\tools\\pandoc\\*"; DestDir: "{app}\\tools\\pandoc";' in script


### PR DESCRIPTION
Follow-up from the real-hardware build pass: the portable ZIP carried ~376 MB of `_tool-download` build scratch (duplicate downloaded pandoc/piper archives) plus `__pycache__` bytecode.

- **`build_portable_zip.py`** now skips `_tool-download` and `__pycache__` when zipping the portable bundle (they exist only as staging/duplicate copies; the real tools ship under `tools/`).
- **`build_windows_distribution.py`** — the generated `.iss` already excluded `_tool-download\*`/`_speech-download\*` from the generic `..\portable\*` copy; this adds `*\__pycache__\*` too. The committed `installer/quill.iss` is regenerated to match (one-line diff).

Tests: new `test_build_portable_zip.py` (scratch excluded, shipped payload kept); the iss-sync test's pinned Excludes string updated. Both green.

Note: the installer itself was already lean — it never bundled `_tool-download` — so this is purely a portable-ZIP cleanup plus a `__pycache__` tidy on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)