### PR TITLE
fix(ci): mastodon mypy call-overload + stale local-AI-unreachable test

### DIFF
--- a/quill/core/mastodon/client.py
+++ b/quill/core/mastodon/client.py
@@ -310,9 +310,12 @@ def instance_character_limit(instance_url: str) -> int:
         if isinstance(v1, dict):
             raw = v1.get("max_toot_chars")
             if raw is not None:
-                try:
-                    parsed = int(raw)
-                except (TypeError, ValueError):
+                if isinstance(raw, int | float | str):
+                    try:
+                        parsed = int(raw)
+                    except (TypeError, ValueError):
+                        parsed = 0
+                else:
                     parsed = 0
                 if parsed > 0:
                     limit = parsed

--- a/tests/unit/core/test_assistant_ai.py
+++ b/tests/unit/core/test_assistant_ai.py
@@ -389,7 +389,11 @@ def test_list_models_reports_local_server_not_running(
     )
     _models, error = assistant_ai.list_assistant_models(settings, api_key="")
     assert error is not None
-    assert "not running" in error.lower()
+    # The "not_running" message was generalized to cover other local-AI servers
+    # (LM Studio, GPT4All) alongside Ollama, and no longer contains the literal
+    # phrase "not running" -- assert on the actionable, stable substrings instead.
+    assert "can't reach a local ai server" in error.lower()
+    assert "ollama serve" in error.lower()
 
 
 def test_list_models_retries_while_warming_up_then_succeeds(


### PR DESCRIPTION
## Summary
- `instance_character_limit`'s v1 fallback called `int()` on a `dict[str, object]` value; mypy 2.2's stricter overload resolution rejects that without an `isinstance` narrow first. Added the narrow (same runtime behavior — non-numeric values still fall through to `parsed = 0`).
- `test_list_models_reports_local_server_not_running` asserted the literal substring `"not running"`, but the `not_running` message was generalized to also cover LM Studio/GPT4All (not just Ollama) and no longer contains that phrase. Updated the assertion to check the current, correct message text instead.

Both were failing on every PR's required checks (`scoped-strict-typing`, `unit-tests`) independent of what the PR actually changed — confirmed by reproducing both failures on a clean worktree off `origin/main` before making any change.

## Test plan
- [x] `mypy quill/core quill/io` — mastodon/client.py error gone (pre-existing unrelated local-only mypy-version noise in `quill/platform/macos/keychain.py` not present in CI's pinned mypy 2.2.0 run)
- [x] `pytest tests/unit/core/test_assistant_ai.py` — 62 passed
- [x] `pytest tests/unit/core/test_mastodon_client.py` — 29 passed
- [x] `ruff check` on both changed files — clean

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>