### PR TITLE
fix(settings): don't let an older app drop a newer sibling's settings

### DIFF
--- a/quill/core/settings.py
+++ b/quill/core/settings.py
@@ -1559,7 +1559,9 @@ def load_settings() -> Settings:
     # SET-5: read the nested versioned document, a legacy flat file, or junk.
     from quill.core.settings_migration import (
         from_versioned,
+        is_future_settings_document,
         is_legacy_settings_document,
+        reconcile_unknown_overrides,
         to_versioned,
     )
 
@@ -1570,6 +1572,8 @@ def load_settings() -> Settings:
         serialize=to_versioned,
         is_legacy=is_legacy_settings_document,
         default=Settings,
+        reconcile_unknown=reconcile_unknown_overrides,
+        is_future=is_future_settings_document,
     )
 
 

--- a/quill/core/settings_migration.py
+++ b/quill/core/settings_migration.py
@@ -49,7 +49,7 @@ No ``wx`` imports: this is pure model code. It is imported lazily by
 
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, fields
 from typing import Any
 
 from quill.core.settings import Settings
@@ -217,3 +217,59 @@ def from_versioned(raw: object) -> Settings:
     document yields an all-defaults :class:`Settings`.
     """
     return _safe_from_dict(migrate(raw))
+
+
+def is_future_settings_document(raw: object) -> bool:
+    """Return True when ``raw`` was written by a *newer* schema than this build.
+
+    The shared ``%APPDATA%\\Quill`` store is written by several apps of possibly
+    different vintages. A file stamped with a schema above this build's must not
+    be rewritten (that would downgrade a newer app's data); the loader reads it
+    for in-memory use and leaves it untouched.
+    """
+    if not isinstance(raw, dict):
+        return False
+    version = raw.get("schema_version")
+    return isinstance(version, int) and version > SETTINGS_SCHEMA_VERSION
+
+
+def _known_setting_keys() -> set[str]:
+    # Fields this build recognizes, plus keys it deliberately retires -- neither
+    # is "unknown". Anything else in a same-version file was written by a newer
+    # sibling app and must survive this build's rewrite.
+    return {f.name for f in fields(Settings)} | set(RETIRED_SETTINGS_KEYS)
+
+
+def reconcile_unknown_overrides(
+    raw: dict[str, Any], desired: dict[str, Any]
+) -> dict[str, Any]:
+    """Return ``desired`` with override keys this build does not recognize
+    carried forward from ``raw`` -- verbatim, in their original group.
+
+    Adding a setting *field* does not bump ``schema_version``, so the common
+    multi-vintage case is two same-version apps where one has a field the other
+    lacks. Without this, the older app's rewrite (dropping the unknown field)
+    silently discards the newer app's setting. Retired and known keys are left
+    to the normal delta path; only genuinely unrecognized keys are preserved.
+    """
+    raw_groups = raw.get("groups")
+    if not isinstance(raw_groups, dict):
+        # A legacy flat file has no "groups"; migration owns that shape.
+        return desired
+    known = _known_setting_keys()
+    merged_groups = {
+        name: dict(bucket)
+        for name, bucket in desired.get("groups", {}).items()
+        if isinstance(bucket, dict)
+    }
+    carried = False
+    for group_name, bucket in raw_groups.items():
+        if not isinstance(bucket, dict):
+            continue
+        for key, value in bucket.items():
+            if str(key) not in known:
+                merged_groups.setdefault(str(group_name), {})[str(key)] = value
+                carried = True
+    if not carried:
+        return desired
+    return {**desired, "groups": merged_groups}

--- a/quill/core/versioned_store.py
+++ b/quill/core/versioned_store.py
@@ -53,6 +53,9 @@ def load_with_migration[T](
     serialize: Callable[[T], dict[str, object]],
     is_legacy: Callable[[dict[str, object]], bool],
     default: Callable[[], T],
+    reconcile_unknown: Callable[[dict[str, object], dict[str, object]], dict[str, object]]
+    | None = None,
+    is_future: Callable[[dict[str, object]], bool] | None = None,
 ) -> T:
     """Load ``path`` as a versioned-delta store, migrating + backing up if needed.
 
@@ -68,6 +71,15 @@ def load_with_migration[T](
       is worth backing up.
     * ``default`` builds the all-defaults object for a missing or unreadable
       file -- which is intentionally *not* created on disk on read.
+    * ``reconcile_unknown`` (optional) preserves the multi-vintage shared-store
+      contract: given ``(raw, desired)`` for a *non-legacy* file, it returns
+      ``desired`` augmented with any content this binary does not recognize but
+      a newer sibling app wrote (e.g. a setting field this older build lacks),
+      carried forward verbatim so the rewrite does not silently drop it. Called
+      only when ``is_legacy(raw)`` is False (a real migration is authoritative).
+    * ``is_future`` (optional) reports that ``raw`` was written by a *newer*
+      schema than this binary understands. Such a file is read for in-memory use
+      but never rewritten -- an older app must not downgrade a newer app's file.
 
     When the on-disk form already equals the canonical form, nothing is written
     (no churn). Otherwise the file is rewritten to the canonical form; if it was
@@ -90,9 +102,20 @@ def load_with_migration[T](
         backup_corrupt_file(store_name, path)
         return default()
     obj = parse(raw)
+    if is_future is not None and is_future(raw):
+        # A file written by a newer schema than this build understands: use what
+        # we can in memory, but never rewrite it -- downgrading it would strip
+        # the newer app's data. It stays intact for the app that owns it.
+        return obj
     desired = serialize(obj)
+    legacy = is_legacy(raw)
+    if reconcile_unknown is not None and not legacy:
+        # Same-schema file that a newer sibling app may have extended (a setting
+        # this older build has no field for). Carry those unknown entries forward
+        # so the rewrite preserves them instead of dropping them.
+        desired = reconcile_unknown(raw, desired)
     if raw != desired:
-        if is_legacy(raw):
+        if legacy:
             backup_before_migration(store_name, raw, version_tag=_version_tag(raw))
         try:
             write_json_atomic(path, desired)

--- a/tests/unit/core/test_settings_multivintage.py
+++ b/tests/unit/core/test_settings_multivintage.py
@@ -1,0 +1,141 @@
+"""Multi-vintage shared-store safety for the settings store.
+
+Several apps of possibly different vintages (QUILL, Quill Radio, QUILL Cast,
+Audio Studio) read AND rewrite the same ``%APPDATA%\\Quill\\settings.json``.
+Adding a setting *field* does not bump ``schema_version``, so the load path
+must not let an older build drop a field a newer sibling wrote, and must never
+downgrade a genuinely newer-schema file.
+"""
+
+from __future__ import annotations
+
+import json
+
+from quill.core.settings import Settings
+from quill.core.settings_migration import (
+    RETIRED_SETTINGS_KEYS,
+    SETTINGS_SCHEMA_VERSION,
+    from_versioned,
+    is_future_settings_document,
+    is_legacy_settings_document,
+    reconcile_unknown_overrides,
+    to_versioned,
+)
+from quill.core.versioned_store import load_with_migration
+
+
+def _load(path):
+    return load_with_migration(
+        path,
+        store_name="settings",
+        parse=from_versioned,
+        serialize=to_versioned,
+        is_legacy=is_legacy_settings_document,
+        default=Settings,
+        reconcile_unknown=reconcile_unknown_overrides,
+        is_future=is_future_settings_document,
+    )
+
+
+def _write(path, doc) -> None:
+    path.write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _flat(doc) -> dict:
+    return {k: v for b in doc.get("groups", {}).values() for k, v in b.items()}
+
+
+# --- pure reconcile / is_future logic ---------------------------------------
+
+
+def test_reconcile_preserves_unknown_override():
+    desired = {"schema_version": SETTINGS_SCHEMA_VERSION, "groups": {"general": {}}}
+    raw = {
+        "schema_version": SETTINGS_SCHEMA_VERSION,
+        "groups": {"general": {"future_setting_from_newer_app": 42}},
+    }
+    out = reconcile_unknown_overrides(raw, desired)
+    assert out["groups"]["general"]["future_setting_from_newer_app"] == 42
+
+
+def test_reconcile_no_unknown_returns_desired_unchanged():
+    desired = {"schema_version": SETTINGS_SCHEMA_VERSION, "groups": {"general": {}}}
+    raw = {"schema_version": SETTINGS_SCHEMA_VERSION, "groups": {"general": {}}}
+    assert reconcile_unknown_overrides(raw, desired) is desired
+
+
+def test_reconcile_does_not_preserve_retired_keys():
+    if not RETIRED_SETTINGS_KEYS:
+        return  # nothing retired in this build; property holds vacuously
+    retired = sorted(RETIRED_SETTINGS_KEYS)[0]
+    desired = {"schema_version": SETTINGS_SCHEMA_VERSION, "groups": {}}
+    raw = {"schema_version": SETTINGS_SCHEMA_VERSION, "groups": {"general": {retired: 1}}}
+    out = reconcile_unknown_overrides(raw, desired)
+    assert retired not in _flat(out)
+
+
+def test_is_future_detects_newer_schema():
+    assert is_future_settings_document({"schema_version": SETTINGS_SCHEMA_VERSION + 1})
+    assert not is_future_settings_document({"schema_version": SETTINGS_SCHEMA_VERSION})
+    assert not is_future_settings_document({"schema_version": 1})
+    assert not is_future_settings_document("junk")
+
+
+# --- end-to-end through the loader ------------------------------------------
+
+
+def test_unknown_only_file_preserved_verbatim_no_churn(tmp_path):
+    path = tmp_path / "settings.json"
+    raw = {
+        "schema_version": SETTINGS_SCHEMA_VERSION,
+        "groups": {"_ungrouped": {"future_only_field": "keep-me"}},
+    }
+    _write(path, raw)
+    before = path.read_text(encoding="utf-8")
+    _load(path)
+    after = path.read_text(encoding="utf-8")
+    assert before == after
+    assert _flat(json.loads(after)).get("future_only_field") == "keep-me"
+
+
+def test_unknown_survives_a_rewrite(tmp_path):
+    # Force a rewrite (a retired key that migration strips) and confirm the
+    # unknown newer-app field is still carried forward.
+    if not RETIRED_SETTINGS_KEYS:
+        return
+    retired = sorted(RETIRED_SETTINGS_KEYS)[0]
+    path = tmp_path / "settings.json"
+    raw = {
+        "schema_version": SETTINGS_SCHEMA_VERSION,
+        "groups": {"general": {retired: "stale", "future_only_field": "keep-me"}},
+    }
+    _write(path, raw)
+    _load(path)
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    flat = _flat(on_disk)
+    assert retired not in flat  # migration dropped the retired key
+    assert flat.get("future_only_field") == "keep-me"  # unknown preserved
+
+
+def test_future_schema_file_not_rewritten(tmp_path):
+    path = tmp_path / "settings.json"
+    raw = {
+        "schema_version": SETTINGS_SCHEMA_VERSION + 5,
+        "groups": {"general": {"something_a_future_build_added": 1}},
+    }
+    _write(path, raw)
+    before = path.read_text(encoding="utf-8")
+    _load(path)
+    after = path.read_text(encoding="utf-8")
+    assert before == after  # an older build must never downgrade a newer file
+
+
+def test_legacy_flat_file_still_migrates(tmp_path):
+    # A stamp-less flat legacy document is unaffected by the new preservation
+    # path (it has no "groups"); it migrates to the canonical v2 shape as before.
+    path = tmp_path / "settings.json"
+    _write(path, {"some_legacy_flat_key": "v"})
+    _load(path)
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk.get("schema_version") == SETTINGS_SCHEMA_VERSION
+    assert "groups" in on_disk


### PR DESCRIPTION
Several apps of different vintages (QUILL, Radio, Cast, Audio Studio) read and rewrite the same %APPDATA%\Quill\settings.json. Adding a setting field does not bump schema_version, so an older build that lacked the field parsed the file, omitted the unknown field on serialize, and rewrote it -- silently discarding a newer sibling's setting (no backup, since the schema version matched).

Harden the shared versioned store: `load_with_migration` gains optional `reconcile_unknown` (carry forward, verbatim and in place, any override key this build does not recognize on a same-schema file) and `is_future` (never rewrite a file stamped with a newer schema -- read-only). Settings wires both. Known/retired keys take the normal delta path; an unknown-only file is left byte-for-byte untouched (no churn/ping-pong).

Keymap has the same drop-on-rewrite shape via its own merge path -- separate follow-up.

Tests: tests/unit/core/test_settings_multivintage.py (preserve, no-churn, future-read-only, legacy-unaffected). Full settings/versioned/persistence/size gates green (113 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)