### PR TITLE
chore(radio): bump Quill Radio runtime version to 1.1.0

### DIFF
--- a/quill/apps/radio.py
+++ b/quill/apps/radio.py
@@ -20,7 +20,7 @@ from quill.ui.main_frame_radio import RadioMixin
 from quill.ui.main_frame_unlock_codes import UnlockCodesMixin
 
 _TITLE = "Quill Radio"
-_VERSION = "1.0.2"
+_VERSION = "1.1.0"
 _REPO = "Community-Access/quill-radio"
 
 #: RadioHistory.close_action's Preferences combo box (see also


### PR DESCRIPTION
Bumps `quill.apps.radio._VERSION` from 1.0.2 to 1.1.0, aligning the About dialog, in-app bug reporter, and Help > Check for Updates with the Quill Radio 1.1.0 release cut in the quill-radio repo.

1.1.0 gathers the radio robustness batch (Triton JS players, self-healing recovery, configurable What's Playing, paged search, Browse volume; PR #1075) and the new raw/lossless stream-copy recording mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)