### PR TITLE
feat(as-trim): guarded imports so QUILL-AS can drop unneeded modules

### DIFF
--- a/quill/core/quillins/model.py
+++ b/quill/core/quillins/model.py
@@ -315,12 +315,13 @@ class FileTypeContribution:
     description: str = ""
 
 
-#: Host-implemented transcription provider "kinds". The host knows how to talk to
-#: each vetted endpoint; a Quillin may only *declare* a provider of a known kind,
-#: so a manifest can never point the host at an arbitrary URL. Add a new kind here
-#: (and a host adapter in ``quill/core/speech/quillin_providers.py``) only after it
-#: is vetted into the network-egress audit.
-TRANSCRIPTION_PROVIDER_KINDS: tuple[str, ...] = ("openai_whisper", "groq", "elevenlabs")
+#: Host-implemented transcription provider "kinds". The canonical definition lives
+#: in ``quill.core.speech.cloud_transcribers`` (the host module present in both QUILL
+#: and the standalone Audio Studio, which ships without Quillins); re-exported here
+#: so existing Quillin validation imports keep working unchanged.
+from quill.core.speech.cloud_transcribers import (  # noqa: E402,F401 - re-export for Quillin validation
+    TRANSCRIPTION_PROVIDER_KINDS,
+)
 
 
 @dataclass(frozen=True, slots=True)

--- a/quill/core/speech/cloud_transcribers.py
+++ b/quill/core/speech/cloud_transcribers.py
@@ -61,6 +61,16 @@ class RestSpec:
     max_file_mb: float = 25.0
 
 
+#: Host-implemented transcription provider "kinds". The host knows how to talk to
+#: each vetted endpoint; a Quillin may only *declare* a provider of a known kind,
+#: so a manifest can never point the host at an arbitrary URL. Add a new kind here
+#: (and a host adapter in ``quill/core/speech/quillin_providers.py``) only after it
+#: is vetted into the network-egress audit. Lives in this host module (not in
+#: ``quill.core.quillins``) so the standalone Audio Studio, which ships without
+#: Quillins, still has the canonical list; ``quill.core.quillins.model`` re-exports
+#: it for back-compat with QUILL's Quillin validation.
+TRANSCRIPTION_PROVIDER_KINDS: tuple[str, ...] = ("openai_whisper", "groq", "elevenlabs")
+
 #: Vetted synchronous-REST cloud kinds. Hosts here are reflected in the egress audit.
 CLOUD_REST_SPECS: dict[str, RestSpec] = {
     "groq": RestSpec(

--- a/quill/core/speech/quillin_providers.py
+++ b/quill/core/speech/quillin_providers.py
@@ -21,7 +21,10 @@ import logging
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from quill.core.quillins.model import TranscriptionProviderContribution
+try:
+    from quill.core.quillins.model import TranscriptionProviderContribution
+except ImportError:  # Quillins absent (standalone Audio Studio): no Quillin-contributed providers.
+    TranscriptionProviderContribution = None  # type: ignore[assignment,misc]
 
 from .provider import (
     InstalledSpeechModel,

--- a/quill/core/speech/service.py
+++ b/quill/core/speech/service.py
@@ -109,8 +109,10 @@ def _size_text(mb: int) -> str:
 
 def detect_has_gpu() -> bool:
     """True when a CUDA GPU is present (reuses the BITS Whisperer probe, wx-free)."""
-    from quill.core.bw_speech import has_nvidia_gpu
-
+    try:
+        from quill.core.bw_speech import has_nvidia_gpu
+    except ImportError:  # bw_speech absent (standalone Audio Studio): no CUDA probe.
+        return False
     return has_nvidia_gpu()
 
 
@@ -188,8 +190,10 @@ def required_ram_gb(size_mb: int) -> int:
 
 def detect_total_ram_gb() -> float:
     """Total physical RAM in GB (reuses the BITS Whisperer detector, wx-free)."""
-    from quill.core.bw_speech import total_ram_gb
-
+    try:
+        from quill.core.bw_speech import total_ram_gb
+    except ImportError:  # bw_speech absent (standalone Audio Studio): unknown RAM.
+        return 0.0
     return total_ram_gb()
 
 

--- a/tests/unit/core/speech/test_cloud_transcribers.py
+++ b/tests/unit/core/speech/test_cloud_transcribers.py
@@ -7,8 +7,8 @@ from urllib.error import HTTPError
 
 import pytest
 
-from quill.core.quillins.model import TRANSCRIPTION_PROVIDER_KINDS
 from quill.core.speech import cloud_transcribers as ct
+from quill.core.speech.cloud_transcribers import TRANSCRIPTION_PROVIDER_KINDS
 
 
 class _FakeResponse:

--- a/tests/unit/core/speech/test_quillin_providers.py
+++ b/tests/unit/core/speech/test_quillin_providers.py
@@ -6,6 +6,13 @@ from pathlib import Path
 
 import pytest
 
+# These tests build real TranscriptionProviderContribution dataclass instances
+# from quill.core.quillins.model and exercise the Quillin provider wiring, so they
+# require Quillins. The standalone Audio Studio ships without Quillins, where the
+# host adapter module still imports (its type reference is guarded) but there is no
+# contribution dataclass to construct.
+pytest.importorskip("quill.core.quillins")
+
 from quill.core.quillins.model import TranscriptionProviderContribution
 from quill.core.speech import quillin_providers as qp
 from quill.core.speech.provider import SpeechError, TranscriptionRequest

--- a/tests/unit/core/test_audio_studio_round3.py
+++ b/tests/unit/core/test_audio_studio_round3.py
@@ -76,7 +76,13 @@ def test_keymap_pack_profiles_parse_and_include_batch_export() -> None:
     a profile. Empty string in profile_minimal is correct — the minimal
     pack has no Audio Studio entry by design.
     """
-    pack_dir = Path("quill/core/keymap")
+    # Resolve the keymap pack dir from the imported keymap module: the profiles
+    # live in a sibling data directory named ``keymap`` next to ``keymap.py`` (it
+    # is a data dir, not a package). Works in QUILL (quill.core.keymap) and the
+    # vendored standalone (quillas.core.keymap) alike.
+    import quill.core.keymap as _keymap_pkg
+
+    pack_dir = Path(_keymap_pkg.__file__).resolve().parent / "keymap"
     profiles = ("profile_default.json", "profile_minimal.json", "profile_sr_friendly.json")
     seen: dict[str, str] = {}
     for name in profiles:


### PR DESCRIPTION
## What

Phase 1 of the Audio Studio optimization (see `docs/superpowers/specs/2026-07-17-audio-studio-optimization-design.md`). Adds guarded imports in `quill/` so the standalone QUILL-AS can ship a smaller dependency closure (no Quillins, braille, pandoc, glow, math, bw_speech, ...) without changing embedded QUILL behavior. The guards are pure no-ops when the modules are present (i.e. always, in QUILL).

## Changes

- `core/speech/quillin_providers.py`: guarded top-level `TranscriptionProviderContribution` import (falls back to `None` when Quillins absent).
- `core/speech/cloud_transcribers.py`: canonical `TRANSCRIPTION_PROVIDER_KINDS` constant (lives in the host module present in both QUILL and the standalone).
- `core/quillins/model.py`: re-exports `TRANSCRIPTION_PROVIDER_KINDS` for back-compat with Quillin validation.
- `core/speech/service.py`: guarded `bw_speech` imports in `detect_has_gpu` / `detect_total_ram_gb` (fallback `False` / `0.0`).
- Tests updated to import the canonical constant and `importorskip` the Quillin test.

## Verification

- `ruff check` clean on changed files; `mypy quill/core quill/io` clean (565 files).
- `pytest tests/unit/core/ -q`: 6118 passed, 22 skipped (guards are no-ops with modules present).
- QUILL-AS standalone suite (separate repo, vendored from this): 888 passed, 2 skipped with these guards + the trimmed closure.

Merged via admin bypass per request; Accessibility CI is bypassed here, but the change is additive guards with no behavioral shift in QUILL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)