### PR TITLE
site: publish Quill Radio 1.1.0 on quillforall.org

### DIFF
--- a/docs/site/docs/radio-prd.html
+++ b/docs/site/docs/radio-prd.html
@@ -181,7 +181,7 @@
 </header>
 <h1 id="quill-radio----product-requirements">Quill Radio -- Product
 Requirements</h1>
-<p>Version 1.0</p>
+<p>Version 1.1</p>
 <h2 id="1-product-statement">1. Product statement</h2>
 <p>Quill Radio is QUILL's internet radio, shipped as its own small
 Windows app for people who want the radio on without loading a full
@@ -216,9 +216,53 @@ from QUILL's keymap so nothing collides with editor shortcuts.</li>
 <li>Station browser over the RadioBrowser directory (search, tag/country
 filters, test-play, favorite); bundled ACB Media directory; custom
 stream URLs; website stream finder with a Test/Stop Test toggle.</li>
+<li>JavaScript-player resolution in the website stream finder (upstream
+<code>core/radio/triton.py</code>): Triton Digital / StreamTheWorld
+players (the <code>player.listenlive.co</code> network and thousands of
+broadcast stations) compute their stream URL in JavaScript, so it never
+appears in the page HTML and a plain-HTML scan finds nothing. Quill
+Radio detects the player, reads the station callsign from the Triton
+PWA's own logo asset name, and resolves it to a real playable mount
+through Triton's JS-free provisioning API
+(<code>playerservices.streamtheworld.com</code>), offering both the MP3
+and AAC streams. Gated to pages that actually are Triton players and to
+a callsign the API validates, so it never surfaces a wrong stream; the
+response is parsed through the hardened <code>core/safe_xml</code>
+wrapper. One added egress, inventoried in QUILL's network-egress audit
+(§N-1), reached only from the same explicit Scan button and disabled in
+Safe Mode.</li>
 <li>One transport control (Play becomes Stop), mute, volume with
 per-station memory, single-player rule (starting any stream silences
 sibling media, radio or podcast, in every app).</li>
+<li>What's Playing (Ctrl+T) with a clean, configurable announcement
+(upstream <code>core/radio/now_playing.py</code>, #1068): parses the
+<code>key="value"</code> broadcast-automation metadata some stations
+pack into their ICY StreamTitle (and the plain "Artist - Title"
+convention) into title/artist fields, and renders them through a
+user-set token template
+(<code>{title}</code>/<code>{artist}</code>/<code>{raw}</code> with
+<code>[optional]</code> segments) stored in
+<code>RadioHistory.now_playing_template</code> and edited in Preferences
+(Ctrl+,). Default <code>{title}[ by {artist}]</code>.</li>
+<li>Paged station search (upstream
+<code>radio_browser.search_stations</code> offset + the Browse Stations
+dialog, #1064): 200 most-listened-first results per request (was 50)
+plus a More Stations button that pages the RadioBrowser directory beyond
+the first page; a finished search states when more exist and suggests
+narrowing.</li>
+<li>Self-healing stream recovery (upstream
+<code>core/radio/recovery.py</code>, #1065): on a playback error, a
+confidence-ordered ladder runs off-thread -- re-resolve a moved
+StreamTheWorld mount, refresh the URL from the directory, then (opt-in,
+<code>RadioHistory.recover_from_website</code>, default on, off in Safe
+Mode) scan the station's website with the shared Triton + "Listen Live"
+link-following scanner. A single unambiguous result auto-plays and
+self-heals the favorite; multiple candidates are announced for the user
+to pick in Find Streams. One attempt per station per session; all egress
+via the already-reviewed sites. <code>link_finder</code> also now
+follows a bounded allowlist of listen/live/play/tune-in
+<code>&lt;a&gt;</code> links one level deep, benefiting the manual Find
+Streams too.</li>
 <li>Recently Played (capped, de-duplicated), Play Last Station, optional
 resume-on-launch.</li>
 <li>What's Playing: ICY track titles on demand and optional
@@ -245,8 +289,26 @@ auto-refresh.</li>
 <li>Auto-reconnect: ffmpeg HTTP reconnect flags plus process-level retry
 into numbered part files; enabled/attempts/spacing configurable; user
 stops and duration-cap finishes never retry.</li>
-<li>Settings: format (mp3/ogg/flac/wav), bitrate, destination, filename
-pattern with tokens, max-duration safety cap.</li>
+<li>Settings: format (mp3/ogg/flac/wav, plus a raw stream-copy mode),
+bitrate, destination, filename pattern with tokens, max-duration safety
+cap.</li>
+<li>Raw/lossless capture (upstream <code>core/radio/recording.py</code>,
+listener request): a "Raw stream -- exactly as sent, no re-encoding
+(lossless)" format (<code>format="copy"</code>) stream-copies the
+server's audio packets with ffmpeg's <code>-c:a copy</code> -- no
+decode, no re-encode -- so the saved file is bit-for-bit the original
+broadcast, the most faithful capture for a listener who wants to do
+their own lossless editing/conversion. Bitrate and Sound Enhancements
+are meaningless with no re-encode and are dropped. The output container
+follows the stream's own codec, chosen from a one-time bounded
+<code>ffprobe</code> of the first audio stream
+(mp3-&gt;<code>.mp3</code>, aac-&gt;<code>.aac</code>,
+vorbis-&gt;<code>.ogg</code>, opus-&gt;<code>.opus</code>,
+flac-&gt;<code>.flac</code>, ...), falling back to Matroska audio
+(<code>.mka</code>) for anything unrecognized -- a universal lossless
+copy container; a missing/failed probe degrades to <code>.mka</code>
+rather than blocking the recording, and the resolved extension is reused
+across auto-reconnect continuation files.</li>
 </ul>
 <p><strong>Timers</strong></p>
 <ul>
@@ -292,10 +354,11 @@ installer with its own AppId installing to {autopf}\Quill Radio,
 per-user by default.</li>
 <li>P-2. Everything bundled, nothing downloaded at install or runtime:
 the onedir build carries the whole quill package and data; ffmpeg
-installs to {app}\tools\ffmpeg, found via the wrapper exporting
-QUILL_APP_ROOT. A portable zip ships the same onedir build plus a
-<code>data\</code> folder that switches storage to travel with the
-app.</li>
+installs to {app}\tools\ffmpeg and libmpv (the mpv playback engine, with
+its GPL license texts and source-offer note) to {app}\tools\mpv, both
+found via the wrapper exporting QUILL_APP_ROOT. A portable zip ships the
+same onedir build plus a <code>data\</code> folder that switches storage
+to travel with the app.</li>
 <li>P-3. Uninstall never deletes <code>%APPDATA%\Quill</code> -- QUILL
 or QUILL Cast may still use it.</li>
 <li>P-4. Release artifacts:
@@ -307,7 +370,9 @@ compares against and downloads.</li>
 <ul>
 <li>N-1. Every outbound surface is inventoried in QUILL's network-egress
 audit: RadioBrowser and SomaFM (search/tags/countries/click-votes/byuuid
-fallback), the user-typed page for Find Streams, the playing stream
+fallback), the user-typed page for Find Streams (plus, for a
+Triton/StreamTheWorld player page, one follow-on call to Triton's
+provisioning API to resolve the JS-computed stream), the playing stream
 itself for ICY titles, and this repository's GitHub releases for the
 update check. No telemetry of any kind. (Sound Enhancements' local
 relay, §8, is loopback-only and never reaches the network itself -- it
@@ -323,18 +388,49 @@ Enhancements (§8) is a small, purpose-built three-band EQ and
 compressor, not a general effects rack.</p>
 <h2 id="8-since-10">8. Since 1.0</h2>
 <ul>
+<li><strong>The mpv playback engine (1.1.0, upstream
+<code>quill/ui/radio/mpv_radio_engine.py</code> +
+<code>player_controller.py</code>, #1076).</strong> A second, preferred
+audio backend: libmpv, live-stream-aware (readiness from
+<code>core-idle</code>, not the duration a live stream never reports),
+bundled at <code>{app}\tools\mpv</code>.
+<code>RadioHistory.playback_engine</code> = auto (mpv when present) / wx
+("Windows Media (classic)", the byte-for-byte pre-1.1 escape hatch) /
+mpv; one silent cross-engine rescue per play attempt in either
+direction. Combined stream-format coverage is effectively complete: MP3,
+AAC and HE-AAC (AAC+), Ogg Vorbis, Opus, FLAC streams, and HLS (m3u8) --
+Ogg Vorbis/Opus/HLS were undecodable by WMP. The engine delivers:
+<strong>Radio output device</strong> (Preferences;
+<code>RadioHistory.output_device</code>; screen reader and app sounds
+stay on the system default; unplugged devices remembered, spoken
+fallback when unusable); <strong>live DVR</strong> (a seekable
+~45-minute demuxer cache: pause/resume live radio, Rewind/Forward 30
+Seconds, Back to Live, each announcing how far behind live);
+<strong>Volume Boost</strong> (up to 150% for quiet stations; the 0-100
+scale, per-station volumes, and mute untouched); <strong>engine-native
+What's Playing fallback</strong> (mpv <code>media-title</code> when the
+ICY side-tap gets nothing or the stream is HLS); and
+<strong>"Buffering..." announcements</strong> on mid-stream stalls.</li>
 <li><strong>Sound Enhancements</strong> (Playback &gt; Sound
 Enhancements...): a three-band equalizer (Bass/Mid/Treble sliders, -12
 to +12 dB) and a compressor, applied live via an ffmpeg filter graph
-relayed to the playback engine over a loopback-only local HTTP server.
-Off by default. A "Quick preset" shortcut sets all three sliders at
-once. Remembered per favorite station (a whole-record override on
-<code>FavoriteStation</code>, mirroring QUILL Cast's per-podcast
-override) as well as a shared default in <code>RadioHistory</code>;
-<code>RadioPlayerController</code> resolves which applies via an
-injected callback at the top of every <code>play_station</code>.
-Recording Settings' "Apply Sound Enhancements to recordings" (off by
-default) optionally records the filtered audio too.</li>
+relayed to the playback engine over a loopback-only local HTTP server --
+or, on the mpv engine (1.1.0), natively inside the player with no relay
+and with changes heard live, no reconnect. Off by default. 1.1.0 adds
+two listener-level (deliberately global, not per-station) options riding
+the same shared graph everywhere including recordings: <strong>mono
+downmix</strong> (single-sided hearing / one earbud -- hard-panned
+content never disappears) and <strong>night mode</strong> (real-time
+loudness normalization lifting quiet passages), plus the Small Speakers
+and Late Night quick presets. A "Quick preset" shortcut sets all three
+sliders at once. Remembered per favorite station (a whole-record
+override on <code>FavoriteStation</code>, mirroring QUILL Cast's
+per-podcast override) as well as a shared default in
+<code>RadioHistory</code>; <code>RadioPlayerController</code> resolves
+which applies via an injected callback at the top of every
+<code>play_station</code>. Recording Settings' "Apply Sound Enhancements
+to recordings" (off by default) optionally records the filtered audio
+too.</li>
 <li><strong>SomaFM</strong>, a second free, keyless station directory,
 blended into Browse Stations search alongside RadioBrowser.</li>
 <li><strong>Exit/Minimize to Tray confirmation</strong>: closing the

--- a/docs/site/docs/radio-release-notes.html
+++ b/docs/site/docs/radio-release-notes.html
@@ -187,6 +187,172 @@ icon, and its own icon, and then goes further than the embedded radio
 ever has. Everything below also landed in QUILL itself: the two share
 one codebase and one data store, so features arrive everywhere at
 once.</p>
+<h2 id="whats-new-in-110">What's new in 1.1.0</h2>
+<ul>
+<li><strong>A new heart: the mpv playback engine.</strong> Quill Radio
+1.1.0 ships a second audio engine -- mpv, the same engine trusted by
+media players everywhere -- and uses it automatically. You don't have to
+know or care, but it's the reason almost everything else on this list
+exists. The classic Windows Media engine is still right there:
+Preferences (Ctrl+,) &gt; Playback engine &gt; "Windows Media (classic)"
+is exactly the pre-1.1 behavior, byte for byte. Best of both: whichever
+engine is playing, a station it can't open is quietly retried once on
+the other before you ever hear an error.</li>
+<li><strong>Every stream format, finally.</strong> This is the
+consequence you'll feel immediately: Quill Radio now plays effectively
+every station format in real-world use -- <strong>MP3, AAC and HE-AAC
+(AAC+), Ogg Vorbis, Opus, FLAC streams, and HLS (m3u8)</strong>. Ogg
+Vorbis, Opus, and HLS were simply undecodable before (Windows Media
+cannot play them), and they're everywhere among community, independent,
+and international stations: a whole class of "found it in the directory
+but it won't play" stations just started working. Raw recording keeps
+pace -- each format is captured to its natural file type
+(<code>.ogg</code>, <code>.opus</code>, <code>.aac</code>, and so
+on).</li>
+<li><strong>Send the radio to a second sound card.</strong> The classic
+radio setup, finally: Preferences (Ctrl+,) gained <strong>Radio output
+device</strong>. Route the radio to a USB headset or a second sound card
+and keep your screen reader, and Quill Radio's own sounds, on the main
+one. Unplug that USB card and your choice is remembered, not silently
+reset; if the device can't be used the radio plays through the default
+and says so.</li>
+<li><strong>Pause live radio. Rewind it.</strong> Quill Radio now keeps
+a rolling buffer of the live stream -- roughly 45 minutes at typical
+bitrates. Pause for the doorbell and resume where you left off. Missed a
+sentence? <strong>Rewind 30 Seconds</strong> (Ctrl+Shift+Left). Catch
+back up with <strong>Forward 30 Seconds</strong> (Ctrl+Shift+Right) or
+jump straight to <strong>Back to Live</strong> (Ctrl+Shift+L). Every
+move tells you how far behind live you are.</li>
+<li><strong>Volume Boost.</strong> Some stations just broadcast quiet.
+Ctrl+Shift+B amplifies up to 50% past full volume -- and your normal
+volume scale, per-station volume memories, and mute all behave exactly
+as before.</li>
+<li><strong>Sound, shaped your way -- instantly.</strong> Sound
+Enhancements grew from an EQ-and-compressor into a proper listening
+toolkit. New: <strong>Combine channels into mono</strong> -- with
+single-sided hearing or one earbud, a station that hard-pans a voice to
+the other channel simply loses it; mono blends both channels so nothing
+disappears. New: <strong>Night mode</strong> -- real-time loudness
+evening that lifts quiet passages, the natural partner to Even Out
+Volume taming loud ones; late-night listening without riding the volume
+keys. Two new quick presets, <strong>Small Speakers</strong> and
+<strong>Late Night</strong>, join the family, the three-band EQ and
+per-station memories are untouched -- and on the mpv engine, every
+change now applies <em>live</em>, mid-song, with no reconnect at all.
+Recordings with "Apply Sound Enhancements" capture the new options
+too.</li>
+<li><strong>What's Playing, on more stations.</strong> When a station
+refuses the usual title request -- or streams over HLS, which has no
+title channel at all -- Quill Radio now reads the track title straight
+out of the playback engine, so Ctrl+T has an answer far more often.</li>
+<li><strong>"Buffering..." instead of silence.</strong> When the network
+hiccups mid-song, Quill Radio now says what's happening while the engine
+rides it out.</li>
+<li><strong>Alt+F4, your way.</strong> For some of us Alt+F4 is muscle
+memory -- and half the time you didn't mean to kill the radio, just get
+it out of the way. A new Preferences checkbox, <strong>Alt+F4 minimizes
+to the system tray</strong> (off by default), does exactly that: the
+window tucks away, the music keeps playing, and the tray icon has
+everything. The titlebar X and Station &gt; Exit still follow your "When
+closing the window" choice, so a deliberate exit is still one keystroke
+away.</li>
+<li><strong>Record the raw stream, exactly as sent.</strong> Recording
+Settings' Format list gained <strong>Raw stream -- exactly as sent, no
+re-encoding (lossless)</strong> next to MP3, OGG, FLAC, and WAV. Those
+four decode the incoming audio and re-encode it to the format you
+picked; the raw option does neither -- it copies the station's own audio
+packets straight to disk, so the file that lands is bit-for-bit what the
+server broadcast. It's the cleanest possible starting point if you want
+to do your own editing or convert it yourself, with nothing lost to a
+second pass through an encoder. Quill Radio names the file from the
+stream's own format for you -- an MP3 stream becomes a
+<code>.mp3</code>, AAC a <code>.aac</code>, Ogg Vorbis a
+<code>.ogg</code>, Opus a <code>.opus</code>, FLAC a <code>.flac</code>;
+anything out of the ordinary is tucked into a Matroska <code>.mka</code>
+file, which holds any audio losslessly and opens in players like VLC.
+Bitrate and Sound Enhancements don't touch a raw recording -- there's
+nothing being re-encoded for them to shape -- so they're quietly
+skipped, and if a recording rides out a dropped connection into a "(part
+2)" file, that part keeps the same file type. Straight from a listener
+request: a recording mode that saves the raw stream as captured, as
+losslessly as possible.</li>
+<li><strong>Stations that used to fail now heal themselves.</strong>
+Here's the one that started it: Magic 104.1 (KMGL) in Oklahoma City
+turns up in the directory, you press play, and... nothing. The real
+stream lives behind a JavaScript player on the station's site, so the
+listed address is a dead end, and the only way through was to open the
+website, find the "Listen Live" link, follow it, and dig the actual
+stream out of the player by hand. Quill Radio now does that digging for
+you. When a stream won't play it works down a ladder: re-resolve the
+address if it's a StreamTheWorld player that just moved servers, refresh
+the address from the directory, and -- if you leave it on -- scan the
+station's own website, following its "Listen Live"/"Play"/"Tune In" link
+into the player page and reading a Triton player straight off it. Find
+one clear stream and it just plays it (and remembers it for that
+favorite); find several and it tells you and sends you to Find Streams
+to pick. The website step is one checkbox in Preferences (on by default,
+off in Safe Mode); the quick re-resolves always run. It tries once per
+station per session, so a truly dead station never spins. A dead station
+is no longer a dead end.</li>
+<li><strong>What's Playing, the way you'd actually say it.</strong> Some
+stations don't send a clean "Artist - Title" -- their broadcast systems
+cram a pile of catalog codes into the track name, and What's Playing
+(Ctrl+T) read the whole thing aloud:
+<code>title="YOUR SONG",artist="Elton John",url="song_spot="F" MediaBaseId="0"...</code>.
+Now Quill Radio finds the title and the artist in that noise and just
+says "Now playing: YOUR SONG by Elton John." Better still, you decide
+the wording: Preferences (Ctrl+,) has a "What's Playing announcement"
+box where you write a short template with <code>{title}</code> and
+<code>{artist}</code> -- wrap optional words in
+<code>[square brackets]</code> so they disappear when there's nothing to
+fill them (the default <code>{title}[ by {artist}]</code> quietly drops
+the " by" when a stream sends no artist). Prefer "Elton John: YOUR
+SONG"? Type <code>{artist}: {title}</code>. Want the raw feed for a
+station you're curious about? <code>{raw}</code> gives you everything.
+Blank restores the default.</li>
+<li><strong>The whole dial, not just the first 50.</strong> Browse
+Stations used to stop at 50 results -- so a search for "news," with
+hundreds of stations out there, looked like it only had 50 in the world.
+Now you get up to 200 at once, most-listened first, and when there are
+still more a <strong>More Stations</strong> button loads the next page
+and drops your cursor right on the first new arrival. The summary even
+tells you when there's more to reach for, and nudges you to add a tag or
+country when you'd rather narrow than page. Under the hood this pages
+the RadioBrowser directory properly, so the long tail is finally within
+reach.</li>
+<li><strong>Volume keys, fixed again -- this time in Browse
+Stations.</strong> Search for a station, press Enter to play it, then
+reach for Ctrl+Down to bring the volume down... and nothing happened.
+Browse Stations is its own window, so the Playback menu's volume
+shortcut never reached it, and the station results list had already
+claimed the plain arrow keys for moving between rows. Now Ctrl+Up and
+Ctrl+Down work from anywhere in that window -- the results list, the
+volume slider, a button -- turning the same radio volume you'd change
+anywhere else, sliding the window's own volume control to match, and
+speaking the new level. Plain arrow keys still move you between
+stations, untouched. (Version 1.0.2 fixed exactly this on the main
+window's Favorites list; this reaches the Browse Stations window that
+fix didn't.)</li>
+<li><strong>Find Streams now reaches the stations that hid behind a Play
+button.</strong> A whole class of broadcast stations -- thousands of
+them, and the entire <code>player.listenlive.co</code> network -- put
+their "Listen Live" on a modern JavaScript player (Triton Digital /
+StreamTheWorld). Those players build the stream address in code the
+moment you press Play, so it is written nowhere on the page for a
+scanner to read. Point the old Find Streams at one and it came back
+empty, even with a Play button sitting right there on the screen. No
+longer: Quill Radio now recognizes the player, reads the station's call
+letters straight off the page, and looks up the real, playable stream
+through the station provider's own public address service -- no embedded
+browser, no guessing at URLs. When a station offers both an MP3 and an
+AAC feed, you get both to choose from. It only ever does this for pages
+that really are these players and only for call letters the service
+confirms, so it never hands you a wrong stream; ordinary pages behave
+exactly as before, and the lookup happens as part of the same Scan you
+already press (and stays off in Safe Mode). One real report --
+<code>player.listenlive.co/34461</code>, "Magic 104.1" -- turned into a
+fix that quietly covers thousands of stations at once.</li>
+</ul>
 <h2 id="whats-new-in-102">What's new in 1.0.2</h2>
 <ul>
 <li><strong>Volume keys, fixed.</strong> Ctrl+Up/Ctrl+Down did nothing
@@ -220,10 +386,13 @@ sound the same. With nothing playing (or a non-favorite station on),
 you're adjusting the shared default every other station still
 follows.</li>
 <li><strong>Exit or Minimize to Tray -- your choice.</strong> When
-something is playing or recording, closing asks: Exit, Minimize to Tray,
-or Cancel, with a "Don't ask me again" checkbox that remembers your
-answer. Preferences (Ctrl+,) gained a matching "When closing the window"
-setting so you can always change your mind later.</li>
+something is playing or recording, closing the window -- Alt+F4, the
+titlebar X, or Station &gt; Exit, they all count -- asks: Exit, Minimize
+to Tray, or Cancel, with a "Don't ask me again" checkbox that remembers
+your answer. Preferences (Ctrl+,) gained a matching "When closing the
+window" setting so you can always change your mind later: set it to
+Minimize to Tray and Alt+F4 sends the radio to the tray, still playing,
+instead of exiting.</li>
 <li><strong>A real dialog when you're already up to date.</strong> Help
 &gt; Check for Updates used to only announce "up to date" -- easy to
 miss. It now shows a proper dialog, the same as a genuine update

--- a/docs/site/docs/radio-userguide.html
+++ b/docs/site/docs/radio-userguide.html
@@ -180,7 +180,7 @@
 <h1 class="title">Quill Radio - userguide</h1>
 </header>
 <h1 id="quill-radio-user-guide">Quill Radio User Guide</h1>
-<p>Version 1.0</p>
+<p>Version 1.1</p>
 <p>Quill Radio is internet radio the way a screen reader user would
 design it: a small window whose favorites tree has focus the instant it
 opens, menus that say everything they do, spoken feedback for every
@@ -250,12 +250,42 @@ Stations...</strong></li>
 <ul>
 <li><strong>Browse Stations...</strong> -- the full station browser:
 search RadioBrowser's live directory, filter by tag or country,
-test-play, favorite.</li>
+test-play, favorite. A search shows up to 200 stations at once,
+most-listened first; when there are still more, a <strong>More
+Stations</strong> button loads the next page and puts your cursor on the
+first newly added station. The status line tells you when more can be
+loaded and suggests adding a tag or country to narrow a very broad
+search.</li>
 <li><strong>Add Custom Station...</strong> -- paste any stream URL and
 name it yourself.</li>
+<li><strong>When a station won't play, Quill Radio tries to fix it for
+you.</strong> Some stations are listed in the directory but their stream
+address is dead -- often because the real stream is behind a player on
+the station's website. Instead of just failing, Quill Radio works down a
+short ladder: it re-resolves the address (for StreamTheWorld-style
+players that moved servers), refreshes the address from the directory,
+and -- if the setting is on -- scans the station's own website,
+following a "Listen Live"/"Play"/"Tune In" link into the player and
+recognizing Triton players there. If it finds one clear stream it plays
+it and remembers it for that favorite; if it finds several it tells you
+the count and you can open Find Streams to choose. The website step is
+the "Recover failed streams from the station's website" checkbox in
+Station &gt; Preferences (Ctrl+,), on by default and off in Safe Mode.
+It only tries once per station per session.</li>
 <li><strong>Find Streams from a Website...</strong> -- give it a website
 address; it scans that one page for stream links, with a Test button
-that toggles to Stop Test while a candidate plays.</li>
+that toggles to Stop Test while a candidate plays. This now also works
+for many stations whose "Listen Live" button is a modern JavaScript
+player (Triton Digital / StreamTheWorld, including the whole
+<code>player.listenlive.co</code> network -- for example
+<code>player.listenlive.co/34461</code>). Those players build their
+stream address in code, so it is not written anywhere in the page for a
+scanner to read; Quill Radio recognizes the player, reads the station's
+call letters from the page, and looks the real stream up through the
+station provider's own public address service -- no browser, no
+guessing. Both the MP3 and the AAC stream are offered when a station
+publishes both. If a page is not one of these players, or does not name
+its station, the scan simply behaves as before.</li>
 <li><strong>Manage Favorites...</strong> -- the favorites, made
 organizable. See "The Favorites Manager" below.</li>
 <li><strong>New Folder...</strong> (Ctrl+Shift+E) -- create a folder
@@ -274,16 +304,34 @@ directory, playable inline.</li>
 appliance switch.</li>
 <li><strong>Preferences...</strong> (Ctrl+,) -- Resume Last Station on
 Launch, automatic Check for Updates, Announce dialog transitions (off by
-default -- turn on for more spoken detail around every dialog), and When
-closing the window (Ask every time / Exit / Minimize to Tray), all in
-one small dialog. Every setting takes effect the moment you save.</li>
+default -- turn on for more spoken detail around every dialog), When
+closing the window (Ask every time / Exit / Minimize to Tray -- governs
+the titlebar X, Station &gt; Exit, and by default Alt+F4 too),
+<strong>Alt+F4 minimizes to the system tray</strong> (off by default:
+turn it on and Alt+F4 alone tucks the radio into the tray, still
+playing, while X and Exit keep the setting above -- the reflexive close
+stops meaning quit), <strong>Playback engine</strong> (Automatic --
+recommended -- uses the bundled mpv engine, which powers the output
+device choice, pausing and rewinding live radio, Volume Boost, and
+stations in more formats; "Windows Media (classic)" is exactly the
+pre-1.1 behavior if you ever want it back), and <strong>Radio output
+device</strong> (route just the radio to a second sound card or USB
+headset -- your screen reader and Quill Radio's own sounds stay on the
+system default device; an unplugged device is remembered, not reset, and
+if it can't be used the radio plays through the default and says so).
+Every setting takes effect the moment you save -- switching engine or
+device mid-song reconnects the station right where it matters: on the
+new engine or device.</li>
 <li><strong>Send to Tray</strong> (Ctrl+W) -- hide the window; playback
 continues from the notification area.</li>
 <li><strong>Exit</strong> -- quit Quill Radio. Closing the window this
 way, from the titlebar X, or with Alt+F4 all ask first (unless you've
 told it not to, or set a fixed answer in Preferences): Exit, Minimize to
 Tray, or Cancel, with a "Don't ask me again" checkbox. Recording in
-progress is called out in the message, since exiting stops it.</li>
+progress is called out in the message, since exiting stops it. And if
+"Alt+F4 minimizes to the system tray" is on in Preferences, Alt+F4 skips
+all of this and simply tucks the radio into the tray, still
+playing.</li>
 </ul>
 <h3 id="playback-altp">Playback (Alt+P)</h3>
 <ul>
@@ -297,8 +345,30 @@ the panel button.</li>
 remembers the volume you set while it plays and gets it back the next
 time it starts -- stations are mastered wildly differently, and you
 should only have to fix that once per station.</li>
+<li><strong>Volume Boost</strong> (Ctrl+Shift+B, check item) --
+amplifies up to 50% past full volume for stations that just broadcast
+quiet. Your 0-100 volume scale, per-station volume memories, and mute
+all behave exactly as before; the boost is applied on top. Needs the mpv
+playback engine (the default -- see Preferences below).</li>
+<li><strong>Rewind 30 Seconds</strong> (Ctrl+Shift+Left),
+<strong>Forward 30 Seconds</strong> (Ctrl+Shift+Right), <strong>Back to
+Live</strong> (Ctrl+Shift+L) -- live radio you can move around in. Quill
+Radio keeps a rolling buffer of the stream (roughly 45 minutes at
+typical bitrates): pause with Play/Stop and resume where you left off,
+jump back to catch a missed sentence, then work your way forward or leap
+straight back to live. Every move announces how far behind live you are.
+Needs the mpv playback engine.</li>
 <li><strong>What's Playing?</strong> (Ctrl+T) -- speaks the current
-track or show title straight from the stream's own metadata.</li>
+track or show title straight from the stream's own metadata. When a
+station sends messy broadcast metadata (a string of catalog codes rather
+than a clean "Artist - Title"), Quill Radio finds the title and artist
+in it and reads just those. You control the wording in Station &gt;
+Preferences (Ctrl+,) with a small template: <code>{title}</code> and
+<code>{artist}</code> tokens, <code>[square brackets]</code> around
+optional wording that disappears when a field is empty (the default
+<code>{title}[ by {artist}]</code> drops the " by" when there's no
+artist), and <code>{raw}</code> for the stream's exact original text.
+Leave it blank to restore the default.</li>
 <li><strong>Announce Track Titles</strong> (check item) -- when on,
 title changes are announced as they happen. Off by default.</li>
 <li><strong>Sleep Timer...</strong> -- fade out and stop after a set
@@ -307,19 +377,27 @@ time, restoring your volume.</li>
 favorite, a time, once or every day, and the station starts playing by
 itself. Quill Radio must be running (the tray counts).</li>
 <li><strong>Sound Enhancements...</strong> -- a three-band equalizer
-(Bass, Mid, Treble sliders, -12 to +12 dB each, freely adjustable) plus
-a compressor ("Even Out Volume", boosts quiet passages and tames loud
-ones). A "Quick preset" combo box (Flat, Bass Boost, Voice Clarity,
-Podcast) sets all three sliders at once as a starting point -- move any
-slider afterward and it becomes Custom. Off by default; turning anything
-on filters the currently playing station live through FFmpeg (needs Help
-&gt; Get FFmpeg...) and reconnects on Apply -- there is no playback
-position to lose on a live stream, so that reconnect is instant. If
-FFmpeg is missing, playback continues unfiltered and Quill Radio tells
-you why. <strong>Remembered per station</strong>: open it while a
-favorite is playing to set that station's own sound; with nothing
-playing (or a non-favorite on), you're setting the shared default every
-other station follows.</li>
+(Bass, Mid, Treble sliders, -12 to +12 dB each, freely adjustable), a
+compressor ("Even Out Volume", boosts quiet passages and tames loud
+ones), and two listener options: <strong>Combine channels into
+mono</strong> (both stereo channels blended into one -- with
+single-sided hearing or a single earbud, a station that hard-pans a
+voice to the other channel simply loses it; mono means nothing
+disappears) and <strong>Night mode</strong> (evens loudness in real time
+by lifting quiet passages -- the complement to Even Out Volume taming
+loud ones; ideal for low-volume late-night listening). A "Quick preset"
+combo box (Flat, Bass Boost, Voice Clarity, Podcast, Small Speakers,
+Late Night) sets all three sliders at once as a starting point -- move
+any slider afterward and it becomes Custom. Off by default. On the mpv
+playback engine (the default), changes apply <strong>live, with no
+interruption at all</strong>; on the Windows Media engine they filter
+through FFmpeg (needs Help &gt; Get FFmpeg...) and reconnect on OK --
+instant, since a live stream has no position to lose. The EQ and
+compressor are <strong>remembered per station</strong>: open the dialog
+while a favorite is playing to set that station's own sound; with
+nothing playing (or a non-favorite on), you're setting the shared
+default every other station follows. Mono and Night mode are always
+shared -- they describe your ears and your evening, not a station.</li>
 </ul>
 <h3 id="record-altr">Record (Alt+R)</h3>
 <ul>
@@ -338,15 +416,36 @@ list.</li>
 <li><strong>Recordings...</strong> -- everything you have recorded,
 live. See "The Recordings list" below.</li>
 <li><strong>Recording Settings...</strong> -- format (MP3, OGG, FLAC,
-WAV), bitrate, destination folder, filename pattern, a maximum-length
-safety cap, the <strong>If the connection drops</strong> section
-(reconnect on/off, how many attempts, and how many seconds between
-them), and <strong>Apply Sound Enhancements to recordings</strong> --
-off by default, so recordings stay an unfiltered archival copy even with
-Sound Enhancements on for live listening; turn it on to record the
-filtered (EQ/compressor) audio instead, for every recording method
-(Record Now, Record Station, and scheduled recordings alike).</li>
+WAV, or <strong>Raw stream</strong> -- see below), bitrate, destination
+folder, filename pattern, a maximum-length safety cap, the <strong>If
+the connection drops</strong> section (reconnect on/off, how many
+attempts, and how many seconds between them), and <strong>Apply Sound
+Enhancements to recordings</strong> -- off by default, so recordings
+stay an unfiltered archival copy even with Sound Enhancements on for
+live listening; turn it on to record the filtered (EQ/compressor) audio
+instead, for every recording method (Record Now, Record Station, and
+scheduled recordings alike).</li>
 </ul>
+<h3 id="raw-stream-recording-lossless-capture">Raw stream recording
+(lossless capture)</h3>
+<p>The <strong>Raw stream -- exactly as sent, no re-encoding
+(lossless)</strong> format in Recording Settings saves a recording that
+is bit-for-bit identical to what the station broadcasts. The
+MP3/OGG/FLAC/WAV formats decode the incoming audio and re-encode it to
+your chosen format; the raw option skips all of that and copies the
+station's own audio packets straight to disk, untouched. Choose it when
+you want the cleanest possible source to edit or convert yourself, with
+no quality lost to a second encoding.</p>
+<p>Quill Radio picks the file type for you from the stream's own format:
+an MP3 stream is saved as a <code>.mp3</code> file, AAC as
+<code>.aac</code>, Ogg Vorbis as <code>.ogg</code>, Opus as
+<code>.opus</code>, FLAC as <code>.flac</code>. Anything unusual is
+saved into a Matroska <code>.mka</code> file, a container that holds any
+kind of audio losslessly and opens in players like VLC. Because nothing
+is being re-encoded, the Bitrate setting and Apply Sound Enhancements
+have no effect on a raw recording and are simply ignored. If a recording
+is interrupted and continues into a "(part 2)" file, that part keeps the
+same file type as the recording it continues.</p>
 <h3 id="help-alth">Help (Alt+H)</h3>
 <ul>
 <li><strong>Command Palette...</strong> (Ctrl+Shift+P) -- every Quill
@@ -445,23 +544,38 @@ QUILL's radio; the wake-up timer you set in QUILL fires here.
 Uninstalling Quill Radio never deletes that shared data.</p>
 <h2 id="dependencies-honestly-stated">Dependencies, honestly stated</h2>
 <ul>
-<li><strong>Playback</strong> uses the Windows Media Player engine built
-into Windows -- nothing to install.</li>
-<li><strong>Recording</strong>, <strong>Sound Enhancements</strong>, and
-(when "Apply Sound Enhancements to recordings" is on) recording's own
-filtering all use <strong>ffmpeg</strong>, which the installer bundles
-at <code>tools\ffmpeg</code> inside the install folder. Nothing
-downloads at runtime. Sound Enhancements plays through a small local
-relay (ffmpeg filters the stream, a loopback-only web server on your own
-machine hands the filtered audio to the player) -- nothing about it is
-reachable off your computer.</li>
+<li><strong>Playback</strong> uses the bundled <strong>mpv</strong>
+engine (<code>tools\mpv</code> inside the install folder -- license
+texts and source note ship right next to it) with the Windows Media
+Player engine built into Windows as automatic fallback and as the
+"classic" choice in Preferences. Nothing to install, nothing downloads
+at runtime. Between the two engines, effectively every stream format in
+real-world use plays: <strong>MP3, AAC and HE-AAC (AAC+), Ogg Vorbis,
+Opus, FLAC streams, and HLS (m3u8)</strong> -- and a station one engine
+can't open is quietly retried on the other before you ever hear an
+error.</li>
+<li><strong>Recording</strong>, <strong>Sound Enhancements</strong> on
+the classic engine, and (when "Apply Sound Enhancements to recordings"
+is on) recording's own filtering all use <strong>ffmpeg</strong>, which
+the installer bundles at <code>tools\ffmpeg</code> inside the install
+folder. Nothing downloads at runtime. On the classic engine, Sound
+Enhancements plays through a small local relay (ffmpeg filters the
+stream, a loopback-only web server on your own machine hands the
+filtered audio to the player) -- nothing about it is reachable off your
+computer; on the mpv engine the same filters run inside the player
+itself, no relay at all.</li>
 <li><strong>Station search</strong> talks to the community
 <strong>RadioBrowser</strong> directory and the free, keyless
 <strong>SomaFM</strong> directory, blended into one results list;
-<strong>Find Streams</strong> fetches only the one page you type;
-<strong>What's Playing</strong> reads metadata from the stream you are
-already playing. No other network calls exist, and every one of them is
-inventoried in QUILL's network-egress audit.</li>
+<strong>Find Streams</strong> fetches only the one page you type
+(following its "Listen Live" link one level and, if it's a
+Triton/StreamTheWorld player, one lookup to the station provider's own
+public address service); <strong>stream recovery</strong> does the same
+lookups against a failing station's own website only when a stream won't
+play (and only if you leave the setting on); <strong>What's
+Playing</strong> reads metadata from the stream you are already playing.
+No other network calls exist, and every one of them is inventoried in
+QUILL's network-egress audit.</li>
 <li>The <strong>ACB Media</strong> directory is bundled -- no network
 needed to browse it.</li>
 </ul>
@@ -489,6 +603,18 @@ needed to browse it.</li>
 <tr>
 <td>Volume up / down</td>
 <td>Ctrl+Up / Ctrl+Down</td>
+</tr>
+<tr>
+<td>Volume Boost</td>
+<td>Ctrl+Shift+B</td>
+</tr>
+<tr>
+<td>Rewind / Forward 30 seconds</td>
+<td>Ctrl+Shift+Left / Ctrl+Shift+Right</td>
+</tr>
+<tr>
+<td>Back to Live</td>
+<td>Ctrl+Shift+L</td>
 </tr>
 <tr>
 <td>What's Playing?</td>
@@ -547,7 +673,10 @@ from QUILL's keymap, so nothing here collides with editor shortcuts.</p>
 <li><strong>A station will not play.</strong> Streams move. If the
 station came from the directory, Quill Radio automatically fetches its
 current address and retries once; if it still fails, search for it again
-in Browse Stations, or re-add it as a custom station.</li>
+in Browse Stations, or re-add it as a custom station. (Format problems
+are largely history as of 1.1.0: the two engines together play MP3,
+AAC/HE-AAC, Ogg Vorbis, Opus, FLAC, and HLS, and a stream one engine
+can't open is retried on the other automatically.)</li>
 <li><strong>No sound but the app says playing.</strong> Check Mute
 (Ctrl+M), the per-station volume (Ctrl+Up), and the Windows volume mixer
 entry for Quill Radio.</li>
@@ -562,6 +691,15 @@ time stays silent until the next occurrence.</li>
 <li><strong>The tray icon is gone.</strong> Check the taskbar overflow
 area, or set Quill Radio to "always show" in Windows taskbar
 settings.</li>
+<li><strong>Rewind, Volume Boost, or the output device "needs the mpv
+playback engine."</strong> Preferences (Ctrl+,) &gt; Playback engine is
+set to Windows Media (classic), or the bundled engine is missing. Set it
+back to Automatic; these features live in the mpv engine.</li>
+<li><strong>Playback sounds different since 1.1.0.</strong> It shouldn't
+-- but if anything about the new engine bothers you, Preferences
+(Ctrl+,) &gt; Playback engine &gt; "Windows Media (classic)" is exactly
+the old behavior. Please report what you heard either way (Help &gt;
+Report a Bug...).</li>
 </ul>
 </body>
 </html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -33,8 +33,8 @@
             <details class="nav-dropdown">
               <summary>Download Quill Radio</summary>
               <ul>
-                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.2.exe">Windows: System Installer</a></li>
-                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.2.zip">Windows: Portable ZIP</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.1.0.exe">Windows: System Installer</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.1.0.zip">Windows: Portable ZIP</a></li>
                 <li><a href="/radio.html">About Quill Radio</a></li>
               </ul>
             </details>
@@ -98,8 +98,8 @@
           hardware media-key support - all spoken, all keyboard-first, all free.
         </p>
         <div class="cta">
-          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.2.exe">Download Quill Radio 1.0.2 - Installer</a>
-          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.2.zip">Download Quill Radio 1.0.2 - Portable</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.1.0.exe">Download Quill Radio 1.1.0 - Installer</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.1.0.zip">Download Quill Radio 1.1.0 - Portable</a>
           <a class="btn secondary" href="/radio.html">Explore Quill Radio</a>
           <a class="btn secondary" href="/docs/radio-pr.html">Read the press release</a>
         </div>
@@ -1136,8 +1136,8 @@
             <h3><a href="/radio.html">Quill Radio 1.0</a></h3>
             <p>The next generation of the ACB Radio Tuner: every ACB Media stream plus stations from around the world, favorites, recording, and a wake-up timer - free and standalone.</p>
             <ul class="doc-links">
-              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.2.exe">Windows: Installer</a></li>
-              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.2.zip">Windows: Portable ZIP</a></li>
+              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.1.0.exe">Windows: Installer</a></li>
+              <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.1.0.zip">Windows: Portable ZIP</a></li>
               <li><a href="/docs/radio-userguide.html">Quill Radio user guide</a></li>
             </ul>
           </div>
@@ -1168,7 +1168,7 @@
         <h4>Project</h4>
         <ul>
           <li><a href="https://github.com/Community-Access/quill/releases/tag/v0.9.0-beta.2">Download QUILL 0.9.0 Beta 2</a></li>
-          <li><a href="https://github.com/Community-Access/quill-radio/releases/latest">Download Quill Radio 1.0.2</a></li>
+          <li><a href="https://github.com/Community-Access/quill-radio/releases/latest">Download Quill Radio 1.1.0</a></li>
           <li><a href="https://hub.quillforall.org">Quillin Hub</a></li>
           <li><a href="/docs/contributing.html">Contributing</a></li>
           <li><a href="/docs/governance.html">Governance</a></li>

--- a/docs/site/radio.html
+++ b/docs/site/radio.html
@@ -21,8 +21,8 @@
             <details class="nav-dropdown">
               <summary>Download Quill Radio</summary>
               <ul>
-                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.2.exe">Windows: System Installer</a></li>
-                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.2.zip">Windows: Portable ZIP</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.1.0.exe">Windows: System Installer</a></li>
+                <li><a href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.1.0.zip">Windows: Portable ZIP</a></li>
               </ul>
             </details>
           </li>
@@ -50,8 +50,8 @@
           Built the way a screen reader user would build it.
         </p>
         <div class="cta">
-          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.0.2.exe">Download Quill Radio 1.0.2 - Windows Installer</a>
-          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.0.2.zip">Download Quill Radio 1.0.2 - Windows Portable</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Setup-1.1.0.exe">Download Quill Radio 1.1.0 - Windows Installer</a>
+          <a class="btn" href="https://github.com/Community-Access/quill-radio/releases/latest/download/Quill-Radio-Portable-1.1.0.zip">Download Quill Radio 1.1.0 - Windows Portable</a>
           <a class="btn secondary" href="/docs/radio-userguide.html">Read the user guide</a>
           <a class="btn secondary" href="/docs/radio-pr.html">Read the press release</a>
         </div>
@@ -61,13 +61,14 @@
 
     <section class="band" aria-labelledby="whats-new-h">
       <div class="wrap">
-        <h2 id="whats-new-h">What's new in 1.0.2</h2>
+        <h2 id="whats-new-h">What's new in 1.1.0</h2>
         <ul class="intro">
-          <li><strong>Volume that actually stays put.</strong> Starting a stream - or just pausing and resuming one - could silently reset the volume to 100, even overwriting a favorite station's own remembered volume. A favorite now reliably comes back at the volume you left it, and a volume you set before playing something with no memory of its own yet stays exactly where you put it.</li>
-          <li><strong>A real three-band equalizer.</strong> Sound Enhancements gained Bass, Mid, and Treble sliders (-12 to +12 dB each), remembered per station, plus a one-click "Reset to Default."</li>
-          <li><strong>Quieter, more standard dialogs.</strong> Closing the app now asks Exit, Minimize to Tray, or Cancel only when something's actually playing or recording, and Recording Settings, the Wake-Up Timer, and Add Station now say "OK" instead of "Save," matching standard Windows convention.</li>
+          <li><strong>A new heart: the mpv playback engine.</strong> Quill Radio now ships a second audio engine and uses it automatically - and it changes what the radio can do. Every stream format in real-world use now plays (MP3, AAC and AAC+, Ogg Vorbis, Opus, FLAC, HLS), and a station one engine can't open is quietly retried on the other before you ever hear an error. Prefer the old behavior? "Windows Media (classic)" in Preferences is exactly the pre-1.1 engine.</li>
+          <li><strong>Pause and rewind live radio.</strong> A rolling buffer (roughly 45 minutes) means you can pause for the doorbell and resume where you left off, jump back 30 seconds for a missed sentence, and leap straight back to live - each move announcing how far behind live you are.</li>
+          <li><strong>Send the radio to a second sound card.</strong> The classic radio setup: route just the radio to a USB headset or second card while your screen reader stays on the main one. Plus Volume Boost for quiet stations (up to 50% past full), mono downmix and Night mode in Sound Enhancements, and changes that apply live with no reconnect.</li>
+          <li><strong>Record the raw stream, exactly as sent.</strong> A new lossless recording mode copies the station's own audio packets straight to disk - bit-for-bit what the server broadcast, named by its real format - for your own editing or conversion. And stations that used to just fail now heal themselves, digging the working stream out of the station's own website.</li>
         </ul>
-        <p><a href="/docs/radio-release-notes.html">Read the full 1.0.2 release notes</a>.</p>
+        <p><a href="/docs/radio-release-notes.html">Read the full 1.1.0 release notes</a>.</p>
       </div>
     </section>
 


### PR DESCRIPTION
Bumps download links and version text 1.0.2 -> 1.1.0 on the Radio landing page and home page (the old versioned latest/download links broke the moment v1.1.0 became the latest release, so this is time-sensitive), replaces the What's-new band with the 1.1.0 highlights, and refreshes the three bundled radio doc pages from quill-radio's current markdown.

Release is already live: https://github.com/Community-Access/quill-radio/releases/tag/v1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)