### PR TITLE
ci(macos): pass QUILL_FEEDBACK_GITHUB_TOKEN into the build step

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -99,6 +99,7 @@ jobs:
         env:
           IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
           NOTARY_PROFILE: ${{ env.NOTARY_PROFILE }}
+          QUILL_FEEDBACK_GITHUB_TOKEN: ${{ secrets.QUILL_FEEDBACK_GITHUB_TOKEN }}
         run: |
           chmod +x scripts/build_macos.sh
           ./scripts/build_macos.sh


### PR DESCRIPTION
Wires the \`macos-release\` environment secret (already set) through to \`build_macos.sh\`, which already generates \`quill/_feedback_token.py\` from it -- one-line change so the macOS rebuild bakes in the bundled bug-report token same as the Windows build already does.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>