### PR TITLE
feat(radio): scheduler 12-hour entry, Edit/Duplicate/Enable, per-entry timezone (quill-radio #7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improved
+
+- **Scheduled radio recordings: 12-hour times, Edit/Duplicate/Enable, and per-entry time zones (quill-radio #7).** The Schedule Recording dialog now accepts a friendly time like `7:30 PM` as well as `19:30`; you can **Edit** a schedule in place, **Duplicate** one as the starting point for a variation (the ACB-convention "same show, several days" case), and **Enable/Disable** a schedule without deleting it — from buttons or the list's context menu. Each schedule can also carry its own **time zone**, so a Pacific listener can pin an Eastern show to Eastern time and it records at the right local moment (DST handled automatically); leaving the zone as "(local time)" keeps the previous behavior. Existing schedules load unchanged (no zone = local). This is radio source shared with the standalone Quill Radio.
+
 - **Audio Studio: shared listening modules + workbench player contract.** The Chapter Workbench player gained a **Mute** button (Ctrl+M in the standalone shell) and public transport (play/pause, stop, next/previous chapter) so a host can drive it. `open_book_in_workbench` now accepts optional `on_player_ready` / `on_finished` / `on_volume` / `on_mute` / `on_closed` callbacks threaded through to `PlayerPanel` — embedded QUILL passes none (unchanged), and the standalone QUILL-AS Audio Studio shell wires them to route media keys, persist per-book volume/mute, stamp Recently Played, and auto-advance a play queue on finish-then-close. The new wx-free stores `quill/core/audio_studio/{book_prefs,history,library,play_queue,sleep_timer}.py` and the shared `library_tree`, `play_queue_dialog`, and `sleep_timer_dialog` UIs live in `quill/` and are vendored into QUILL-AS; each `save_*` site is classified in the persistence audit and every focusable control carries an accessible name. The two Workbench helper dialogs (silence params, ACX result) moved to `chapter_workbench_dialogs.py` to keep `chapter_workbench.py` within the GATE-11 size ratchet.
 
 ## 0.9.0 Beta 3

--- a/quill/core/radio/recording_schedule.py
+++ b/quill/core/radio/recording_schedule.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from quill.core.radio.recording import RadioRecorder, RecordingError, RecordingSettings
 
@@ -42,9 +43,12 @@ class RecordingScheduleEntry:
 
     ``run_at`` is an ISO ``YYYY-MM-DDTHH:MM`` moment for ``"once"``; for
     ``"daily"``/``"weekly"`` only its ``HH:MM`` time-of-day is read. ``weekday``
-    (0=Monday..6=Sunday) only matters for ``"weekly"``. ``last_fired_date``
-    (an ISO date) guards against firing more than once for the same
-    occurrence -- for ``"once"`` it also means "already used."
+    (0=Monday..6=Sunday) only matters for ``"weekly"``. ``timezone`` is an IANA
+    zone name (e.g. ``"America/New_York"``); empty means the machine's local
+    time, and the entry's wall-clock time is interpreted in that zone so a
+    Pacific user can record an Eastern show at the right local moment.
+    ``last_fired_date`` (an ISO date) guards against firing more than once for
+    the same occurrence -- for ``"once"`` it also means "already used."
     """
 
     id: str
@@ -54,6 +58,7 @@ class RecordingScheduleEntry:
     run_at: str
     weekday: int = -1
     duration_minutes: int = 60
+    timezone: str = ""
     enabled: bool = True
     last_fired_date: str = ""
 
@@ -66,6 +71,7 @@ class RecordingScheduleEntry:
             "run_at": self.run_at,
             "weekday": self.weekday,
             "duration_minutes": self.duration_minutes,
+            "timezone": self.timezone,
             "enabled": self.enabled,
             "last_fired_date": self.last_fired_date,
         }
@@ -91,6 +97,7 @@ class RecordingScheduleEntry:
             run_at=run_at,
             weekday=int(weekday) if isinstance(weekday, (int, float)) else -1,
             duration_minutes=int(duration) if isinstance(duration, (int, float)) else 60,
+            timezone=str(data.get("timezone", "")).strip(),
             enabled=bool(data.get("enabled", True)),
             last_fired_date=str(data.get("last_fired_date", "")),
         )
@@ -105,11 +112,39 @@ def _time_of_day(run_at: str) -> tuple[int, int] | None:
     return parsed.hour, parsed.minute
 
 
+def _entry_zone(entry: RecordingScheduleEntry) -> ZoneInfo | None:
+    """The entry's IANA zone, or ``None`` for local time / an unknown name.
+
+    An empty ``timezone`` means "local", and a bad name degrades to local too
+    so a corrupt record can never crash the scheduler thread.
+    """
+    if not entry.timezone:
+        return None
+    try:
+        return ZoneInfo(entry.timezone)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+
+
 def is_due(entry: RecordingScheduleEntry, now: datetime) -> bool:
-    """Pure, testable: would *entry* fire right now?"""
+    """Pure, testable: would *entry* fire right now?
+
+    With ``entry.timezone`` empty (the default) *now* is compared as-is, the
+    original naive-local behavior. With a zone set, the entry's wall-clock time
+    is interpreted in that zone: *now* is converted into the zone (a naive
+    *now* is taken as system-local first), so an ``America/New_York`` 19:00
+    daily entry fires at 16:00 for a Pacific listener.
+    """
     if not entry.enabled:
         return False
-    today = now.date().isoformat()
+    zone = _entry_zone(entry)
+    if zone is not None:
+        now_absolute = now if now.tzinfo is not None else now.astimezone()
+        local_now = now_absolute.astimezone(zone)
+    else:
+        now_absolute = now
+        local_now = now
+    today = local_now.date().isoformat()
     if entry.recurrence == "once":
         if entry.last_fired_date:
             return False
@@ -117,18 +152,34 @@ def is_due(entry: RecordingScheduleEntry, now: datetime) -> bool:
             target = datetime.fromisoformat(entry.run_at)
         except ValueError:
             return False
-        return now >= target
+        if zone is not None and target.tzinfo is None:
+            target = target.replace(tzinfo=zone)
+        return now_absolute >= target
     if entry.last_fired_date == today:
         return False
     time_of_day = _time_of_day(entry.run_at)
     if time_of_day is None:
         return False
     hour, minute = time_of_day
-    if now.hour != hour or now.minute != minute:
+    if local_now.hour != hour or local_now.minute != minute:
         return False
-    if entry.recurrence == "weekly" and now.weekday() != entry.weekday:
+    if entry.recurrence == "weekly" and local_now.weekday() != entry.weekday:
         return False
     return True
+
+
+def _today_in_zone(entry: RecordingScheduleEntry, now: datetime) -> str:
+    """ISO date of *now* in the entry's effective zone (local when unset).
+
+    Used to stamp ``last_fired_date`` in the same frame of reference ``is_due``
+    reads it, so the once-per-day guard is correct for a zoned entry even when
+    the machine's local date differs from the entry-zone date at that instant.
+    """
+    zone = _entry_zone(entry)
+    if zone is not None:
+        now_absolute = now if now.tzinfo is not None else now.astimezone()
+        return now_absolute.astimezone(zone).date().isoformat()
+    return now.date().isoformat()
 
 
 def due_entries(
@@ -202,6 +253,15 @@ class RecordingScheduler:
         self.entries.append(entry)
         save_schedule(self._data_dir, self.entries)
 
+    def update(self, entry: RecordingScheduleEntry) -> bool:
+        """Replace the entry with the same id in place; ``False`` if absent."""
+        for index, existing in enumerate(self.entries):
+            if existing.id == entry.id:
+                self.entries[index] = entry
+                save_schedule(self._data_dir, self.entries)
+                return True
+        return False
+
     def remove(self, entry_id: str) -> bool:
         before = len(self.entries)
         self.entries = [e for e in self.entries if e.id != entry_id]
@@ -229,7 +289,7 @@ class RecordingScheduler:
         except RecordingError as exc:
             error = str(exc)
             logger.warning("Scheduled radio recording %s could not start: %s", entry.id, exc)
-        entry.last_fired_date = now.date().isoformat()
+        entry.last_fired_date = _today_in_zone(entry, now)
         save_schedule(self._data_dir, self.entries)
         self._on_fired(entry, error)
 

--- a/quill/ui/main_frame_radio.py
+++ b/quill/ui/main_frame_radio.py
@@ -227,6 +227,7 @@ class RadioMixin:
             default_stream_url=station.stream_url if station is not None else "",
             on_add=self._radio_scheduler.add,
             on_remove=self._radio_scheduler.remove,
+            on_update=self._radio_scheduler.update,
             favorites=self._radio_favorites,
             announce_cb=self._announce,
         )

--- a/quill/ui/main_frame_radio.py
+++ b/quill/ui/main_frame_radio.py
@@ -220,7 +220,7 @@ class RadioMixin:
     def _radio_open_schedule_recording(self) -> None:
         controller = getattr(self, "_radio_controller", None)
         station = controller.state.station if controller is not None else None
-        dialog = ScheduleRecordingDialog(
+        ScheduleRecordingDialog(
             self.frame,
             entries=self._radio_scheduler.entries,
             default_station_name=station.name if station is not None else "",
@@ -230,8 +230,7 @@ class RadioMixin:
             on_update=self._radio_scheduler.update,
             favorites=self._radio_favorites,
             announce_cb=self._announce,
-        )
-        dialog.show()
+        ).show()
 
     def _on_radio_state_changed(self, state: RadioPlaybackState) -> None:
         from quill.core.settings import save_settings

--- a/quill/ui/radio/schedule_recording_dialog.py
+++ b/quill/ui/radio/schedule_recording_dialog.py
@@ -5,12 +5,20 @@ while QUILL is running (Tools > Media > Internet Radio).
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from datetime import datetime, timedelta
+from zoneinfo import available_timezones
 
 from quill.core.radio.recording_schedule import RecordingScheduleEntry, new_id
+from quill.core.radio.wake_timer import parse_time_of_day
 from quill.ui.dialog_contract import apply_modal_ids
 
 _WEEKDAYS = ("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+
+#: The timezone dropdown: "(local time)" (an empty entry.timezone) followed by
+#: every IANA zone, so a Pacific user can pin an Eastern show to Eastern time.
+_LOCAL_TIME_LABEL = "(local time)"
+_TIMEZONE_CHOICES = (_LOCAL_TIME_LABEL, *sorted(available_timezones()))
 
 
 def _entry_summary(entry: RecordingScheduleEntry) -> str:
@@ -26,8 +34,64 @@ def _entry_summary(entry: RecordingScheduleEntry) -> str:
     else:
         weekday = _WEEKDAYS[entry.weekday] if 0 <= entry.weekday < 7 else "?"
         when = f"every {weekday} at {time_text}"
+    zone = f" {entry.timezone}" if entry.timezone else ""
     state = "" if entry.enabled else " (disabled)"
-    return f"{entry.station_name} -- {when}, {entry.duration_minutes} min{state}"
+    return f"{entry.station_name} -- {when}{zone}, {entry.duration_minutes} min{state}"
+
+
+def build_schedule_entry(
+    *,
+    name: str,
+    url: str,
+    recurrence_index: int,
+    time_text: str,
+    date_text: str,
+    weekday_index: int,
+    timezone_name: str,
+    duration_minutes: int,
+    editing_id: str | None = None,
+    now: datetime | None = None,
+) -> tuple[RecordingScheduleEntry | None, str | None]:
+    """Validate form values and build an entry (wx-free, so it is unit-testable).
+
+    Returns ``(entry, None)`` on success or ``(None, message)`` on the first
+    validation failure. ``time_text`` accepts 12-hour (``7:30 PM``) or 24-hour
+    (``19:30``) via :func:`parse_time_of_day`; ``timezone_name`` empty means
+    local time. A naive-local one-time recording must be in the future; a zoned
+    one-time is judged in its own zone at fire time, so the future guard is
+    skipped for it. ``editing_id`` reuses that id (edit in place) instead of
+    minting a new one.
+    """
+    name = name.strip()
+    url = url.strip()
+    if not name or not url:
+        return None, "A station name and a stream URL are both required."
+    recurrence = ("once", "daily", "weekly")[recurrence_index if recurrence_index >= 0 else 0]
+    normalized_time = parse_time_of_day(time_text)
+    if not normalized_time:
+        return None, "Time must be like 7:30 PM or 19:30."
+    hour, minute = (int(part) for part in normalized_time.split(":", 1))
+    if recurrence == "once":
+        try:
+            run_at = datetime.fromisoformat(f"{date_text.strip()}T{hour:02d}:{minute:02d}:00")
+        except ValueError:
+            return None, "Date must be in YYYY-MM-DD format."
+        if not timezone_name and run_at <= (now or datetime.now()):
+            return None, "Choose a date and time in the future."
+        run_at_text = run_at.isoformat()
+    else:
+        run_at_text = f"2026-01-01T{hour:02d}:{minute:02d}:00"
+    entry = RecordingScheduleEntry(
+        id=editing_id or new_id(),
+        station_name=name,
+        stream_url=url,
+        recurrence=recurrence,  # type: ignore[arg-type]
+        run_at=run_at_text,
+        weekday=weekday_index if recurrence == "weekly" else -1,
+        duration_minutes=duration_minutes,
+        timezone=timezone_name,
+    )
+    return entry, None
 
 
 class ScheduleRecordingDialog:
@@ -42,6 +106,7 @@ class ScheduleRecordingDialog:
         default_stream_url: str = "",
         on_add: Callable[[RecordingScheduleEntry], None],
         on_remove: Callable[[str], bool],
+        on_update: Callable[[RecordingScheduleEntry], bool] | None = None,
         favorites: object | None = None,
         announce_cb: Callable[[str], None] | None = None,
     ) -> None:
@@ -51,8 +116,12 @@ class ScheduleRecordingDialog:
         self._entries = list(entries)
         self._on_add = on_add
         self._on_remove = on_remove
+        self._on_update = on_update or (lambda _entry: False)
         self._favorites = favorites
         self._announce = announce_cb or (lambda _m: None)
+        #: When set, the form is editing this existing entry in place (Save
+        #: Changes) rather than adding a new one.
+        self._editing_id: str | None = None
 
         self.dialog = wx.Dialog(
             parent, title="Schedule Recording", style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER
@@ -67,10 +136,22 @@ class ScheduleRecordingDialog:
         )
         root.Add(self._list, 1, wx.EXPAND | wx.ALL, 10)
 
+        list_btns = wx.BoxSizer(wx.HORIZONTAL)
+        self._edit_btn = wx.Button(self.dialog, label="&Edit")
+        self._edit_btn.SetName("Edit the selected schedule")
+        self._edit_btn.Enable(False)
+        self._duplicate_btn = wx.Button(self.dialog, label="D&uplicate")
+        self._duplicate_btn.SetName("Duplicate the selected schedule for a quick variation")
+        self._duplicate_btn.Enable(False)
+        self._toggle_btn = wx.Button(self.dialog, label="Disab&le")
+        self._toggle_btn.SetName("Enable or disable the selected schedule")
+        self._toggle_btn.Enable(False)
         self._remove_btn = wx.Button(self.dialog, label="&Remove")
         self._remove_btn.SetName("Remove the selected schedule")
         self._remove_btn.Enable(False)
-        root.Add(self._remove_btn, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
+        for btn in (self._edit_btn, self._duplicate_btn, self._toggle_btn, self._remove_btn):
+            list_btns.Add(btn, 0, wx.RIGHT, 6)
+        root.Add(list_btns, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         root.Add(wx.StaticLine(self.dialog), 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
         root.Add(wx.StaticText(self.dialog, label="Add a new schedule"), 0, wx.ALL, 10)
@@ -138,11 +219,22 @@ class ScheduleRecordingDialog:
         grid.Add(self._date_ctrl, 0)
 
         grid.Add(
-            wx.StaticText(self.dialog, label="&Time (24-hour HH:MM):"), 0, wx.ALIGN_CENTER_VERTICAL
+            wx.StaticText(self.dialog, label="&Time (7:30 PM or 19:30):"),
+            0,
+            wx.ALIGN_CENTER_VERTICAL,
         )
         self._time_ctrl = wx.TextCtrl(self.dialog, value=default_date.strftime("%H:%M"))
-        self._time_ctrl.SetName("Time of day, as HH:MM in 24-hour time")
+        self._time_ctrl.SetName("Time of day; accepts 12-hour like 7:30 PM or 24-hour like 19:30")
         grid.Add(self._time_ctrl, 0)
+
+        grid.Add(wx.StaticText(self.dialog, label="Time &zone:"), 0, wx.ALIGN_CENTER_VERTICAL)
+        self._timezone_choice = wx.Choice(self.dialog, choices=list(_TIMEZONE_CHOICES))
+        self._timezone_choice.SetName(
+            "Time zone for this recording; local time by default. Choose a zone to record a "
+            "show in another region at its own local time"
+        )
+        self._timezone_choice.SetSelection(0)
+        grid.Add(self._timezone_choice, 0)
 
         grid.Add(
             wx.StaticText(self.dialog, label="&Duration (minutes):"), 0, wx.ALIGN_CENTER_VERTICAL
@@ -159,9 +251,13 @@ class ScheduleRecordingDialog:
         root.Add(self._status, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
 
         btn_row = wx.BoxSizer(wx.HORIZONTAL)
-        add_btn = wx.Button(self.dialog, label="&Add Schedule")
+        self._add_btn = wx.Button(self.dialog, label="&Add Schedule")
+        self._new_btn = wx.Button(self.dialog, label="Ne&w")
+        self._new_btn.SetName("Clear the form and stop editing")
+        self._new_btn.Enable(False)
         close_btn = wx.Button(self.dialog, wx.ID_CANCEL, "Close")
-        btn_row.Add(add_btn, 0, wx.RIGHT, 6)
+        btn_row.Add(self._add_btn, 0, wx.RIGHT, 6)
+        btn_row.Add(self._new_btn, 0, wx.RIGHT, 6)
         btn_row.AddStretchSpacer()
         btn_row.Add(close_btn)
         root.Add(btn_row, 0, wx.EXPAND | wx.ALL, 10)
@@ -169,24 +265,49 @@ class ScheduleRecordingDialog:
         self.dialog.SetSizer(root)
 
         self._remove_btn.Bind(wx.EVT_BUTTON, self._on_remove_click)
-        add_btn.Bind(wx.EVT_BUTTON, self._on_add_click)
+        self._edit_btn.Bind(wx.EVT_BUTTON, self._on_edit_click)
+        self._duplicate_btn.Bind(wx.EVT_BUTTON, self._on_duplicate_click)
+        self._toggle_btn.Bind(wx.EVT_BUTTON, self._on_toggle_click)
+        self._add_btn.Bind(wx.EVT_BUTTON, self._on_add_click)
+        self._new_btn.Bind(wx.EVT_BUTTON, lambda _e: self._reset_form())
         self._list.Bind(wx.EVT_LISTBOX, lambda _e: self._refresh_remove_button())
         self._list.Bind(wx.EVT_KEY_DOWN, self._on_list_key)
         self._list.Bind(wx.EVT_CONTEXT_MENU, self._on_list_context_menu)
         self._refresh_list()
 
-    def _refresh_remove_button(self) -> None:
-        """The Remove button names its target and dims when there is none."""
+    def _selected_entry(self) -> RecordingScheduleEntry | None:
         index = self._list.GetSelection()
         if 0 <= index < len(self._entries):
-            name = self._entries[index].station_name
+            return self._entries[index]
+        return None
+
+    def _refresh_remove_button(self) -> None:
+        """Name each list action for its target and dim them when there is none."""
+        entry = self._selected_entry()
+        if entry is not None:
+            name = entry.station_name
             self._remove_btn.SetLabel(f"&Remove {name}")
             self._remove_btn.SetName(f"Remove the {name} schedule")
             self._remove_btn.Enable(True)
+            self._edit_btn.Enable(True)
+            self._edit_btn.SetName(f"Edit the {name} schedule")
+            self._duplicate_btn.Enable(True)
+            self._duplicate_btn.SetName(f"Duplicate the {name} schedule")
+            self._toggle_btn.Enable(True)
+            if entry.enabled:
+                self._toggle_btn.SetLabel("Disab&le")
+                self._toggle_btn.SetName(f"Disable the {name} schedule")
+            else:
+                self._toggle_btn.SetLabel("Enab&le")
+                self._toggle_btn.SetName(f"Enable the {name} schedule")
         else:
             self._remove_btn.SetLabel("&Remove")
             self._remove_btn.SetName("Remove the selected schedule")
             self._remove_btn.Enable(False)
+            self._edit_btn.Enable(False)
+            self._duplicate_btn.Enable(False)
+            self._toggle_btn.Enable(False)
+            self._toggle_btn.SetLabel("Disab&le")
 
     def _on_list_key(self, event: object) -> None:
         wx = self._wx
@@ -200,11 +321,22 @@ class ScheduleRecordingDialog:
         index = self._list.GetSelection()
         if not (0 <= index < len(self._entries)):
             return
+        entry = self._entries[index]
         menu = wx.Menu()
+        edit_id = wx.NewIdRef()
+        duplicate_id = wx.NewIdRef()
+        toggle_id = wx.NewIdRef()
         delete_id = wx.NewIdRef()
-        menu.Append(delete_id, f"&Delete {self._entries[index].station_name}\tDelete")
+        menu.Append(edit_id, "&Edit")
+        menu.Append(duplicate_id, "D&uplicate")
+        menu.Append(toggle_id, "Enab&le" if not entry.enabled else "Disab&le")
+        menu.Append(delete_id, f"&Delete {entry.station_name}\tDelete")
+        menu.Bind(wx.EVT_MENU, lambda _e: self._on_edit_click(None), id=edit_id)
+        menu.Bind(wx.EVT_MENU, lambda _e: self._on_duplicate_click(None), id=duplicate_id)
+        menu.Bind(wx.EVT_MENU, lambda _e: self._on_toggle_click(None), id=toggle_id)
         menu.Bind(wx.EVT_MENU, lambda _e: self._on_remove_click(None), id=delete_id)
-        self._context_menu_id_refs = [delete_id]  # pinned while the popup can fire
+        # pinned while the popup can fire
+        self._context_menu_id_refs = [edit_id, duplicate_id, toggle_id, delete_id]
         self._list.PopupMenu(menu)
         menu.Destroy()
 
@@ -218,12 +350,18 @@ class ScheduleRecordingDialog:
         finally:
             self.dialog.Destroy()
 
-    def _refresh_list(self) -> None:
+    def _refresh_list(self, keep_id: str | None = None) -> None:
         self._list.Clear()
         for entry in self._entries:
             self._list.Append(_entry_summary(entry), entry.id)
+        selected = 0
+        if keep_id is not None:
+            for index, entry in enumerate(self._entries):
+                if entry.id == keep_id:
+                    selected = index
+                    break
         if self._entries:
-            self._list.SetSelection(0)
+            self._list.SetSelection(selected)
         self._refresh_remove_button()
 
     def _on_remove_click(self, _event: object) -> None:
@@ -233,51 +371,115 @@ class ScheduleRecordingDialog:
         entry_id = self._list.GetClientData(index)
         if self._on_remove(entry_id):
             self._entries = [e for e in self._entries if e.id != entry_id]
+            if self._editing_id == entry_id:
+                self._reset_form()
             self._refresh_list()
             self._announce("Removed scheduled recording")
 
-    def _on_add_click(self, _event: object) -> None:
-        name = self._name_ctrl.GetValue().strip()
-        url = self._url_ctrl.GetValue().strip()
-        if not name or not url:
-            self._status.SetLabel("A station name and a stream URL are both required.")
-            return
-        recurrence_index = self._recurrence_choice.GetSelection()
-        recurrence = ("once", "daily", "weekly")[recurrence_index if recurrence_index >= 0 else 0]
-        time_text = self._time_ctrl.GetValue().strip()
-        try:
-            hour, minute = (int(part) for part in time_text.split(":", 1))
-            if not (0 <= hour < 24 and 0 <= minute < 60):
-                raise ValueError
-        except ValueError:
-            self._status.SetLabel("Time must be in 24-hour HH:MM format, e.g. 08:00.")
-            return
-        weekday = self._weekday_choice.GetSelection()
-        if recurrence == "once":
-            date_text = self._date_ctrl.GetValue().strip()
-            try:
-                run_at = datetime.fromisoformat(f"{date_text}T{hour:02d}:{minute:02d}:00")
-            except ValueError:
-                self._status.SetLabel("Date must be in YYYY-MM-DD format.")
-                return
-            if run_at <= datetime.now():
-                self._status.SetLabel("Choose a date and time in the future.")
-                return
-            run_at_text = run_at.isoformat()
-        else:
-            run_at_text = f"2026-01-01T{hour:02d}:{minute:02d}:00"
+    def _enter_add_mode(self) -> None:
+        """Leave edit mode: the primary button adds a new schedule again."""
+        self._editing_id = None
+        self._add_btn.SetLabel("&Add Schedule")
+        self._new_btn.Enable(False)
 
-        entry = RecordingScheduleEntry(
-            id=new_id(),
-            station_name=name,
-            stream_url=url,
-            recurrence=recurrence,  # type: ignore[arg-type]
-            run_at=run_at_text,
-            weekday=weekday if recurrence == "weekly" else -1,
-            duration_minutes=self._duration_ctrl.GetValue(),
+    def _reset_form(self) -> None:
+        """Clear the inputs and return to add mode (the New button)."""
+        self._name_ctrl.SetValue("")
+        self._url_ctrl.SetValue("")
+        self._recurrence_choice.SetSelection(0)
+        self._weekday_choice.SetSelection(0)
+        self._timezone_choice.SetSelection(0)
+        self._duration_ctrl.SetValue(60)
+        self._status.SetLabel("")
+        self._enter_add_mode()
+
+    def _load_entry_into_form(self, entry: RecordingScheduleEntry) -> None:
+        """Populate the form fields from an existing entry (edit/duplicate)."""
+        self._name_ctrl.SetValue(entry.station_name)
+        self._url_ctrl.SetValue(entry.stream_url)
+        self._recurrence_choice.SetSelection(("once", "daily", "weekly").index(entry.recurrence))
+        if 0 <= entry.weekday < 7:
+            self._weekday_choice.SetSelection(entry.weekday)
+        try:
+            moment = datetime.fromisoformat(entry.run_at)
+            self._time_ctrl.SetValue(moment.strftime("%H:%M"))
+            if entry.recurrence == "once":
+                self._date_ctrl.SetValue(moment.strftime("%Y-%m-%d"))
+        except ValueError:
+            pass
+        self._duration_ctrl.SetValue(entry.duration_minutes)
+        if entry.timezone and entry.timezone in _TIMEZONE_CHOICES:
+            self._timezone_choice.SetSelection(_TIMEZONE_CHOICES.index(entry.timezone))
+        else:
+            self._timezone_choice.SetSelection(0)
+
+    def _on_edit_click(self, _event: object) -> None:
+        entry = self._selected_entry()
+        if entry is None:
+            return
+        self._load_entry_into_form(entry)
+        self._editing_id = entry.id
+        self._add_btn.SetLabel("&Save Changes")
+        self._new_btn.Enable(True)
+        self._status.SetLabel(
+            f"Editing {entry.station_name}. Change the fields, then choose Save Changes."
         )
+        self._name_ctrl.SetFocus()
+
+    def _on_duplicate_click(self, _event: object) -> None:
+        entry = self._selected_entry()
+        if entry is None:
+            return
+        self._load_entry_into_form(entry)
+        self._enter_add_mode()  # a duplicate is a new entry, not an edit
+        self._name_ctrl.SetValue(f"{entry.station_name} (copy)")
+        self._status.SetLabel("Duplicated. Adjust the fields, then choose Add Schedule.")
+        self._name_ctrl.SetFocus()
+
+    def _on_toggle_click(self, _event: object) -> None:
+        entry = self._selected_entry()
+        if entry is None:
+            return
+        updated = replace(entry, enabled=not entry.enabled)
+        if self._on_update(updated):
+            self._entries = [updated if e.id == updated.id else e for e in self._entries]
+            self._refresh_list(keep_id=updated.id)
+            state = "enabled" if updated.enabled else "disabled"
+            self._announce(f"{updated.station_name} {state}")
+
+    def _build_entry_from_form(self) -> RecordingScheduleEntry | None:
+        """Read the controls, validate via the pure builder, show any error."""
+        tz_index = self._timezone_choice.GetSelection()
+        entry, error = build_schedule_entry(
+            name=self._name_ctrl.GetValue(),
+            url=self._url_ctrl.GetValue(),
+            recurrence_index=self._recurrence_choice.GetSelection(),
+            time_text=self._time_ctrl.GetValue(),
+            date_text=self._date_ctrl.GetValue(),
+            weekday_index=self._weekday_choice.GetSelection(),
+            timezone_name="" if tz_index <= 0 else _TIMEZONE_CHOICES[tz_index],
+            duration_minutes=self._duration_ctrl.GetValue(),
+            editing_id=self._editing_id,
+        )
+        if error:
+            self._status.SetLabel(error)
+            return None
+        return entry
+
+    def _on_add_click(self, _event: object) -> None:
+        entry = self._build_entry_from_form()
+        if entry is None:
+            return
+        if self._editing_id:
+            if self._on_update(entry):
+                self._entries = [entry if e.id == entry.id else e for e in self._entries]
+                self._enter_add_mode()
+                self._refresh_list(keep_id=entry.id)
+                self._status.SetLabel(f"Saved: {_entry_summary(entry)}")
+                self._announce(f"Saved changes to {entry.station_name}")
+            return
         self._on_add(entry)
         self._entries.append(entry)
-        self._refresh_list()
+        self._refresh_list(keep_id=entry.id)
         self._status.SetLabel(f"Added: {_entry_summary(entry)}")
-        self._announce(f"Scheduled recording added for {name}")
+        self._announce(f"Scheduled recording added for {entry.station_name}")

--- a/tests/unit/core/test_radio_recording_schedule.py
+++ b/tests/unit/core/test_radio_recording_schedule.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from quill.core.radio.recording_schedule import (
@@ -14,6 +14,8 @@ from quill.core.radio.recording_schedule import (
     new_id,
     save_schedule,
 )
+
+_UTC = UTC
 
 
 def _entry(**overrides: object) -> RecordingScheduleEntry:
@@ -111,3 +113,92 @@ def test_load_schedule_missing_file_returns_empty(tmp_path: Path) -> None:
 def test_load_schedule_corrupt_file_returns_empty(tmp_path: Path) -> None:
     (tmp_path / "radio_recording_schedule.json").write_text("not json", encoding="utf-8")
     assert load_schedule(tmp_path) == []
+
+
+# -- per-entry timezone (#7): interpret the entry's wall-clock in its own zone --
+
+
+def test_timezone_field_round_trips_and_defaults_to_empty() -> None:
+    assert _entry().timezone == ""
+    entry = _entry(timezone="America/New_York")
+    reloaded = RecordingScheduleEntry.from_dict(entry.to_dict())
+    assert reloaded is not None
+    assert reloaded.timezone == "America/New_York"
+    # A legacy record without the key defaults to "" (local).
+    legacy = RecordingScheduleEntry.from_dict({
+        "id": "e1",
+        "station_name": "X",
+        "stream_url": "https://x",
+        "run_at": "2026-01-01T08:00:00",
+    })
+    assert legacy is not None
+    assert legacy.timezone == ""
+
+
+def test_zoned_daily_fires_at_the_entrys_local_hour_not_the_systems() -> None:
+    # A daily 19:00 America/New_York entry. In July (EDT, UTC-4), 19:00 local
+    # is 23:00 UTC. It must fire at that instant regardless of where the machine
+    # (and the passed `now`) is -- the Pacific-user-records-an-Eastern-show case.
+    entry = _entry(recurrence="daily", run_at="2026-01-01T19:00:00", timezone="America/New_York")
+    assert is_due(entry, datetime(2026, 7, 14, 23, 0, tzinfo=_UTC)) is True  # 19:00 EDT
+    assert is_due(entry, datetime(2026, 7, 14, 22, 0, tzinfo=_UTC)) is False  # 18:00 EDT
+    assert is_due(entry, datetime(2026, 7, 15, 2, 0, tzinfo=_UTC)) is False  # 22:00 EDT
+
+
+def test_zoned_weekly_uses_the_weekday_in_the_entrys_zone() -> None:
+    # 21:00 America/Los_Angeles Tuesday. In July (PDT, UTC-7) that is 04:00 UTC
+    # Wednesday -- the UTC weekday differs from the entry-zone weekday, and the
+    # entry-zone weekday (Tuesday) is what must match.
+    entry = _entry(
+        recurrence="weekly", run_at="2026-01-01T21:00:00", weekday=1, timezone="America/Los_Angeles"
+    )
+    # 2026-07-14 is a Tuesday; 21:00 PDT == 2026-07-15 04:00 UTC.
+    assert is_due(entry, datetime(2026, 7, 15, 4, 0, tzinfo=_UTC)) is True
+    # Same wall clock a week's wrong day: 2026-07-15 21:00 PDT (a Wednesday).
+    assert is_due(entry, datetime(2026, 7, 16, 4, 0, tzinfo=_UTC)) is False
+
+
+def test_zoned_once_compares_the_absolute_instant() -> None:
+    # A one-time 19:00 America/New_York recording fires at the real instant,
+    # 23:00 UTC, not when the machine clock reads 19:00.
+    entry = _entry(recurrence="once", run_at="2026-07-14T19:00:00", timezone="America/New_York")
+    assert is_due(entry, datetime(2026, 7, 14, 23, 0, tzinfo=_UTC)) is True
+    assert is_due(entry, datetime(2026, 7, 14, 22, 59, tzinfo=_UTC)) is False
+
+
+def test_invalid_timezone_degrades_to_local_naive_behavior() -> None:
+    # A bad zone name must not crash the scheduler thread; it degrades to the
+    # naive local comparison (as if timezone were empty).
+    entry = _entry(recurrence="daily", run_at="2026-01-01T08:00:00", timezone="Not/AZone")
+    assert is_due(entry, datetime(2026, 7, 14, 8, 0, 0)) is True
+
+
+def test_scheduler_update_replaces_in_place_and_persists(tmp_path: Path) -> None:
+    from quill.core.radio.recording_schedule import RecordingScheduler
+
+    # A scheduler with a stubbed recorder; we only exercise the store methods.
+    class _NullRecorder:
+        def start(self, **_kwargs: object) -> None:  # pragma: no cover - not called
+            raise AssertionError
+
+    from quill.core.radio.recording import RecordingSettings
+
+    scheduler = RecordingScheduler(
+        data_dir=tmp_path,
+        recorder=_NullRecorder(),  # type: ignore[arg-type]
+        recording_settings=RecordingSettings(),
+    )
+    try:
+        original = _entry(id="k1", station_name="Old", recurrence="daily")
+        scheduler.add(original)
+        edited = _entry(id="k1", station_name="New", recurrence="daily", duration_minutes=30)
+        assert scheduler.update(edited) is True
+        assert [e.station_name for e in scheduler.entries] == ["New"]
+        assert scheduler.update(_entry(id="missing")) is False
+        # Persisted: a fresh load sees the edit.
+        reloaded = load_schedule(tmp_path)
+        assert len(reloaded) == 1
+        assert reloaded[0].station_name == "New"
+        assert reloaded[0].duration_minutes == 30
+    finally:
+        scheduler.shutdown()

--- a/tests/unit/ui/fixtures/accessible_name_inventory.json
+++ b/tests/unit/ui/fixtures/accessible_name_inventory.json
@@ -513,6 +513,7 @@
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.Choice": "named",
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.Choice#2": "named",
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.Choice#3": "named",
+  "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.Choice#4": "named",
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.ListBox": "named",
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.SpinCtrl": "named",
   "quill/ui/radio/schedule_recording_dialog.py::ScheduleRecordingDialog.__init__::wx.TextCtrl": "named",

--- a/tests/unit/ui/test_schedule_recording_builder.py
+++ b/tests/unit/ui/test_schedule_recording_builder.py
@@ -1,0 +1,125 @@
+"""Tests for the wx-free schedule-form builder (12-hour time, timezone, edit id).
+
+The dialog itself is wx; ``build_schedule_entry`` is the pure validation/build
+step it delegates to, so it is testable without constructing any widgets.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from quill.ui.radio.schedule_recording_dialog import build_schedule_entry
+
+# Recurrence dropdown order: Once=0, Daily=1, Weekly=2.
+_ONCE, _DAILY, _WEEKLY = 0, 1, 2
+
+
+def _daily(**overrides: object) -> tuple[object, object]:
+    kwargs = dict(
+        name="WXYZ",
+        url="https://example.com/stream",
+        recurrence_index=_DAILY,
+        time_text="08:00",
+        date_text="",
+        weekday_index=0,
+        timezone_name="",
+        duration_minutes=60,
+    )
+    kwargs.update(overrides)
+    return build_schedule_entry(**kwargs)  # type: ignore[arg-type]
+
+
+def test_accepts_12_hour_time() -> None:
+    entry, error = _daily(time_text="7:30 PM")
+    assert error is None
+    assert entry is not None
+    assert entry.run_at.endswith("T19:30:00")
+
+
+def test_accepts_24_hour_time() -> None:
+    entry, error = _daily(time_text="19:30")
+    assert error is None
+    assert entry is not None
+    assert entry.run_at.endswith("T19:30:00")
+
+
+def test_rejects_garbage_time() -> None:
+    entry, error = _daily(time_text="half past nine")
+    assert entry is None
+    assert error is not None and "7:30 PM" in error
+
+
+def test_requires_name_and_url() -> None:
+    assert _daily(name="")[0] is None
+    assert _daily(url="  ")[0] is None
+
+
+def test_timezone_is_carried_onto_the_entry() -> None:
+    entry, error = _daily(timezone_name="America/New_York")
+    assert error is None
+    assert entry is not None
+    assert entry.timezone == "America/New_York"
+
+
+def test_weekly_records_the_weekday_only_for_weekly() -> None:
+    weekly, _ = _daily(recurrence_index=_WEEKLY, weekday_index=3)
+    assert weekly is not None and weekly.weekday == 3
+    daily, _ = _daily(recurrence_index=_DAILY, weekday_index=3)
+    assert daily is not None and daily.weekday == -1
+
+
+def test_editing_id_is_reused_instead_of_a_new_one() -> None:
+    entry, error = _daily(editing_id="keep-me")
+    assert error is None
+    assert entry is not None and entry.id == "keep-me"
+    fresh, _ = _daily()
+    assert fresh is not None and fresh.id != "keep-me"
+
+
+def test_local_once_must_be_in_the_future() -> None:
+    now = datetime(2026, 7, 14, 12, 0, 0)
+    past, error = build_schedule_entry(
+        name="X",
+        url="https://x",
+        recurrence_index=_ONCE,
+        time_text="08:00",
+        date_text="2026-07-14",
+        weekday_index=0,
+        timezone_name="",
+        duration_minutes=60,
+        now=now,
+    )
+    assert past is None
+    assert error is not None and "future" in error
+    future, error2 = build_schedule_entry(
+        name="X",
+        url="https://x",
+        recurrence_index=_ONCE,
+        time_text="18:00",
+        date_text="2026-07-14",
+        weekday_index=0,
+        timezone_name="",
+        duration_minutes=60,
+        now=now,
+    )
+    assert error2 is None
+    assert future is not None and future.run_at == "2026-07-14T18:00:00"
+
+
+def test_zoned_once_skips_the_naive_future_guard() -> None:
+    # A one-time recording in another zone is judged in that zone at fire time,
+    # so the naive-local "must be in the future" guard does not apply.
+    now = datetime(2026, 7, 14, 12, 0, 0)
+    entry, error = build_schedule_entry(
+        name="X",
+        url="https://x",
+        recurrence_index=_ONCE,
+        time_text="08:00",
+        date_text="2026-07-14",
+        weekday_index=0,
+        timezone_name="America/New_York",
+        duration_minutes=60,
+        now=now,
+    )
+    assert error is None
+    assert entry is not None and entry.timezone == "America/New_York"


### PR DESCRIPTION
## What

Implements quill-radio #7 (an ACB-convention request). Radio source lives in QUILL and is vendored into the standalone Quill Radio, so the fix lands here and flows on re-vendor.

Three improvements to scheduled radio recordings:

1. **12-hour time entry** — the Time field now accepts `7:30 PM` as well as `19:30`, reusing `wake_timer.parse_time_of_day`.
2. **Edit / Duplicate / Enable-Disable** — edit a schedule in place (Save Changes), duplicate one as the basis for a variation (the "same show, several days" convention case), and toggle a schedule on/off without deleting it. Available from buttons and the list context menu.
3. **Per-entry time zone** — each schedule can carry its own IANA zone, so a Pacific listener can pin an Eastern show to Eastern time and it records at the right local instant (DST handled by `zoneinfo`). "(local time)" keeps prior behavior.

## Core (`recording_schedule.py`)

- New `timezone` field on `RecordingScheduleEntry` (`""` = local, back-compat). `is_due` is now zone-aware: the entry's wall-clock time is interpreted in its own zone; an empty zone keeps the exact original naive-local logic; a bad zone name degrades to local (never crashes the scheduler thread).
- `last_fired_date` is stamped in the entry's zone so the once-per-day guard stays correct across a midnight boundary.
- `RecordingScheduler.update()` replaces an entry in place.

## Dialog (`schedule_recording_dialog.py`)

- Time-zone dropdown; 12-hour parsing; Edit/Duplicate/Enable buttons + context-menu items; a "New" button to leave edit mode.
- Form validation extracted into a **wx-free** `build_schedule_entry()` so it is unit-testable without constructing widgets.

`on_update` wired at the call site (`main_frame_radio.py`). `tzdata` is already a dependency.

## Tests

`test_radio_recording_schedule.py`: zone-aware `is_due` (daily fires at the entry's local hour, weekly uses the entry-zone weekday, once compares the absolute instant), invalid-zone degrade, timezone round-trip, `scheduler.update()` persistence. `test_schedule_recording_builder.py`: `build_schedule_entry` — 12/24-hour parse, garbage rejected, timezone carried, weekday only for weekly, edit-id reuse, local-once future guard, zoned-once skips the naive guard. **60 tests pass; ruff + `mypy quill/core/radio/recording_schedule.py` clean.**

The dialog widgets themselves are not exercised by an automated UI test (per the project's no-local-UI-automation stance); the correctness-critical logic is covered by the wx-free core + builder tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)