### PR TITLE
site: launch Quill Radio on quillforall.org

### DIFF
--- a/docs/site/docs.html
+++ b/docs/site/docs.html
@@ -106,6 +106,31 @@
         </div>
       </div>
 
+      <h2 id="radio">Quill Radio</h2>
+      <p>Quill Radio is the next generation of the ACB Radio Tuner: a free, standalone internet radio app for Windows sharing QUILL's own codebase and data store.</p>
+      <div class="cards">
+        <div class="card">
+          <h3><a href="/radio.html">Quill Radio overview</a></h3>
+          <p>Features, the ACB Radio Tuner heritage story, and downloads for the installer and portable flavors.</p>
+        </div>
+        <div class="card">
+          <h3><a href="/docs/radio-userguide.html">User guide</a></h3>
+          <p>Installing, the main window, every menu, the Favorites Manager, the Recordings list, and the full keyboard reference.</p>
+        </div>
+        <div class="card">
+          <h3><a href="/docs/radio-prd.html">Product requirements</a></h3>
+          <p>The design document behind Quill Radio: architecture, feature scope, and accessibility commitments.</p>
+        </div>
+        <div class="card">
+          <h3><a href="/docs/radio-release-notes.html">Release notes</a></h3>
+          <p>Everything that shipped in Quill Radio 1.0, in full detail.</p>
+        </div>
+        <div class="card">
+          <h3><a href="/docs/radio-pr.html">Press release</a></h3>
+          <p>The full 1.0 announcement.</p>
+        </div>
+      </div>
+
       <h2 id="contributing">Contributing &amp; governance</h2>
       <div class="cards">
         <div class="card">

--- a/docs/site/docs/radio-pr.html
+++ b/docs/site/docs/radio-pr.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc 3.10" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Quill Radio 1.0 Press Release</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      white-space: pre-wrap;
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #1a1a1a;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: 1.5em;}
+    div.column{flex: auto;}
+    @media screen {
+    div.columns{gap: min(4vw, 1.5em);}
+    div.column{overflow-x: auto;}
+    }
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Quill Radio 1.0 Press Release</h1>
+</header>
+<h1 id="for-immediate-release">FOR IMMEDIATE RELEASE</h1>
+<h2
+id="quill-radio-10-arrives-the-next-generation-of-the-acb-radio-tuner-built-for-every-screen-reader-every-station-on-earth">Quill
+Radio 1.0 arrives: the next generation of the ACB Radio Tuner, built for
+every screen reader, every station on Earth</h2>
+<p><strong>A free Windows app carries forward a beloved community
+project — and takes it somewhere it could never go before.</strong></p>
+<hr />
+<p>For more than a decade, blind and low-vision listeners who wanted ACB
+Media on their desktop reached for the ACB Radio Tuner — a small,
+devoted tool built by and for the American Council of the Blind's radio
+community. It did one thing, and it did that one thing with care. It
+never chased the wider internet. It never grew a favorites tree, a
+recorder, or a second life beyond its original ten streams. It didn't
+have to. It was enough, for a long time, to just play ACB Media reliably
+and get out of the way.</p>
+<p>Today, Community Access is releasing <strong>Quill Radio 1.0</strong>
+— free, and built from the ground up as the spiritual successor to that
+project. It plays every ACB Media stream out of the box, with zero
+setup. And then it keeps going: tens of thousands of stations from every
+country on the map, a real favorites system with folders as deep as you
+want them, recording that picks itself back up if your internet
+stumbles, a wake-up timer, hardware media key support, and a system tray
+presence that keeps the music playing while you work. It is, quite
+simply, everything the original tuner was — plus everything a modern
+radio app was always missing.</p>
+<p>"When I first heard about the ACB Radio Tuner years ago, it felt like
+someone had finally built something <em>for</em> us instead of merely
+accessible <em>to</em> us," said the President of Blind Information
+Technology Solutions (BITS), an ACB affiliate. "Quill Radio takes that
+same spirit and asks a bigger question: what if the whole world's radio
+worked that way? What if recording a show, organizing your favorite
+stations, and waking up to your favorite program were all just as
+effortless as pressing Enter on a station name? This isn't a replacement
+for what we loved. It's what we always hoped it would grow into."</p>
+<h3 id="from-ten-streams-to-the-whole-dial">From ten streams to the
+whole dial</h3>
+<p>Quill Radio opens with your favorite stations already front and
+center — arrow down, press Enter, and you're listening. No dialogs to
+dismiss, no mouse required, nothing standing between you and the sound.
+The built-in <strong>ACB Media</strong> collection carries all ten of
+ACB's own streams — Mainstream, The Trove, Cafe, Community, Live,
+Special, and the rest — playable the moment you install, exactly as the
+original tuner promised.</p>
+<p>But where the ACB Radio Tuner stopped, Quill Radio was just getting
+started. <strong>Browse Stations</strong> opens a huge, friendly
+directory of live stations from around the world: tens of thousands of
+them, searchable by name, genre, language, or tag, with a quick listen
+before you commit to a favorite. Found a stream on a website that isn't
+in any directory? <strong>Find Streams from a Website</strong> scans the
+page and offers up whatever it finds. Paste a web address directly if
+you already know exactly what you want. However a station reaches you,
+it becomes a favorite with one keystroke.</p>
+<h3 id="a-favorites-system-that-grows-the-way-your-listening-does">A
+favorites system that grows the way your listening does</h3>
+<p>The original tuner had a flat list. Quill Radio has folders — as
+many, and as deep, as you want. Build "News," then "News &gt; Morning"
+and "News &gt; Evening" inside it, creating any of them right where you
+need them, before a single station lives there. Rename any station to
+what <em>you</em> call it — your own name follows it everywhere, from
+the main window to the tray to the Recently Played list. Delete a folder
+and its stations don't vanish with it; they step safely back to the top
+level. Nothing you build is ever one keystroke from destroyed.</p>
+<p>Every favorite remembers its own volume. Stations are mastered wildly
+differently — one whispers, the next one shouts — and Quill Radio only
+makes you fix that once per station, forever.</p>
+<h3 id="recording-that-keeps-up-with-the-real-world">Recording that
+keeps up with the real world</h3>
+<p>Recording in Quill Radio isn't a fragile afterthought. Start a
+capture and, if your connection drops mid-show, Quill Radio first tries
+to quietly ride out the gap; if the drop is real, it waits, reconnects,
+and picks up right where it left off in a new, clearly numbered file —
+with how hard it tries and how long it waits entirely yours to set.
+Record what's already playing, or record a second station while you
+listen to something else entirely. Schedule a show once, daily, or
+weekly, picking straight from your favorites list instead of retyping a
+web address from memory. And the <strong>Recordings</strong> window
+shows the whole story at a glance: recording now with its size growing
+live, recorded and ready, or scheduled and waiting — with Play, Stop,
+Open in Folder, and Remove all one keystroke away.</p>
+<h3 id="an-appliance-when-you-want-it-to-be-one">An appliance, when you
+want it to be one</h3>
+<p>Check <strong>Resume Last Station on Launch</strong> once, and Quill
+Radio becomes exactly what a radio should be: something you turn on.
+<strong>Play Last Station</strong> (Ctrl+L) picks up wherever you left
+off without any navigation at all. The <strong>Wake-Up Timer</strong> is
+the sleep timer's twin — pick a favorite, pick a time, once or every
+day, and the station starts itself. Hardware media keys control playback
+anywhere on your PC, even when the app is tucked away in the tray, with
+its own icon and a live now-playing tooltip.</p>
+<p>And no matter where a stream comes from — a favorite, ACB Media,
+Recently Played, or a fresh search — starting it always silences
+whatever else was playing, radio or podcast, everywhere in the app. You
+never hear two things fighting for your attention.</p>
+<h3 id="built-to-be-heard-not-just-used">Built to be heard, not just
+used</h3>
+<p>Every single thing Quill Radio does, it says out loud, working
+smoothly with JAWS, NVDA, and Windows Narrator without ever stealing
+focus. The <strong>Command Palette</strong> (Ctrl+Shift+P) puts every
+Quill Radio command behind one searchable list. <strong>What's
+Playing</strong> (Ctrl+T) speaks the current track or show title the
+moment you ask.</p>
+<p>Quill Radio shares everything with QUILL and QUILL Cast: favorites,
+history, recordings, schedules, and settings all travel together,
+everywhere. Favorite a station here, and it's already a favorite in
+QUILL. Set a wake-up timer in QUILL, and it fires here. Nothing is ever
+set up twice.</p>
+<h3 id="two-flavors-everything-included">Two flavors, everything
+included</h3>
+<p>Quill Radio comes as a simple installer or a truly portable version
+you can carry on a USB stick, favorites and all. Both come with
+everything already built in for recording — nothing to download
+separately, ever. <strong>Help &gt; Get FFmpeg</strong> stands ready as
+a safety net on the rare chance anything ever goes missing. In-app
+<strong>Check for Updates</strong> knows exactly which version you're
+running and fetches the right one automatically, with friendly spoken
+progress the whole way.</p>
+<h3 id="we-want-to-hear-from-you">We want to hear from you</h3>
+<p>Quill Radio is, and always will be, free. It is also young, and it
+grows from the people who use it. <strong>Help &gt; Report a
+Bug</strong> sends us a note directly from inside the app — no account
+or sign-up required — stamped with Quill Radio's own version number so
+we always know exactly what you were running. Every report shapes what
+ships next; that has been true since the first line of QUILL was
+written, and it's just as true here.</p>
+<h3 id="a-note-on-where-this-came-from">A note on where this came
+from</h3>
+<p>Quill Radio is offered with real gratitude to the American Council of
+the Blind and to everyone who built and maintained the original ACB
+Radio Tuner over the years. That project proved something important:
+that a radio app designed specifically for blind listeners, by people
+who understood exactly what that meant, could be simple, dependable, and
+genuinely loved. Quill Radio doesn't replace that legacy. It's an
+attempt to honor it — by taking the same care and pointing it at the
+whole dial.</p>
+<hr />
+<p><strong>About Quill Radio</strong></p>
+<p>Quill Radio is a free, screen-reader-first internet radio application
+for Windows, built by Community Access and sharing its foundation with
+the QUILL writing environment. It is not yet digitally signed by
+Microsoft, so Windows SmartScreen may show a caution on first run —
+choose "More info," then "Run anyway," and you're on your way.</p>
+<p><strong>Learn more and download:</strong> <a
+href="http://www.quillforall.org/radio.html">http://www.quillforall.org/radio.html</a>
+<strong>Send feedback:</strong> Help &gt; Report a Bug, right inside the
+app</p>
+<p><strong>About Community Access</strong></p>
+<p>Community Access builds free, screen-reader-first software including
+QUILL, Quill Radio, and QUILL Cast — created by and for the community
+that depends on it. Learn more at <a
+href="http://www.quillforall.org">http://www.quillforall.org</a>.</p>
+<p><em>Media contact: <a
+href="http://www.quillforall.org">http://www.quillforall.org</a></em></p>
+</body>
+</html>

--- a/docs/site/docs/radio-prd.html
+++ b/docs/site/docs/radio-prd.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc 3.10" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Quill Radio - prd</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      white-space: pre-wrap;
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #1a1a1a;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: 1.5em;}
+    div.column{flex: auto;}
+    @media screen {
+    div.columns{gap: min(4vw, 1.5em);}
+    div.column{overflow-x: auto;}
+    }
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Quill Radio - prd</h1>
+</header>
+<h1 id="quill-radio----product-requirements">Quill Radio -- Product
+Requirements</h1>
+<p>Version 1.0</p>
+<h2 id="1-product-statement">1. Product statement</h2>
+<p>Quill Radio is QUILL's internet radio, shipped as its own small
+Windows app for people who want the radio on without loading a full
+writing environment. It is screen-reader-first, keyboard-complete, and
+deliberately small -- and by 1.0 it is a complete radio product:
+organization, recording resilience, timers, and appliance-grade
+startup.</p>
+<h2 id="2-architecture-requirement-not-a-fork">2. Architecture
+requirement: not a fork</h2>
+<ul>
+<li>R-1. All feature code lives in the upstream <code>quill</code>
+package (<code>quill.apps.radio</code>, <code>RadioMixin</code>,
+<code>AppShellFrame</code>, <code>quill/core/radio/*</code>,
+<code>quill/ui/radio/*</code>). This repository contains only the
+product wrapper (entry point, icon, installer, docs). Nothing here
+reimplements a feature.</li>
+<li>R-2. The app stays in sync with QUILL by construction: the wrapper
+depends on <code>quill</code> from the upstream repository, and the
+one-file build pulls the entire package. Divergence is only permitted
+for content that exists because QUILL is not in the picture.</li>
+<li>R-3. Data is shared, not copied: favorites (folders, custom names,
+per-station volumes), recently-played history, recordings, schedules,
+the wake-up timer, and settings live in the same
+<code>%APPDATA%\Quill</code> store QUILL uses.</li>
+<li>R-4. Keystrokes are the app's own (menu accelerators), kept separate
+from QUILL's keymap so nothing collides with editor shortcuts.</li>
+</ul>
+<h2 id="3-scope-all-reused-from-upstream-all-shipped-in-10">3. Scope
+(all reused from upstream; all shipped in 1.0)</h2>
+<p><strong>Listening</strong></p>
+<ul>
+<li>Station browser over the RadioBrowser directory (search, tag/country
+filters, test-play, favorite); bundled ACB Media directory; custom
+stream URLs; website stream finder with a Test/Stop Test toggle.</li>
+<li>One transport control (Play becomes Stop), mute, volume with
+per-station memory, single-player rule (starting any stream silences
+sibling media, radio or podcast, in every app).</li>
+<li>Recently Played (capped, de-duplicated), Play Last Station, optional
+resume-on-launch.</li>
+<li>What's Playing: ICY track titles on demand and optional
+announce-on-change (off by default).</li>
+<li>Stream fallback: a directory station whose stream errors is
+re-fetched by uuid and retried once, self-healing the saved
+favorite.</li>
+</ul>
+<p><strong>Organization</strong></p>
+<ul>
+<li>Favorites Manager: nested path-based folders, live rich search, Move
+Up/Down, Mark-and-Move (Move Above/Below adopting the destination
+folder), station rename (custom display names used everywhere), folder
+rename carrying descendants, folder delete that returns stations to the
+top level.</li>
+</ul>
+<p><strong>Recording</strong></p>
+<ul>
+<li>Record now; Record Station (a different station than the one
+playing, for N minutes); scheduled recordings (once/daily/weekly).</li>
+<li>Recordings list: live status (Recording with growing size / Recorded
+/ Scheduled), Play, Stop Recording, Open in Folder, Remove, 2-second
+auto-refresh.</li>
+<li>Auto-reconnect: ffmpeg HTTP reconnect flags plus process-level retry
+into numbered part files; enabled/attempts/spacing configurable; user
+stops and duration-cap finishes never retry.</li>
+<li>Settings: format (mp3/ogg/flac/wav), bitrate, destination, filename
+pattern with tokens, max-duration safety cap.</li>
+</ul>
+<p><strong>Timers</strong></p>
+<ul>
+<li>Sleep timer (shared radio/podcasts fade-and-restore).</li>
+<li>Wake-up timer: once or daily at HH:MM; fires only within a 5-minute
+window (never retro-fires); "once" disables itself; requires the app
+running (tray counts); honest about that in the UI.</li>
+</ul>
+<p><strong>Shell</strong></p>
+<ul>
+<li>System tray with full controls and the app's own icon; Send to Tray
+(Ctrl+W) and Exit; hardware media keys (play/pause, stop) system-wide
+while running, never stolen from an app that already owns them, released
+on exit.</li>
+<li>Command Palette scoped to the app's registry; Redeem Unlock Code
+(shared store); in-app update check that downloads the installer with
+spoken progress and offers Install now; About.</li>
+<li>Unlock-gated Audio Description Project menu when
+<code>future.adp_assistant</code> is unlocked.</li>
+</ul>
+<p>Out of scope by decision: QUILL's editor, AI, speech transcription,
+braille, and TTS stacks (not installed); a custom update engine beyond
+download-and-run.</p>
+<h2 id="4-accessibility-requirements">4. Accessibility requirements</h2>
+<ul>
+<li>A-1. Every interactive element has an accessible name; upstream
+inventory gates audit the shared surfaces.</li>
+<li>A-2. Focus lands on the favorites list at launch; focus dead zones
+are defects.</li>
+<li>A-3. All dialogs route through the shared dialog contract (modal
+ids, focus placement, region announcements) and are registered in the
+dialog inventory.</li>
+<li>A-4. Every action announces its outcome; silent state changes are
+defects. Track-title announcements are opt-in so ambient chatter never
+surprises anyone.</li>
+<li>A-5. Full keyboard operation including manager reordering and the
+tray menu; Delete/F2/Enter conventions consistent across lists.</li>
+</ul>
+<h2 id="5-packaging-requirements">5. Packaging requirements</h2>
+<ul>
+<li>P-1. PyInstaller one-file exe with the app's own icon; Inno Setup
+installer with its own AppId installing to {autopf}\Quill Radio,
+per-user by default.</li>
+<li>P-2. Everything bundled, nothing downloaded at install or runtime:
+the exe carries the whole quill package and data; ffmpeg (essentials
+build) installs to {app}\tools\ffmpeg, found via the wrapper exporting
+QUILL_APP_ROOT.</li>
+<li>P-3. Uninstall never deletes <code>%APPDATA%\Quill</code> -- QUILL
+or QUILL Cast may still use it.</li>
+<li>P-4. Release artifacts:
+<code>Quill-Radio-Setup-&lt;version&gt;.exe</code>, tagged
+<code>v&lt;version&gt;</code>, which Help &gt; Check for Updates
+compares against and downloads.</li>
+</ul>
+<h2 id="6-network-requirements">6. Network requirements</h2>
+<ul>
+<li>N-1. Exactly four outbound surfaces, each inventoried in QUILL's
+network-egress audit: RadioBrowser
+(search/tags/countries/click-votes/byuuid fallback), the user-typed page
+for Find Streams, the playing stream itself for ICY titles, and this
+repository's GitHub releases for the update check. No telemetry of any
+kind.</li>
+<li>N-2. Safe Mode disables the radio's network surfaces along with the
+feature.</li>
+</ul>
+<h2 id="7-non-goals">7. Non-goals</h2>
+<p>macOS/Linux standalone builds (upstream QUILL covers macOS; the tray
+pattern does not exist there), auto-updating in place, telemetry.</p>
+</body>
+</html>

--- a/docs/site/docs/radio-release-notes.html
+++ b/docs/site/docs/radio-release-notes.html
@@ -1,0 +1,275 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc 3.10" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Quill Radio - release-notes-1.0</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      white-space: pre-wrap;
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #1a1a1a;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: 1.5em;}
+    div.column{flex: auto;}
+    @media screen {
+    div.columns{gap: min(4vw, 1.5em);}
+    div.column{overflow-x: auto;}
+    }
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Quill Radio - release-notes-1.0</h1>
+</header>
+<h1 id="quill-radio-10----release-notes">Quill Radio 1.0 -- Release
+Notes</h1>
+<p>The radio, on its own -- and finished. Quill Radio takes the internet
+radio QUILL users already know, gives it a window, a menu bar, a tray
+icon, and its own icon, and then goes further than the embedded radio
+ever has. Everything below also landed in QUILL itself: the two share
+one codebase and one data store, so features arrive everywhere at
+once.</p>
+<h2 id="highlights">Highlights</h2>
+<ul>
+<li><strong>Your folders, on the front page.</strong> The main window is
+your favorites tree -- the same nested folders you build in the manager,
+with a full context menu (Play/Stop, Rename, Move to Folder, Remove, New
+Folder) one Shift+F10 away. Create folders exactly where you want them
+with <strong>New Folder</strong> (Ctrl+Shift+E); they exist immediately,
+stations or not. An <strong>Add to Favorites</strong> button keeps
+whatever is playing, and flips to Remove when it's already saved.</li>
+<li><strong>Favorites first, radio as an appliance.</strong> The app
+opens with your favorites focused; Enter plays. <strong>Play Last
+Station</strong> (Ctrl+L) resumes whatever you had on, and
+<strong>Resume Last Station on Launch</strong> makes launching the app
+all you ever do. A <strong>Recently Played</strong> menu keeps your last
+fifteen stations one keystroke deep.</li>
+<li><strong>A real Favorites Manager.</strong> Folders of any depth
+(News/Morning style), live search across names, countries, tags, and
+folders, Move Up/Down, and Mark-and-Move for long hops. Rename any
+station to what <em>you</em> call it; rename folders with F2; deleting a
+folder walks its stations safely back to the top level -- never out of
+your collection.</li>
+<li><strong>What's Playing.</strong> Ctrl+T speaks the current track or
+show title straight from the stream's metadata; an optional check item
+announces titles as they change.</li>
+<li><strong>Recording, grown up.</strong> Record what you're hearing,
+record a <em>different</em> station while you listen to something else,
+or schedule shows once, daily, or weekly -- picking straight from your
+favorites, no typing. The new <strong>Recordings</strong> list shows
+everything -- recording now (size growing live), recorded, and scheduled
+-- with Play (Stop while it plays), Stop Recording, Open in Folder, and
+Remove. And recordings now <strong>survive dropped connections</strong>:
+ffmpeg rides out short gaps, and a true drop resumes into a numbered
+part file, with attempts and spacing yours to tune.</li>
+<li><strong>Wake up with the radio.</strong> The sleep timer got its
+twin: pick a favorite, a time, once or every day. (The app must be
+running -- the tray counts.)</li>
+<li><strong>Never double-plays.</strong> Starting any stream silences
+whatever else was playing, radio or podcast, in every app.</li>
+<li><strong>Per-station volume memory.</strong> Every favorite remembers
+the volume you gave it.</li>
+<li><strong>Hardware media keys</strong> control the app system-wide,
+even from the tray.</li>
+<li><strong>The Command Palette</strong> (Ctrl+Shift+P), scoped to
+exactly this app's commands.</li>
+<li><strong>One data store.</strong> Favorites (folders, names,
+volumes), history, recordings, timers, settings -- shared with QUILL and
+QUILL Cast. Set it up once, have it everywhere.</li>
+<li><strong>Two flavors, everything bundled.</strong> A system installer
+and a truly portable zip whose <code>data</code> folder keeps your whole
+radio on the stick. ffmpeg included, its own app icon, no downloads ever
+-- and if ffmpeg somehow goes missing, <strong>Help &gt; Get
+FFmpeg...</strong> restores it from the official source. In-app
+<strong>Check for Updates</strong> knows which flavor you run and
+downloads the matching artifact with spoken progress, offering Install
+now.</li>
+<li><strong>Report a Bug, built in.</strong> Files an issue straight
+from the Help menu, no GitHub account needed, stamped with Quill Radio's
+own version.</li>
+<li><strong>Spoken feedback everywhere</strong>, through JAWS, NVDA, or
+Narrator, without stealing focus.</li>
+</ul>
+<h2 id="known-notes-for-this-release">Known notes for this release</h2>
+<ul>
+<li>Releases are not yet code-signed: Windows SmartScreen may warn on
+first run. Choose More info, then Run anyway. Signing is planned.</li>
+</ul>
+<h2 id="what-quill-radio-deliberately-is-not">What Quill Radio
+deliberately is not</h2>
+<p>It is not QUILL minus some menus -- it is the radio, period. The
+editor, AI, transcription, braille, and speech-synthesis stacks are not
+installed at all.</p>
+<h2 id="not-a-fork----a-guarantee">Not a fork -- a guarantee</h2>
+<p>Quill Radio runs the exact same radio feature code as QUILL, from the
+same upstream package. Fixes land once and reach QUILL, Quill Radio, and
+QUILL Cast together. This repository carries only the wrapper, the
+installer, the icon, and these docs.</p>
+<h2 id="dependencies">Dependencies</h2>
+<p>Playback uses Windows' built-in media engine; recording uses the
+bundled ffmpeg; station search uses the community RadioBrowser
+directory; the ACB Media directory is bundled. Every network call the
+app can make is inventoried in QUILL's public network-egress audit.</p>
+<h2 id="requirements">Requirements</h2>
+<p>Windows 10 or 11, x64 (or ARM64 under emulation). No Python
+installation required.</p>
+</body>
+</html>

--- a/docs/site/docs/radio-userguide.html
+++ b/docs/site/docs/radio-userguide.html
@@ -1,0 +1,523 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="utf-8" />
+  <meta name="generator" content="pandoc 3.10" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <title>Quill Radio - userguide</title>
+  <style>
+    /* Default styles provided by pandoc.
+    ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
+    */
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    img {
+      max-width: 100%;
+    }
+    svg {
+      height: auto;
+      max-width: 100%;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    h5, h6 {
+      font-size: 1em;
+      font-style: italic;
+    }
+    h6 {
+      font-weight: normal;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    code {
+      white-space: pre-wrap;
+      font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
+      font-size: 85%;
+      margin: 0;
+      hyphens: manual;
+    }
+    pre {
+      margin: 1em 0;
+      overflow: auto;
+    }
+    pre code {
+      padding: 0;
+      overflow: visible;
+      overflow-wrap: normal;
+    }
+    .sourceCode {
+     background-color: transparent;
+     overflow: visible;
+    }
+    hr {
+      border: none;
+      border-top: 1px solid #1a1a1a;
+      height: 1px;
+      margin: 1em 0;
+    }
+    table {
+      margin: 1em 0;
+      border-collapse: collapse;
+      width: 100%;
+      overflow-x: auto;
+      display: block;
+      font-variant-numeric: lining-nums tabular-nums;
+    }
+    table caption {
+      margin-bottom: 0.75em;
+    }
+    tbody {
+      margin-top: 0.5em;
+      border-top: 1px solid #1a1a1a;
+      border-bottom: 1px solid #1a1a1a;
+    }
+    th {
+      border-top: 1px solid #1a1a1a;
+      padding: 0.25em 0.5em 0.25em 0.5em;
+    }
+    td {
+      padding: 0.125em 0.5em 0.25em 0.5em;
+    }
+    header {
+      margin-bottom: 4em;
+      text-align: center;
+    }
+    #TOC li {
+      list-style: none;
+    }
+    #TOC ul {
+      padding-left: 1.3em;
+    }
+    #TOC > ul {
+      padding-left: 0;
+    }
+    #TOC a:not(:hover) {
+      text-decoration: none;
+    }
+    span.smallcaps{font-variant: small-caps;}
+    div.columns{display: flex; gap: 1.5em;}
+    div.column{flex: auto;}
+    @media screen {
+    div.columns{gap: min(4vw, 1.5em);}
+    div.column{overflow-x: auto;}
+    }
+    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+    /* The extra [class] is a hack that increases specificity enough to
+       override a similar rule in reveal.js */
+    ul.task-list[class]{list-style: none;}
+    ul.task-list li input[type="checkbox"] {
+      font-size: inherit;
+      width: 0.8em;
+      margin: 0 0.8em 0.2em -1.6em;
+      vertical-align: middle;
+    }
+    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  </style>
+</head>
+<body>
+<header id="title-block-header">
+<h1 class="title">Quill Radio - userguide</h1>
+</header>
+<h1 id="quill-radio-user-guide">Quill Radio User Guide</h1>
+<p>Version 1.0</p>
+<p>Quill Radio is internet radio the way a screen reader user would
+design it: a small window whose favorites tree has focus the instant it
+opens, menus that say everything they do, spoken feedback for every
+action, and a tray icon so the music keeps playing while you work. It
+runs the exact same radio code as QUILL itself and shares its data, so
+nothing you set up here is ever stranded.</p>
+<h2 id="installing">Installing</h2>
+<p>Two flavors, both fully bundled (ffmpeg included, nothing ever
+downloads):</p>
+<ul>
+<li><strong>The installer</strong>
+(<code>Quill-Radio-Setup-1.0.0.exe</code>) -- its own folder, Start Menu
+entry, uninstaller. Your data lives in the shared Quill store in your
+Windows profile.</li>
+<li><strong>The portable zip</strong>
+(<code>Quill-Radio-Portable-1.0.0.zip</code>) -- extract anywhere, even
+a USB stick, and run <code>QuillRadio\QuillRadio.exe</code>. Its
+<code>data</code> folder keeps your favorites, history, and settings
+inside the app folder, so the whole radio travels with you.</li>
+</ul>
+<p>Windows SmartScreen may warn on first run because this release is not
+code-signed; choose "More info" then "Run anyway". The build is exactly
+what this repository's source produces.</p>
+<h2 id="getting-started">Getting started</h2>
+<p>Launch Quill Radio from the Start Menu (or the portable folder's
+<code>QuillRadio.exe</code>). The window opens with keyboard focus on
+your <strong>Favorite stations</strong> tree.</p>
+<ul>
+<li>No favorites yet? Press Alt+S for the Station menu, then
+<strong>Browse Stations...</strong> to search thousands of stations by
+name, genre, country, or language, listen before you commit, and add the
+keepers to your favorites. The <strong>ACB Media</strong> submenu is
+also right there -- the whole ACB stream directory, playable without any
+setup.</li>
+<li>With favorites: arrow to a station and press <strong>Enter</strong>.
+That is the whole loop.</li>
+<li>Want the radio on the moment the app opens? Check <strong>Station
+&gt; Resume Last Station on Launch</strong> once, and Quill Radio
+becomes an appliance: launch it, and your station is already
+playing.</li>
+</ul>
+<p>Everything Quill Radio announces goes through the same announcement
+engine QUILL uses, so it speaks through your screen reader (JAWS, NVDA,
+Narrator) without stealing focus.</p>
+<h2 id="the-main-window">The main window</h2>
+<p>Tab order: the now-playing line, the favorites tree, then four
+buttons.</p>
+<ul>
+<li><strong>Now playing</strong> (read-only text): what is on right now;
+also mirrored in the status bar and the Playback menu.</li>
+<li><strong>Favorite stations</strong> (tree): the same nested folder
+structure you build in the Favorites Manager, right on the main page.
+Enter plays a station, Delete removes it (with confirmation), F2 renames
+a station or folder, and Shift+F10 opens the full context menu --
+Play/Stop, Rename, Move to Folder, Remove, New Folder, and Manage
+Favorites. Your custom names are used everywhere.</li>
+<li>Buttons: <strong>Play</strong> (it becomes <strong>Stop</strong>
+while connecting or playing -- one transport control, never a dead
+button), <strong>Add to Favorites</strong> (it becomes <strong>Remove
+from Favorites</strong> when the playing station is already saved --
+perfect for keeping something you found in ACB Media or Recently
+Played), <strong>Record</strong>, <strong>Browse
+Stations...</strong></li>
+</ul>
+<h2 id="menus">Menus</h2>
+<h3 id="station-alts">Station (Alt+S)</h3>
+<ul>
+<li><strong>Browse Stations...</strong> -- the full station browser:
+search RadioBrowser's live directory, filter by tag or country,
+test-play, favorite.</li>
+<li><strong>Add Custom Station...</strong> -- paste any stream URL and
+name it yourself.</li>
+<li><strong>Find Streams from a Website...</strong> -- give it a website
+address; it scans that one page for stream links, with a Test button
+that toggles to Stop Test while a candidate plays.</li>
+<li><strong>Manage Favorites...</strong> -- the favorites, made
+organizable. See "The Favorites Manager" below.</li>
+<li><strong>New Folder...</strong> (Ctrl+Shift+E) -- create a folder
+right where you want it: pick the location (top level or inside any
+existing folder), then name it. The folder exists immediately, ready for
+Move to Folder.</li>
+<li><strong>Play Last Station</strong> (Ctrl+L) -- resume whatever you
+last had on, one keystroke, no navigation.</li>
+<li><strong>Recently Played</strong> (submenu) -- your last fifteen
+stations, newest first, playable inline.</li>
+<li><strong>Favorite Stations</strong> (submenu) -- every favorite,
+nested by your folders, playable inline.</li>
+<li><strong>ACB Media</strong> (submenu) -- ACB's whole stream
+directory, playable inline.</li>
+<li><strong>Resume Last Station on Launch</strong> (check item) -- the
+appliance switch.</li>
+<li><strong>Send to Tray</strong> (Ctrl+W) -- hide the window; playback
+continues from the notification area.</li>
+<li><strong>Exit</strong> -- quit Quill Radio.</li>
+</ul>
+<h3 id="playback-altp">Playback (Alt+P)</h3>
+<ul>
+<li>A live (disabled) now-playing line at the top, so the menu itself
+tells you what is on.</li>
+<li><strong>Play / Stop</strong> (Ctrl+P) -- one transport item that
+reads Play when idle and Stop while connecting or playing, exactly like
+the panel button.</li>
+<li><strong>Mute/Unmute</strong> (Ctrl+M), <strong>Volume Up</strong>
+(Ctrl+Up), <strong>Volume Down</strong> (Ctrl+Down). Each favorite
+remembers the volume you set while it plays and gets it back the next
+time it starts -- stations are mastered wildly differently, and you
+should only have to fix that once per station.</li>
+<li><strong>What's Playing?</strong> (Ctrl+T) -- speaks the current
+track or show title straight from the stream's own metadata.</li>
+<li><strong>Announce Track Titles</strong> (check item) -- when on,
+title changes are announced as they happen. Off by default.</li>
+<li><strong>Sleep Timer...</strong> -- fade out and stop after a set
+time, restoring your volume.</li>
+<li><strong>Wake-Up Timer...</strong> -- the sleep timer's twin: pick a
+favorite, a time, once or every day, and the station starts playing by
+itself. Quill Radio must be running (the tray counts).</li>
+</ul>
+<h3 id="record-altr">Record (Alt+R)</h3>
+<ul>
+<li><strong>Record Now / Stop Recording</strong> -- capture the station
+you are listening to.</li>
+<li><strong>Record Station...</strong> -- record a <em>different</em>
+station for a set number of minutes while you listen to something else
+(or to nothing). The recorder is its own process; it never needed the
+player.</li>
+<li><strong>Schedule Recording...</strong> -- record a show later, once,
+daily, or weekly, even from the tray. Pick a favorite from the list and
+its name and stream fill in for you (both stay editable for one-off
+streams); the Remove button names the schedule it will delete and dims
+when none is selected, and the Delete key and a context menu work on the
+list.</li>
+<li><strong>Recordings...</strong> -- everything you have recorded,
+live. See "The Recordings list" below.</li>
+<li><strong>Recording Settings...</strong> -- format (MP3, OGG, FLAC,
+WAV), bitrate, destination folder, filename pattern, a maximum-length
+safety cap, and the <strong>If the connection drops</strong> section:
+reconnect on/off, how many attempts, and how many seconds between
+them.</li>
+</ul>
+<h3 id="help-alth">Help (Alt+H)</h3>
+<ul>
+<li><strong>Command Palette...</strong> (Ctrl+Shift+P) -- every Quill
+Radio command in one searchable list.</li>
+<li><strong>Redeem Unlock Code...</strong> -- enter a signed code for a
+pre-release capability. Verified entirely on your machine; nothing is
+transmitted; one code counts for QUILL, Quill Radio, and QUILL Cast
+together.</li>
+<li><strong>Check for Updates...</strong> -- compares your version with
+the newest release, downloads the right artifact for your flavor
+directly (the installer for an installed copy, the portable zip for a
+portable one) with spoken progress, then offers Install now or Open
+folder.</li>
+<li><strong>Get FFmpeg...</strong> -- a safety net: FFmpeg ships inside
+Quill Radio, but if it ever goes missing this downloads the official
+build so recording works again.</li>
+<li><strong>Report a Bug...</strong> -- files an issue directly from the
+app (no GitHub account needed), stamped "Quill Radio" with this app's
+own version so we know exactly what you were running; falls back to the
+online support form if anything goes wrong.</li>
+<li><strong>About Quill Radio</strong> -- version, sync statement,
+project address.</li>
+</ul>
+<h2 id="the-favorites-manager">The Favorites Manager</h2>
+<p>Station &gt; Manage Favorites... is a full organizer,
+keyboard-first:</p>
+<ul>
+<li><strong>Search favorites</strong> filters live across names
+(including your custom names), countries, languages, tags, and folder
+names; results flatten into one arrow-key list with each station's
+folder spoken in its label.</li>
+<li><strong>Folders of any depth.</strong> Create one with <strong>New
+Folder...</strong> (Ctrl+Shift+E) -- pick its location, name it, and it
+exists immediately, even before a station lives in it. Or just file a
+station under "News/Morning" and the path springs into being. Rename a
+folder (F2) and its subfolders come along; delete one and its stations
+simply step out to the top level -- nothing is ever deleted with a
+folder.</li>
+<li><strong>Reordering.</strong> Move Up / Move Down within a folder;
+for long hops, <strong>Mark for Move</strong>, select the destination,
+then <strong>Move Above</strong> or <strong>Move Below</strong> -- the
+moved station joins the destination's folder.</li>
+<li><strong>Rename</strong> (F2 on a station) gives it your own display
+name everywhere; blank restores the directory's name.</li>
+<li>Enter plays (the Play button reads Stop while that station is on),
+Delete removes (with confirmation), Shift+F10 opens every action on the
+selected item. The main-page tree offers the same actions, so the
+Manager is for the heavy lifting, not a required stop.</li>
+</ul>
+<h2 id="the-recordings-list">The Recordings list</h2>
+<p>Record &gt; Recordings... shows the whole recording life cycle in one
+place, refreshing live:</p>
+<ul>
+<li>The recording being written right now -- status
+<strong>Recording</strong>, its size growing as you watch.</li>
+<li>Every finished file, newest first -- status
+<strong>Recorded</strong>, with size and date.</li>
+<li>Upcoming scheduled recordings -- status <strong>Scheduled</strong>,
+with their times.</li>
+</ul>
+<p>Actions: <strong>Play</strong> (through the app's own player; it
+reads <strong>Stop</strong> while that recording is playing),
+<strong>Stop Recording</strong>, <strong>Open in Folder</strong>,
+<strong>Remove</strong> (Delete key, with confirmation),
+<strong>Refresh</strong>. If the internet hiccups during a recording,
+ffmpeg first rides it out; if the connection truly dies, Quill Radio
+waits and resumes into a numbered part file, announcing each attempt --
+tune or disable this in Recording Settings.</p>
+<h2 id="hardware-media-keys">Hardware media keys</h2>
+<p>If your keyboard has media keys, Play/Pause and Stop control Quill
+Radio system-wide while it runs -- even from the tray. Keys another app
+already owns are left alone.</p>
+<h2 id="the-system-tray">The system tray</h2>
+<p>Closing the window keeps Quill Radio available in the notification
+area with its own icon, announced by name. Right-click (or
+keyboard-invoke) the tray icon for: Show, the live now-playing line, a
+single <strong>Play/Stop</strong> item whose label is always current,
+Mute/Unmute, your <strong>Favorite Stations</strong> (nested by folder)
+and <strong>Recently Played</strong> submenus, Record Now/Stop
+Recording, Schedule Recording, Recording Settings, Browse Stations, and
+Exit. Double-click brings the window back.</p>
+<h2 id="sharing-data-with-quill">Sharing data with QUILL</h2>
+<p>Quill Radio reads and writes the same data store as QUILL and QUILL
+Cast (<code>%APPDATA%\Quill</code>): favorites (folders, custom names,
+and per-station volumes included), history, recordings, schedules,
+timers, and settings. A station you favorite here is a favorite in
+QUILL's radio; the wake-up timer you set in QUILL fires here.
+Uninstalling Quill Radio never deletes that shared data.</p>
+<h2 id="dependencies-honestly-stated">Dependencies, honestly stated</h2>
+<ul>
+<li><strong>Playback</strong> uses the Windows Media Player engine built
+into Windows -- nothing to install.</li>
+<li><strong>Recording</strong> (and the auto-trim/normalize passes) use
+<strong>ffmpeg</strong>, which the installer bundles at
+<code>tools\ffmpeg</code> inside the install folder. Nothing downloads
+at runtime.</li>
+<li><strong>Station search</strong> talks to the community
+<strong>RadioBrowser</strong> directory; <strong>Find Streams</strong>
+fetches only the one page you type; <strong>What's Playing</strong>
+reads metadata from the stream you are already playing. No other network
+calls exist, and every one of them is inventoried in QUILL's
+network-egress audit.</li>
+<li>The <strong>ACB Media</strong> directory is bundled -- no network
+needed to browse it.</li>
+</ul>
+<h2 id="keyboard-reference">Keyboard reference</h2>
+<table>
+<thead>
+<tr>
+<th>Action</th>
+<th>Key</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Play / Stop</td>
+<td>Ctrl+P</td>
+</tr>
+<tr>
+<td>Play Last Station</td>
+<td>Ctrl+L</td>
+</tr>
+<tr>
+<td>Mute / Unmute</td>
+<td>Ctrl+M</td>
+</tr>
+<tr>
+<td>Volume up / down</td>
+<td>Ctrl+Up / Ctrl+Down</td>
+</tr>
+<tr>
+<td>What's Playing?</td>
+<td>Ctrl+T</td>
+</tr>
+<tr>
+<td>Send to tray</td>
+<td>Ctrl+W</td>
+</tr>
+<tr>
+<td>New Folder</td>
+<td>Ctrl+Shift+E</td>
+</tr>
+<tr>
+<td>Command Palette</td>
+<td>Ctrl+Shift+P</td>
+</tr>
+<tr>
+<td>Play selected favorite</td>
+<td>Enter (in the list)</td>
+</tr>
+<tr>
+<td>Rename (manager)</td>
+<td>F2</td>
+</tr>
+<tr>
+<td>Remove (manager / recordings)</td>
+<td>Delete</td>
+</tr>
+<tr>
+<td>Station menu</td>
+<td>Alt+S</td>
+</tr>
+<tr>
+<td>Playback menu</td>
+<td>Alt+P</td>
+</tr>
+<tr>
+<td>Record menu</td>
+<td>Alt+R</td>
+</tr>
+<tr>
+<td>Help menu</td>
+<td>Alt+H</td>
+</tr>
+</tbody>
+</table>
+<p>These keys belong to Quill Radio's own menus and are kept separate
+from QUILL's keymap, so nothing here collides with editor shortcuts.</p>
+<h2 id="troubleshooting">Troubleshooting</h2>
+<ul>
+<li><strong>A station will not play.</strong> Streams move. If the
+station came from the directory, Quill Radio automatically fetches its
+current address and retries once; if it still fails, search for it again
+in Browse Stations, or re-add it as a custom station.</li>
+<li><strong>No sound but the app says playing.</strong> Check Mute
+(Ctrl+M), the per-station volume (Ctrl+Up), and the Windows volume mixer
+entry for Quill Radio.</li>
+<li><strong>A recording stopped early.</strong> Check Record &gt;
+Recordings... -- a dropped connection continues into "(part 2)" files
+when reconnect is on. The maximum-length cap in Recording Settings also
+ends recordings deliberately.</li>
+<li><strong>The wake-up timer did not fire.</strong> Quill Radio (or
+QUILL) must be running at the set time -- the tray counts, a closed app
+does not. It also never retro-fires: opening the app hours after the set
+time stays silent until the next occurrence.</li>
+<li><strong>The tray icon is gone.</strong> Check the taskbar overflow
+area, or set Quill Radio to "always show" in Windows taskbar
+settings.</li>
+</ul>
+</body>
+</html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>QUILL - Screen-reader-first writing environment</title>
-  <meta name="description" content="QUILL is a screen-reader-first writing studio for Windows and macOS, built by the community that depends on it. Every command speaks. Everything works from the keyboard. Version 0.9.0 - the final feature beta before 1.0 - is complete: writing, formatting, speech, braille, linked notes, document rescue, optional AI, and extensions, with nothing hidden and nothing silent.">
+  <title>QUILL - Screen-reader-first software, built by the community that depends on it</title>
+  <meta name="description" content="QUILL is a growing family of free, screen-reader-first software for Windows and macOS: the QUILL writing studio, the Quill Radio internet radio app, and more on the way. Every command speaks. Everything works from the keyboard. Built by the community that depends on it.">
   <link rel="stylesheet" href="/assets/style.css">
 </head>
 <body>
@@ -13,13 +13,13 @@
     <div class="wrap">
       <a class="brand" href="/">
         <span class="quill">QUILL</span>
-        <span class="tag">writing, made inclusive</span>
+        <span class="tag">accessible software, built with you</span>
       </a>
       <nav class="site" aria-label="Primary">
         <ul>
           <li class="nav-has-sub">
             <details class="nav-dropdown">
-              <summary>Download</summary>
+              <summary>Download QUILL</summary>
               <ul>
                 <li><a href="https://github.com/Community-Access/quill/releases/download/v0.9.0-beta.2/Quill-for-All-Setup-0.9.0.Beta.2.exe">Windows: System Installer (online)</a></li>
                 <li><a href="https://github.com/Community-Access/quill/releases/download/v0.9.0-beta.2/Quill-for-All-Setup-Offline-0.9.0.Beta.2.exe">Windows: System Installer (offline)</a></li>
@@ -29,6 +29,17 @@
               </ul>
             </details>
           </li>
+          <li class="nav-has-sub">
+            <details class="nav-dropdown">
+              <summary>Download Quill Radio</summary>
+              <ul>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.1.exe">Windows: System Installer</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.1.zip">Windows: Portable ZIP</a></li>
+                <li><a href="/radio.html">About Quill Radio</a></li>
+              </ul>
+            </details>
+          </li>
+          <li><a href="/radio.html">Quill Radio</a></li>
           <li><a href="/docs/release-notes.html">Release Notes</a></li>
           <li><a href="/docs/userguide.html">User Guide</a></li>
           <li><a href="/tutorials/index.html">Tutorials</a></li>
@@ -45,16 +56,16 @@
     <!-- Hero -->
     <div class="hero">
       <div class="wrap">
-        <h1>Writing software built around your screen reader.</h1>
+        <h1>Accessible software built around your screen reader - not around an afterthought.</h1>
         <p class="lede">
-          QUILL is a screen-reader-first writing studio for Windows and macOS, built by the
-          community that depends on it. Every command announces its outcome. Everything works
-          from the keyboard. Your words never leave your device without your explicit say-so.
-          And with version 0.9.0 - the final feature beta before 1.0 - the vision is complete:
-          everything this project set out to build is in the product, and from here to 1.0 it
-          only gets more solid. The last homecoming landed during the beta window: the
-          <strong>Audio Studio</strong>, a keyboard-first audiobook and podcast workshop that
-          narrates, chapters, casts voices, titles by ear, and publishes - start to feed.
+          QUILL began as a writing studio and has grown into a small family of free,
+          screen-reader-first software for Windows and macOS, built by the community that
+          depends on it: the <strong>QUILL</strong> writing environment, the new
+          <strong>Quill Radio</strong> internet radio app, and a dedicated podcast client on
+          the way. Every command announces its outcome. Everything works from the keyboard.
+          Your data never leaves your device without your explicit say-so. QUILL itself is at
+          version 0.9.0 - the final feature beta before 1.0 - with everything this project set
+          out to build already in the product.
         </p>
         <p class="acronym">
           <strong>Q</strong>uality <span aria-hidden="true">&middot;</span>
@@ -75,6 +86,25 @@
         <p class="req-note">Windows 10 or later, 64-bit. Online installers download optional components on first use; offline installers bundle everything. Extract portable ZIPs and run from any folder. macOS 12 or later: download the disk image (.dmg) and drag QUILL to Applications. The Python runtime is included in all builds.</p>
       </div>
     </div>
+
+    <!-- Quill Radio 1.0 announcement -->
+    <section class="band callout" aria-labelledby="radio-announce-h">
+      <div class="wrap">
+        <h2 id="radio-announce-h">Introducing Quill Radio 1.0 - the next generation of the ACB Radio Tuner</h2>
+        <p class="intro">
+          A free, standalone internet radio app for Windows: every ACB Media stream ready the
+          moment you install, plus tens of thousands of stations from around the world, a real
+          nested favorites system, recording with automatic reconnection, a wake-up timer, and
+          hardware media-key support - all spoken, all keyboard-first, all free.
+        </p>
+        <div class="cta">
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.1.exe">Download Quill Radio 1.0.1 - Installer</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.1.zip">Download Quill Radio 1.0.1 - Portable</a>
+          <a class="btn secondary" href="/radio.html">Explore Quill Radio</a>
+          <a class="btn secondary" href="/docs/radio-pr.html">Read the press release</a>
+        </div>
+      </div>
+    </section>
 
     <!-- Beginners start here: kept immediately after the hero so a screen
          reader reading in document order (or jumping by heading) meets the
@@ -1102,6 +1132,15 @@
               <li><a href="/docs/responsible-ai-use.html">Responsible AI use</a></li>
             </ul>
           </div>
+          <div class="card">
+            <h3><a href="/radio.html">Quill Radio 1.0</a></h3>
+            <p>The next generation of the ACB Radio Tuner: every ACB Media stream plus stations from around the world, favorites, recording, and a wake-up timer - free and standalone.</p>
+            <ul class="doc-links">
+              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.1.exe">Windows: Installer</a></li>
+              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.1.zip">Windows: Portable ZIP</a></li>
+              <li><a href="/docs/radio-userguide.html">Quill Radio user guide</a></li>
+            </ul>
+          </div>
         </div>
       </div>
     </section>
@@ -1128,7 +1167,8 @@
       <nav aria-label="Project">
         <h4>Project</h4>
         <ul>
-          <li><a href="https://github.com/Community-Access/quill/releases/tag/v0.9.0-beta.2">Download 0.9.0 Beta 2</a></li>
+          <li><a href="https://github.com/Community-Access/quill/releases/tag/v0.9.0-beta.2">Download QUILL 0.9.0 Beta 2</a></li>
+          <li><a href="https://github.com/Community-Access/quill-radio/releases/latest">Download Quill Radio 1.0.1</a></li>
           <li><a href="https://hub.quillforall.org">Quillin Hub</a></li>
           <li><a href="/docs/contributing.html">Contributing</a></li>
           <li><a href="/docs/governance.html">Governance</a></li>

--- a/docs/site/radio.html
+++ b/docs/site/radio.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Quill Radio - the next generation of the ACB Radio Tuner</title>
+  <meta name="description" content="Quill Radio is a free, screen-reader-first internet radio app for Windows: every ACB Media stream ready out of the box, tens of thousands of stations worldwide, nested favorites, reconnecting recordings, a wake-up timer, and hardware media keys.">
+  <link rel="stylesheet" href="/assets/style.css">
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to main content</a>
+  <header class="site">
+    <div class="wrap">
+      <a class="brand" href="/">
+        <span class="quill">QUILL</span>
+        <span class="tag">accessible software, built with you</span>
+      </a>
+      <nav class="site" aria-label="Primary">
+        <ul>
+          <li class="nav-has-sub">
+            <details class="nav-dropdown">
+              <summary>Download Quill Radio</summary>
+              <ul>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.1.exe">Windows: System Installer</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.1.zip">Windows: Portable ZIP</a></li>
+              </ul>
+            </details>
+          </li>
+          <li><a href="/index.html">QUILL home</a></li>
+          <li><a href="/docs/radio-userguide.html">User guide</a></li>
+          <li><a href="/docs/radio-release-notes.html">Release notes</a></li>
+          <li><a href="/docs/radio-pr.html">Press release</a></li>
+          <li><a href="/faq.html">FAQ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <div class="hero">
+      <div class="wrap">
+        <h1>Quill Radio: the next generation of the ACB Radio Tuner.</h1>
+        <p class="lede">
+          For over a decade, the ACB Radio Tuner gave blind and low-vision listeners a small,
+          devoted way to hear ACB Media on the desktop. Quill Radio carries that legacy forward
+          - every ACB Media stream plays the moment you install, with zero setup - and then goes
+          further: tens of thousands of stations from every country, a real nested favorites
+          system, recording that survives a dropped connection, a wake-up timer, hardware media
+          keys, and a system tray presence that keeps the music going while you work. Free.
+          Built the way a screen reader user would build it.
+        </p>
+        <div class="cta">
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.1.exe">Download Quill Radio 1.0.1 - Windows Installer</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.1.zip">Download Quill Radio 1.0.1 - Windows Portable</a>
+          <a class="btn secondary" href="/docs/radio-userguide.html">Read the user guide</a>
+          <a class="btn secondary" href="/docs/radio-pr.html">Read the press release</a>
+        </div>
+        <p class="req-note">Windows 10 or later, 64-bit. Everything is bundled - ffmpeg for recording included, nothing downloads at install or runtime. The installer places Quill Radio in its own folder with a Start Menu entry; the portable zip carries its own <code>data</code> folder so the whole app, favorites and all, travels on a USB stick. Not yet code-signed: Windows SmartScreen may warn on first run - choose "More info," then "Run anyway."</p>
+      </div>
+    </div>
+
+    <section class="band" aria-labelledby="heritage-h">
+      <div class="wrap">
+        <h2 id="heritage-h">Where this came from</h2>
+        <p class="intro">
+          Quill Radio is offered with real gratitude to the American Council of the Blind and
+          everyone who built and maintained the original ACB Radio Tuner. That project proved
+          something worth proving: a radio app designed specifically for blind listeners, by
+          people who understood exactly what that meant, could be simple, dependable, and
+          genuinely loved. Quill Radio doesn't replace that legacy - it's an attempt to honor it,
+          by taking the same care and pointing it at the whole dial.
+        </p>
+      </div>
+    </section>
+
+    <section class="band" aria-labelledby="features-h">
+      <div class="wrap">
+        <h2 id="features-h">Everything you'd expect - and everything you didn't have before</h2>
+
+        <details class="deep" open>
+          <summary><h3>From ten streams to the whole dial</h3></summary>
+          <div>
+            <p>The bundled <strong>ACB Media</strong> directory carries all ten ACB streams -
+            Mainstream, The Trove, Cafe, Community, Live, Special, and the rest - playable the
+            moment you install. <strong>Browse Stations</strong> opens the live RadioBrowser
+            directory: tens of thousands of stations worldwide, searchable by name, genre,
+            country, or language, with a Test button to preview before you commit.
+            <strong>Find Streams from a Website</strong> scans a page you give it for stream
+            links, and you can always paste a URL directly. However a station reaches you, one
+            keystroke makes it a favorite.</p>
+          </div>
+        </details>
+
+        <details class="deep">
+          <summary><h3>Favorites that grow the way your listening does</h3></summary>
+          <div>
+            <p>Folders as deep as you want - News, then News &gt; Morning, then News &gt;
+            Morning &gt; Local - created wherever you need them with <strong>New Folder</strong>
+            (Ctrl+Shift+E), before a single station lives there. Rename any station to what
+            <em>you</em> call it; your name follows it everywhere. Delete a folder and its
+            stations step safely back to the top level - nothing vanishes with it. Every
+            favorite remembers its own volume, because stations are mastered wildly
+            differently and you should only have to fix that once.</p>
+          </div>
+        </details>
+
+        <details class="deep">
+          <summary><h3>Recording that survives the real internet</h3></summary>
+          <div>
+            <p>If your connection drops mid-recording, ffmpeg first rides out the gap; if the
+            drop is real, Quill Radio waits, reconnects, and resumes into a cleanly numbered
+            part file - attempts and spacing entirely yours to tune. Record what's playing, or
+            record a different station while you listen to something else - the recorder never
+            needed the player. Schedule a show once, daily, or weekly, picking straight from
+            your favorites. The <strong>Recordings</strong> window shows the whole life cycle
+            live: recording now with its size growing, recorded and ready, or scheduled and
+            waiting.</p>
+          </div>
+        </details>
+
+        <details class="deep">
+          <summary><h3>An appliance, when you want it to be one</h3></summary>
+          <div>
+            <p>Check <strong>Resume Last Station on Launch</strong> once and Quill Radio
+            becomes exactly what a radio should be: something you turn on. <strong>Play Last
+            Station</strong> (Ctrl+L) picks up where you left off with no navigation at all.
+            The <strong>Wake-Up Timer</strong> is the sleep timer's twin - pick a favorite, pick
+            a time, once or every day. Hardware media keys control playback system-wide, even
+            from the tray, with a live now-playing tooltip.</p>
+          </div>
+        </details>
+
+        <details class="deep">
+          <summary><h3>Built to be heard</h3></summary>
+          <div>
+            <p>Everything Quill Radio does, it says out loud, through the same announcement
+            engine that powers QUILL - accurate, and compatible with JAWS, NVDA, and Narrator
+            without ever stealing focus. The <strong>Command Palette</strong> (Ctrl+Shift+P)
+            puts every command behind one searchable list. <strong>What's Playing</strong>
+            (Ctrl+T) speaks the current track or show title from the stream's own metadata,
+            the instant you ask.</p>
+          </div>
+        </details>
+
+        <details class="deep">
+          <summary><h3>One data store, shared with QUILL</h3></summary>
+          <div>
+            <p>Quill Radio shares favorites, history, recordings, schedules, and settings with
+            QUILL and QUILL Cast. Favorite a station here, and it's already a favorite in
+            QUILL. Set a wake-up timer in QUILL, and it fires here. Nothing is ever set up
+            twice.</p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <section class="band" aria-labelledby="feedback-h">
+      <div class="wrap">
+        <h2 id="feedback-h">Tell us what to build next</h2>
+        <p class="intro">
+          Quill Radio is free, and it grows from the people who use it. <strong>Help &gt;
+          Report a Bug</strong>, right inside the app, sends us a note in seconds - no account
+          or sign-up needed - stamped with Quill Radio's own version so we always know exactly
+          what you were running. Every report shapes what ships next.
+        </p>
+        <div class="cta">
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/issues/new">Report a bug or request a feature</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="band" aria-labelledby="docs-h">
+      <div class="wrap">
+        <h2 id="docs-h">Documentation</h2>
+        <div class="cards">
+          <div class="card">
+            <h3><a href="/docs/radio-userguide.html">User guide</a></h3>
+            <p>Installing, the main window, every menu, the Favorites Manager, the Recordings list, and the full keyboard reference.</p>
+          </div>
+          <div class="card">
+            <h3><a href="/docs/radio-prd.html">Product requirements</a></h3>
+            <p>The design document behind Quill Radio: architecture, feature scope, and the accessibility commitments the app is held to.</p>
+          </div>
+          <div class="card">
+            <h3><a href="/docs/radio-release-notes.html">Release notes</a></h3>
+            <p>What shipped in 1.0: every feature, in full detail.</p>
+          </div>
+          <div class="card">
+            <h3><a href="/docs/radio-pr.html">Press release</a></h3>
+            <p>The full announcement: the ACB Radio Tuner heritage, every capability, and how to get involved.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site">
+    <div class="wrap">
+      <p class="note">
+        <strong class="quill" style="color:var(--accent)">Quill Radio</strong> -
+        free, screen-reader-first internet radio for Windows, sharing its codebase with QUILL.
+      </p>
+      <nav aria-label="Documentation">
+        <h4>Documentation</h4>
+        <ul>
+          <li><a href="/docs/radio-userguide.html">User guide</a></li>
+          <li><a href="/docs/radio-release-notes.html">Release notes</a></li>
+          <li><a href="/docs/radio-pr.html">Press release</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="Project">
+        <h4>Project</h4>
+        <ul>
+          <li><a href="https://github.com/Community-Access/quill-radio/releases/latest">Download Quill Radio</a></li>
+          <li><a href="https://github.com/Community-Access/quill-radio/issues/new">Report a bug</a></li>
+        </ul>
+      </nav>
+      <nav aria-label="The QUILL family">
+        <h4>The QUILL family</h4>
+        <ul>
+          <li><a href="/index.html">QUILL writing environment</a></li>
+          <li><a href="/podcast/index.html">The QUILL Cast (learn QUILL by ear)</a></li>
+        </ul>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New /radio.html page: Quill Radio 1.0 features, the ACB Radio Tuner heritage story, installer + portable downloads, and links to its docs.
- Front page: separate "Download QUILL" and "Download Quill Radio" menus, an announcement callout for Quill Radio 1.0, a Quill Radio card in "Start here," a new tagline and hero that speak to the growing QUILL family (QUILL, Quill Radio, and a podcast client on the way), and Quill Radio links in the footer.
- Documentation hub (docs.html): new "Quill Radio" section linking its user guide, PRD, release notes, and press release.
- Quill Radio's user guide, PRD, release notes, and press release are published as HTML (docs/site/docs/radio-*.html), mirroring the HTML+EPUB pair already committed to the quill-radio repo.

## Testing
- Hand-reviewed every new/changed page for correct relative links (nav, footer, download URLs against the live v1.0.1 release assets) and consistent header/footer structure with the rest of the site.
- No workflow other than github-pages.yml (deploy-only, push-to-main trigger) reads docs/site, so no CI gate change was needed for this content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)