### PR TITLE
Preserve an existing bundled feedback token on a tokenless dev/test build

### DIFF
--- a/tests/unit/tools/test_generate_feedback_token.py
+++ b/tests/unit/tools/test_generate_feedback_token.py
@@ -49,3 +49,28 @@ def test_require_token_succeeds_when_env_var_present(monkeypatch, tmp_path: Path
     monkeypatch.setattr(gen, "OUTPUT_FILE", output)
     assert gen.main(["--require-token"]) == 0
     assert "github_pat_example123" in output.read_text(encoding="utf-8")
+
+
+def test_missing_env_preserves_an_existing_bundled_token(monkeypatch, tmp_path: Path) -> None:
+    # A dev/test rebuild with no env token must NOT wipe a working token that was
+    # set up earlier -- it keeps the bug reporter consistent across rebuilds.
+    import generate_feedback_token as gen
+
+    output = tmp_path / "_feedback_token.py"
+    gen.write_module("github_pat_previously_set", output)
+    monkeypatch.delenv("QUILL_FEEDBACK_GITHUB_TOKEN", raising=False)
+    monkeypatch.setattr(gen, "OUTPUT_FILE", output)
+    assert gen.main([]) == 0
+    assert "github_pat_previously_set" in output.read_text(encoding="utf-8")
+
+
+def test_env_token_overwrites_an_existing_bundled_token(monkeypatch, tmp_path: Path) -> None:
+    import generate_feedback_token as gen
+
+    output = tmp_path / "_feedback_token.py"
+    gen.write_module("github_pat_old", output)
+    monkeypatch.setenv("QUILL_FEEDBACK_GITHUB_TOKEN", "github_pat_new")
+    monkeypatch.setattr(gen, "OUTPUT_FILE", output)
+    assert gen.main([]) == 0
+    text = output.read_text(encoding="utf-8")
+    assert "github_pat_new" in text and "github_pat_old" not in text

--- a/tools/generate_feedback_token.py
+++ b/tools/generate_feedback_token.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -47,6 +48,21 @@ BUNDLED_TOKEN = {token!r}
 """,
         encoding="utf-8",
     )
+
+
+def read_existing_token(output_path: Path) -> str:
+    """Return the non-empty BUNDLED_TOKEN already written to *output_path*, or "".
+
+    Used so a build with no ``QUILL_FEEDBACK_GITHUB_TOKEN`` in its environment
+    does not clobber a working token that was set up earlier -- keeping the bug
+    reporter consistent across repeated dev/test builds (you populate the token
+    once and rebuilds preserve it).
+    """
+    if not output_path.is_file():
+        return ""
+    text = output_path.read_text("utf-8")
+    match = re.search(r"^BUNDLED_TOKEN = (['\"])(.*)\1", text, re.MULTILINE)
+    return match.group(2) if match else ""
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -73,6 +89,15 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+    if not token:
+        # No token in the environment: keep any working token already bundled
+        # rather than wiping it to empty, so a dev/test rebuild stays consistent
+        # (the token is populated once, then preserved). A fresh env token always
+        # wins below.
+        existing = read_existing_token(OUTPUT_FILE)
+        if existing:
+            print(f"{ENV_VAR} not set; preserving the existing bundled token in {OUTPUT_FILE}.")
+            return 0
     write_module(token, OUTPUT_FILE)
     if token:
         print(f"Wrote {OUTPUT_FILE} with a bundled token.")


### PR DESCRIPTION
Follow-up to the Report-a-Bug "No token" P0.

`generate_feedback_token.py` overwrote `quill/_feedback_token.py` on **every** build, so a dev/test rebuild with no `QUILL_FEEDBACK_GITHUB_TOKEN` in its environment wiped any working token that had been set up earlier — silently breaking the bug reporter for that build.

It now **preserves an existing non-empty `BUNDLED_TOKEN`** when the env var is unset (and `--require-token` was not given), so the token is populated once and repeated dev/test builds keep it — consistent bug reporting across testing scenarios. A fresh env-var token still always wins; `--require-token` still hard-fails a release build with no token.

Tests added for both preserve and overwrite paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)