### PR TITLE
chore(persistence): classify the R1-R4 recording-resume marker

### DIFF
--- a/quill/tools/persistence_audit.py
+++ b/quill/tools/persistence_audit.py
@@ -125,6 +125,10 @@ _REVIEWED_PERSISTENCE: dict[str, str] = {
     "core/watch_queue.py::_save_locked": "cache",
     "core/ai/activity_log.py::append": "cache",
     # --- marker / small state flags ---
+    # Radio's active-recording resume marker (R1-R4): transient state written
+    # when a recording starts and cleared on clean stop; absent by default, and
+    # its loss just means no resume offer on the next launch.
+    "core/radio/recording_resume.py::save_marker": "marker",
     "core/onboarding.py::mark_assistant_onboarding_complete": "marker",
     "core/onboarding.py::mark_glow_onboarding_complete": "marker",
     "core/onboarding.py::mark_onboarding_complete": "marker",


### PR DESCRIPTION
core/radio/recording_resume.py::save_marker was left unclassified by the R1-R4 merge, failing the persistence-audit gate on main. It is a transient resume marker (written on start, cleared on clean stop, absent by default), so it is classified 'marker'. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)