### PR TITLE
fix(radio): Find Streams resolves iHeart/TuneIn player pages to a playable stream (#1087)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- **Find Streams from a Website now resolves iHeart (and TuneIn) station pages to a playable stream instead of returning the page URL (#1087).** Scanning a site that links to an iHeart `/live/...` player page used to hand back the iHeart page URL itself — which does nothing when you press play — because `/live` is a stream-shaped path hint that short-circuited the scanner before it followed the link. iHeart/TuneIn portal page links are now followed one level deep like any "Listen Live" link, so the real stream embedded in the page's inline player (an `stream.revma.ihrhls.com/.../hls.m3u8` HLS URL, for instance) is extracted and offered instead. A station's own `/live/` path on its own domain is unaffected.
+
 - **Audio Studio: shared listening modules + workbench player contract.** The Chapter Workbench player gained a **Mute** button (Ctrl+M in the standalone shell) and public transport (play/pause, stop, next/previous chapter) so a host can drive it. `open_book_in_workbench` now accepts optional `on_player_ready` / `on_finished` / `on_volume` / `on_mute` / `on_closed` callbacks threaded through to `PlayerPanel` — embedded QUILL passes none (unchanged), and the standalone QUILL-AS Audio Studio shell wires them to route media keys, persist per-book volume/mute, stamp Recently Played, and auto-advance a play queue on finish-then-close. The new wx-free stores `quill/core/audio_studio/{book_prefs,history,library,play_queue,sleep_timer}.py` and the shared `library_tree`, `play_queue_dialog`, and `sleep_timer_dialog` UIs live in `quill/` and are vendored into QUILL-AS; each `save_*` site is classified in the persistence audit and every focusable control carries an accessible name. The two Workbench helper dialogs (silence params, ACX result) moved to `chapter_workbench_dialogs.py` to keep `chapter_workbench.py` within the GATE-11 size ratchet.
 
 ## 0.9.0 Beta 3

--- a/quill/core/radio/link_finder.py
+++ b/quill/core/radio/link_finder.py
@@ -80,6 +80,17 @@ _LISTEN_LINK_HINTS = (
 )
 _MAX_LISTEN_LINKS_TO_FOLLOW = 3
 
+#: Known third-party station directories/portals. A *page* URL on one of these
+#: hosts (an iHeart ``/live/<slug>-<id>/`` or a TuneIn ``/radio/<name>-s<id>/``
+#: landing page) is never itself a playable stream -- the real stream is
+#: embedded in the page's inline player. Such links are followed one level deep
+#: (like a "Listen Live" link) so the embedded stream is extracted, instead of
+#: being offered as a bogus stream candidate. Without this, iHeart ``/live``
+#: links were flagged as "stream-shaped" (``/live`` is a path hint) and the
+#: unplayable portal page URL was handed to the user (issue #1087).
+_PORTAL_HOSTS = ("iheart.com", "tunein.com")
+_PORTAL_PAGE_PATH_HINTS = ("/live/", "/radio/", "/podcast/")
+
 
 class LinkFinderError(CodedError):
     """A website scan failed (network, or Safe Mode refusal)."""
@@ -192,6 +203,15 @@ class _StreamLinkParser(HTMLParser):
             lowered = href.lower()
             if lowered.startswith(("mailto:", "javascript:", "#")):
                 return
+            joined = urllib.parse.urljoin(self._base_url, href)
+            if joined.startswith(("https://", "http://")) and _is_portal_page_url(joined):
+                # issue #1087: a known portal/directory page (iHeart /live,
+                # TuneIn /radio) is a player landing page, never a direct
+                # stream. Follow it one level deep so the real embedded stream
+                # URL is pulled from its inline player, instead of offering the
+                # unplayable portal page URL as a candidate.
+                self.listen_urls.append(joined)
+                return
             if lowered.endswith(_STREAM_EXTENSIONS):
                 url = urllib.parse.urljoin(self._base_url, href)
                 self.candidates.append(
@@ -219,6 +239,23 @@ def _looks_like_listen_link(lowered_href: str, label: str) -> bool:
     """
     haystack = f"{label.lower()} {lowered_href}"
     return any(hint in haystack for hint in _LISTEN_LINK_HINTS)
+
+
+def _is_portal_page_url(url: str) -> bool:
+    """True when *url* is a known station-directory portal page (iHeart/TuneIn).
+
+    Such a page is a player/landing page, never a direct stream, so the scanner
+    follows it one level deep to extract the real embedded stream rather than
+    offering the portal page URL itself as a candidate (issue #1087). Matching
+    is host + path scoped: the same ``/live/`` path fragment on a station's own
+    domain is unaffected, only true portal hosts are treated this way.
+    """
+    parsed = urllib.parse.urlsplit(url)
+    host = (parsed.hostname or "").lower()
+    if not any(host == portal or host.endswith("." + portal) for portal in _PORTAL_HOSTS):
+        return False
+    path = parsed.path.lower()
+    return any(hint in path for hint in _PORTAL_PAGE_PATH_HINTS)
 
 
 _FETCH_ERRORS = (urllib.error.URLError, TimeoutError, ssl.SSLError, OSError)

--- a/tests/unit/core/test_radio_link_finder.py
+++ b/tests/unit/core/test_radio_link_finder.py
@@ -352,3 +352,69 @@ def test_http_listen_link_is_followed_not_dropped(monkeypatch: pytest.MonkeyPatc
 
 def test_listenlive_href_matches_even_with_an_image_only_label() -> None:
     assert lf._looks_like_listen_link("http://player.listenlive.co/34461", "")
+
+
+# -- iHeart/TuneIn portal pages: follow, don't offer the page URL (issue #1087) --
+
+
+def test_iheart_live_link_is_followed_not_offered_as_a_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # #1087: delilah.com links to an iHeart /live/ page. Because /live is a
+    # stream-path hint, the scanner used to offer the iHeart *page* URL as a
+    # stream (unplayable) and never fetch it. It must instead follow the portal
+    # page one level deep and surface the real HLS stream embedded in it.
+    home = (
+        "<html><body>"
+        '<a href="https://www.iheart.com/live/delilah-4846/?autoplay=true">Listen</a>'
+        "</body></html>"
+    )
+    # The iHeart page embeds the real stream as an escaped quoted string in an
+    # inline player-config <script> (the shape verified against the live page).
+    iheart = (
+        "<html><body><script>"
+        'var cfg = {"streams":{"secure_hls_stream":'
+        '"https://stream.revma.ihrhls.com/zc4846/hls.m3u8"}};'
+        "</script></body></html>"
+    )
+    pages = {
+        "https://delilah.com": home,
+        "https://www.iheart.com/live/delilah-4846/?autoplay=true": iheart,
+    }
+    monkeypatch.setattr(lf, "_fetch_html", lambda url: pages[url])
+    result = scan_page_for_streams("delilah.com")
+    urls = [c.url for c in result.candidates]
+    assert "https://stream.revma.ihrhls.com/zc4846/hls.m3u8" in urls
+    # The iHeart page URL itself must NOT be offered as a playable stream.
+    assert not any("iheart.com/live" in u for u in urls)
+
+
+def test_tunein_radio_link_is_followed_not_offered_as_a_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A TuneIn /radio/ station page is a portal page too: follow it, don't
+    # offer the tunein.com page URL as a stream candidate.
+    home = (
+        "<html><body>"
+        '<a href="https://tunein.com/radio/BBC-Radio-1-s24939/">BBC Radio 1</a>'
+        "</body></html>"
+    )
+    tunein = '<html><body><audio src="https://cdn.example.com/bbc.mp3"></audio></body></html>'
+    pages = {
+        "https://directory.example.com": home,
+        "https://tunein.com/radio/BBC-Radio-1-s24939/": tunein,
+    }
+    monkeypatch.setattr(lf, "_fetch_html", lambda url: pages[url])
+    result = scan_page_for_streams("directory.example.com")
+    urls = [c.url for c in result.candidates]
+    assert "https://cdn.example.com/bbc.mp3" in urls
+    assert not any("tunein.com/radio" in u for u in urls)
+
+
+def test_is_portal_page_url_matches_hosts_and_paths() -> None:
+    assert lf._is_portal_page_url("https://www.iheart.com/live/delilah-4846/")
+    assert lf._is_portal_page_url("https://tunein.com/radio/BBC-Radio-1-s24939/")
+    # Same path fragment on a station's own domain is NOT a portal page.
+    assert not lf._is_portal_page_url("https://station.example.com/live/stream.mp3")
+    # An iHeart URL that isn't a station page path is not a portal page.
+    assert not lf._is_portal_page_url("https://www.iheart.com/news/")


### PR DESCRIPTION
## What

Fixes #1087. Find Streams from a Website returned an iHeart `/live/...` page URL as a candidate that does nothing when played, and never fetched the page to extract the real stream.

## Root cause

`/live` is in `_STREAM_PATH_HINTS`, so a link to `https://www.iheart.com/live/delilah-4846/` was classified as a "stream-shaped link" candidate. Because candidates were non-empty, `scan_page_for_streams` skipped its "follow Listen links one level deep" branch — so the unplayable portal page URL was offered and the page was never scanned for its embedded stream.

## Fix

Known station-directory portal page links (`iheart.com` `/live/`, `tunein.com` `/radio/`) are now routed to the listen-link follow path instead of being treated as stream candidates. The followed page's existing inline-`<script>` scan then surfaces the real HLS stream (e.g. `stream.revma.ihrhls.com/zc<id>/hls.m3u8`).

Matching is host+path scoped via a new `_is_portal_page_url` helper, so a station's own `/live/` path on its own domain is unaffected.

## Tests

- `test_iheart_live_link_is_followed_not_offered_as_a_stream` — the Delilah case: the revma HLS URL is surfaced and the iHeart page URL is not offered.
- `test_tunein_radio_link_is_followed_not_offered_as_a_stream` — TuneIn `/radio/` portal page followed, not offered.
- `test_is_portal_page_url_matches_hosts_and_paths` — host+path scoping, incl. the negative (station's own `/live/`).

No network in tests (`_fetch_html` monkeypatched, the existing pattern). Full `test_radio_link_finder.py` passes (29). Gates: `ruff check`, `ruff format --check`, `mypy quill/core/radio/link_finder.py` all clean.

## Notes

Radio source lives in QUILL and is vendored into the standalone Quill Radio; this flows there on the next re-vendor. Follow-ups (not in this PR): a dedicated iHeart extractor for ranking, and the iHeart-aggregated Triton-stationId case (Z100-style pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)