### PR TITLE
fix(startup): init radio/podcasts after the frame exists

### DIFF
--- a/quill/ui/main_frame.py
+++ b/quill/ui/main_frame.py
@@ -1263,8 +1263,6 @@ class MainFrame(
         )
         self._snippet_expansion_guard = False
         self._init_abbreviations()
-        self._init_radio()
-        self._init_podcasts()
         self._intellisense_popup: _IntellisensePopup | None = None
         self._intellisense_context: IntellisenseContext | None = None
         self._intellisense_fragment_text = ""
@@ -1300,6 +1298,8 @@ class MainFrame(
         # "Untitled" combined with any transient status-bar text. _refresh_title()
         # sets the real document-name title as soon as the editor is ready.
         self.frame = wx.Frame(None, title="Quill", size=(1000, 700))
+        self._init_radio()
+        self._init_podcasts()
         self._intellisense_popup = _IntellisensePopup(wx, self.frame)
         self._intellisense_popup.set_accept_callback(self._apply_intellisense_selection)
         self._intellisense_popup.set_dismiss_callback(self._dismiss_intellisense_popup)

--- a/quill/ui/main_frame_radio.py
+++ b/quill/ui/main_frame_radio.py
@@ -29,6 +29,9 @@ class RadioMixin:
     # -- setup --------------------------------------------------------------
 
     def _init_radio(self) -> None:
+        # Parents the player controller on self.frame: MainFrame.__init__ must
+        # only call this (and _init_podcasts) after the frame is constructed,
+        # or startup dies with AttributeError('frame').
         self._radio_favorites = radio_favorites.load_favorites(app_data_dir())
         self._radio_ever_played = False
         self._radio_controller = RadioPlayerController(


### PR DESCRIPTION
Fixes #1016.

## Problem

`main` is currently unlaunchable: `MainFrame.__init__` calls `_init_radio()` / `_init_podcasts()` ~35 lines before `self.frame = wx.Frame(None, ...)` is created, and both mixins parent their player controllers on `self.frame`, so every startup dies with `AttributeError('frame')` before a window appears. Reproduced on a clean `main` checkout with `python -m quill` and in the packaged Windows portable build.

## Fix

One commit, two files:

- `quill/ui/main_frame.py` — move the two init calls to immediately after the frame is constructed. Net-zero lines, so the module stays exactly at its GATE-11 budget. Nothing between the old and new positions reads radio/podcast state (verified by grep over the intervening lines).
- `quill/ui/main_frame_radio.py` — document the ordering constraint at `_init_radio` so the next reorganization doesn't reintroduce the crash.

## Verification

- `python -m quill` launches and stays up (was: instant crash).
- `ruff check` and `python -m quill.tools.module_size_budget` pass.
- Also verified in a packaged Windows portable build.

Deliberately contains **only** the startup fix — found while preparing test builds for #1012, but kept clean of that work so it can merge immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)