### PR TITLE
fix(qa): retry the dialog accelerator in the UIA helper (CI foreground race)

### DIFF
--- a/tests/uia/test_dialog_accessibility.py
+++ b/tests/uia/test_dialog_accessibility.py
@@ -9,14 +9,22 @@ from tests.uia.a11y_scan import scan_window, summarize, unnamed_focusable
 pytestmark = pytest.mark.uia
 
 
-def _open_dialog_via_keys(quill_app, keys: str, title_fragment: str, timeout: float = 15.0):
-    quill_app.main_window.set_focus()
-    quill_app.main_window.type_keys(keys)
-    dialog = quill_app.main_window.child_window(
-        title_re=f".*{title_fragment}.*", control_type="Window"
-    )
-    dialog.wait("exists visible", timeout=timeout)
-    return dialog
+def _open_dialog_via_keys(quill_app, keys: str, title_fragment: str, attempts: int = 3):
+    # A freshly-launched window can lose the first accelerator to a foreground
+    # race (seen on CI runners), so the keystroke is retried, never assumed.
+    last_error: Exception | None = None
+    for _ in range(attempts):
+        quill_app.main_window.set_focus()
+        quill_app.main_window.type_keys(keys)
+        dialog = quill_app.main_window.child_window(
+            title_re=f".*{title_fragment}.*", control_type="Window"
+        )
+        try:
+            dialog.wait("exists visible", timeout=6)
+            return dialog
+        except Exception as exc:  # noqa: BLE001 - retry the keystroke
+            last_error = exc
+    raise AssertionError(f"dialog {title_fragment!r} never opened via {keys!r}: {last_error}")
 
 
 def test_go_to_line_dialog_is_fully_named(quill_app) -> None:


### PR DESCRIPTION
First cloud run of the UIA suite: 5 of 6 green on windows-latest (launch, title, menus, typing, spoken-output assertion, and the dialog accessibility scan all passed). The one failure was the Escape test losing its Ctrl+G to a foreground race on a freshly launched window; the helper now retries the keystroke instead of assuming the first landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)