### PR TITLE
feat(site): "Beginners start here" section directly after the hero

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -67,6 +67,45 @@
     </div>
 
 
+    <!-- Beginners start here: kept immediately after the hero so a screen
+         reader reading in document order (or jumping by heading) meets the
+         learning material before any feature marketing. Requested by a
+         community member: beginners need the podcast and the guide first,
+         not agents and snippets. -->
+    <section class="band" aria-labelledby="beginners-h">
+      <div class="wrap">
+        <h2 id="beginners-h">Beginners start here</h2>
+        <p class="intro">
+          New to QUILL? You do not need to read this whole page. These three things
+          will teach you the program, in whichever way you like to learn.
+        </p>
+        <div class="cards">
+          <div class="card">
+            <h3><a href="/podcast/index.html">Learn by listening: The QUILL Cast</a></h3>
+            <p>A free 36-episode audio course that teaches all of QUILL by ear, from
+            the installer to every feature - about fifteen minutes per part, with
+            hands-on homework at the end of each episode. Play episodes right on the
+            page, read the full transcripts, or <a href="/podcast/feed.xml">subscribe
+            by RSS</a> in any podcast app.</p>
+            <span class="more"><a href="/podcast/index.html">Start episode one <span aria-hidden="true">&rarr;</span></a></span>
+          </div>
+          <div class="card">
+            <h3><a href="/tutorials/index.html">Learn by doing: hands-on tutorials</a></h3>
+            <p>Six complete walkthroughs, ten to twenty minutes each, starting with
+            "your first hour in QUILL" - install, write, save, and hear what QUILL
+            tells you along the way.</p>
+            <span class="more"><a href="/tutorials/index.html">Start the first tutorial <span aria-hidden="true">&rarr;</span></a></span>
+          </div>
+          <div class="card">
+            <h3><a href="/docs/userguide.html">Learn by reading: the user guide</a></h3>
+            <p>The complete reference: writing, navigation, every command and setting,
+            and all of QUILL's accessibility features explained in plain language.</p>
+            <span class="more"><a href="/docs/userguide.html">Open the user guide <span aria-hidden="true">&rarr;</span></a></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- Screen-reader-first design -->
     <section class="band" aria-labelledby="sr-h">
       <div class="wrap">


### PR DESCRIPTION
Community request (Debee, BITS list #844): screen-reader users reading the front page in document order hit agents/snippets marketing before any learning material.

A new **Beginners start here** section now sits immediately after the hero — the second h2 on the page, so both linear reading and heading-jump navigation meet it early. Three cards in learning-style order: **The QUILL Cast** (learn by listening, episode-one link), **hands-on tutorials** (learn by doing), and **the user guide** (learn by reading). The existing Start Here section lower down keeps its download and reference cards unchanged. Merging deploys via the Pages workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)