### PR TITLE
fix(build): exclude local dev-tool caches from the shipped quill/ source copy

### DIFF
--- a/installer/README-installer.txt
+++ b/installer/README-installer.txt
@@ -1,4 +1,4 @@
-QUILL for All 0.9.0 Beta 1 — Windows Installer
+QUILL for All 0.9.0 Beta 2 — Windows Installer
 Publisher: Community Access
 
 Thank you for installing Quill.

--- a/scripts/build_windows_distribution.py
+++ b/scripts/build_windows_distribution.py
@@ -46,6 +46,13 @@ from quill.branding import APP_DISPLAY_NAME, APP_ORGANIZATION  # noqa: E402
 # (DECtalk, Piper, eSpeak-NG) ship ARM64 Windows binaries.  Revisit when any
 # of them do: Python (embed-arm64.zip), Pandoc, and Node all have arm64 assets.
 
+# A contributor's local dev-tool caches (mypy/pytest/ruff, stray bytecode)
+# must never leak into a shipped build -- they're sizable, irrelevant to end
+# users, and only present because *this* machine happened to run those tools.
+_DEV_CACHE_IGNORE = shutil.ignore_patterns(
+    "__pycache__", ".mypy_cache", ".pytest_cache", ".ruff_cache"
+)
+
 # Pinned Windows embeddable Python. Bumping these values is the only
 # thing needed to ship on a new Python point release.
 EMBEDDED_PYTHON_VERSION = "3.13.14"
@@ -1226,7 +1233,9 @@ def bundle_embedded_python(
     if not quill_source.is_dir():
         raise RuntimeError(f"Could not find quill/ package source under {source_root.resolve()}.")
     print(f"Copying Quill package source from {quill_source} into runtime...")
-    shutil.copytree(quill_source, site_packages / "quill", dirs_exist_ok=True)
+    shutil.copytree(
+        quill_source, site_packages / "quill", dirs_exist_ok=True, ignore=_DEV_CACHE_IGNORE
+    )
 
     # Stage the changelog inside the package so the running build can show
     # abbreviated "What's New" / Check-for-Updates release notes offline

--- a/tests/unit/scripts/test_build_windows_distribution.py
+++ b/tests/unit/scripts/test_build_windows_distribution.py
@@ -815,3 +815,36 @@ def test_kokoro_is_not_bundled_and_installs_on_demand() -> None:
     # The engines users actually need offline stay bundled.
     assert "speech" in DEFAULT_BUNDLED_DEPENDENCY_GROUPS
     assert "ui" in DEFAULT_BUNDLED_DEPENDENCY_GROUPS
+
+
+def test_dev_cache_ignore_excludes_local_tool_caches_but_keeps_real_source(
+    tmp_path: Path,
+) -> None:
+    """A contributor's local mypy/pytest/ruff caches (or stray __pycache__)
+    must never leak into a shipped build via the quill/ source copy -- they're
+    only present because tools happened to run on this machine, and a mypy
+    cache alone can be tens of MB of pure bloat for an end user."""
+    from scripts.build_windows_distribution import _DEV_CACHE_IGNORE
+
+    source = tmp_path / "quill"
+    (source / "core").mkdir(parents=True)
+    (source / "core" / "settings.py").write_text("x = 1\n", encoding="utf-8")
+    (source / "__pycache__").mkdir()
+    (source / "__pycache__" / "settings.cpython-313.pyc").write_bytes(b"\x00")
+    (source / "io" / ".mypy_cache" / "3.13").mkdir(parents=True)
+    (source / "io" / ".mypy_cache" / "3.13" / "settings.data.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    (source / ".pytest_cache").mkdir()
+    (source / ".ruff_cache").mkdir()
+
+    dest = tmp_path / "copied"
+    import shutil
+
+    shutil.copytree(source, dest, ignore=_DEV_CACHE_IGNORE)
+
+    assert (dest / "core" / "settings.py").exists()
+    assert not (dest / "__pycache__").exists()
+    assert not (dest / "io" / ".mypy_cache").exists()
+    assert not (dest / ".pytest_cache").exists()
+    assert not (dest / ".ruff_cache").exists()


### PR DESCRIPTION
## Summary
- Fixes a real packaging bug found while building the Beta 2 Windows distribution: `quill/io/.mypy_cache` (23 MB, left over from a scoped mypy run) got copied straight into the portable bundle because the `quill/` source `shutil.copytree` had no exclusions.
- Adds `_DEV_CACHE_IGNORE` (`__pycache__`, `.mypy_cache`, `.pytest_cache`, `.ruff_cache`) so any contributor's local tool caches can never leak into a shipped build again.
- Refreshes `installer/README-installer.txt`'s version line to 0.9.0 Beta 2 (it still said Beta 1).

## Test plan
- [x] New test `test_dev_cache_ignore_excludes_local_tool_caches_but_keeps_real_source` (confirmed it fails without the fix)
- [x] Full `tests/unit/scripts/test_build_windows_distribution.py` suite passes (29 tests)
- [x] Module size budget gate passes
- [x] ruff check/format clean