### PR TITLE
Add Finder-launchable run-from-source.command wrapper (macOS)

### DIFF
--- a/run-from-source.command
+++ b/run-from-source.command
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Finder launcher for Quill (macOS).
+#
+# Double-click this file in Finder to run Quill from source. macOS opens it in
+# Terminal, which runs this wrapper. All it does is locate its own directory
+# (the repo root) and hand off to run-from-source.sh, forwarding any arguments.
+#
+# The first time you use it, macOS may block it ("cannot be opened because it is
+# from an unidentified developer"). Right-click the file -> Open -> Open, or run
+# `xattr -d com.apple.quarantine run-from-source.command` once in Terminal.
+#
+# Note: .command files must stay executable (chmod +x) to launch from Finder.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec "$ROOT/run-from-source.sh" "$@"


### PR DESCRIPTION
## Summary

Adds `run-from-source.command`, a thin wrapper so macOS users can launch Quill from source directly from **Finder** (double-click), without opening a terminal.

Double-clicking `run-from-source.sh` in Finder opens it in a text editor rather than running it. macOS *does* run `.command` files in Terminal on double-click, so this wrapper resolves the repo root and forwards all arguments to the existing `run-from-source.sh` — no logic duplicated.

## Details

- New file: `run-from-source.command` (executable, `chmod +x`).
- Body is 2 lines: locate its own directory, then `exec run-from-source.sh "$@"`.
- Header comment documents the first-run Gatekeeper quarantine prompt and the workaround (`xattr -d com.apple.quarantine ...` or right-click → Open).

## Testing

- `run-from-source.command --print-python` correctly delegates to `run-from-source.sh` and prints the resolved interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)