### PR TITLE
fix(audio-studio): make the home library actually populate and persist

### DIFF
--- a/quill/core/audio_studio/library.py
+++ b/quill/core/audio_studio/library.py
@@ -97,6 +97,32 @@ def _find(state: LibraryState, path: str) -> BookEntry | None:
     return None
 
 
+def add_book(
+    state: LibraryState, path: str, title: str = "", *, now: float = 0.0
+) -> BookEntry:
+    """Add ``path`` to the library if absent; return its entry either way.
+
+    This is the library's ingestion point -- the reason the "Your books" tree
+    fills up instead of staying empty. Callers add a book when it is opened in
+    the Workbench, when a wizard export finishes, or when the user acts on an
+    Inbox entry (favorite / move / file into a folder), which promotes that
+    recently-opened file into the permanent library.
+
+    Idempotent and safe to call on every open: an existing book (matched by
+    ``path``) is returned unchanged except that a blank title is backfilled from
+    the supplied one. A new book is stamped with ``added_at = now``; the title
+    falls back to the file stem when none is given.
+    """
+    book = _find(state, path)
+    if book is not None:
+        if title and not book.title:
+            book.title = title
+        return book
+    entry = BookEntry(path=path, title=title or Path(path).stem, added_at=now)
+    state.books.append(entry)
+    return entry
+
+
 def record_play(state: LibraryState, path: str, *, now: float) -> None:
     """Stamp ``last_played_at`` on the matching book; no-op when absent."""
     book = _find(state, path)

--- a/quill/ui/audio_studio/library_tree.py
+++ b/quill/ui/audio_studio/library_tree.py
@@ -26,6 +26,8 @@ from quill.core.audio_studio.library import (
     PINNED_VIEWS,
     BookEntry,
     LibraryState,
+    add_book,
+    view_query,
 )
 from quill.core.audio_studio.library import (
     move_to_folder as _move_to_folder,
@@ -65,7 +67,15 @@ def build_library_tree(
             select_item = item
 
     for view in PINNED_VIEWS:
-        tag(tree.AppendItem(root, view), ("view", view))
+        view_item = tree.AppendItem(root, view)
+        tag(view_item, ("view", view))
+        # Populate the view with the books its query returns. Without this the
+        # four views rendered as permanently empty headers -- the reason the
+        # home library looked broken. Books also appear under their folder
+        # below; a pinned view is a cross-cutting saved search, so a book can
+        # legitimately show under Favorites/Recently Played and under its folder.
+        for book in view_query(state, view):
+            tag(tree.AppendItem(view_item, book.title), ("book", book.path))
 
     folder_items: dict[str, object] = {"": root}
 
@@ -114,6 +124,11 @@ class LibraryTreeActions:
         *,
         announce: Callable[[str], None],
     ) -> bool:
+        # Ingest first: acting on a book (including an Inbox entry that only
+        # lives in the recent-files list) promotes it into the library, so the
+        # toggle actually takes effect and the announcement is truthful. Without
+        # this, favoriting an Inbox book announced success but changed nothing.
+        add_book(store, entry.path, entry.title)
         now_fav = _toggle_favorite(store, entry.path)
         verb = "Added" if now_fav else "Removed"
         prep = "to" if now_fav else "from"
@@ -167,6 +182,9 @@ class LibraryTreeActions:
             if not LibraryTreeActions.new_folder(parent, store, announce=lambda _m: None):
                 return False
             choice = store.folders[-1]
+        # Ingest first (see toggle_favorite): filing an Inbox book into a folder
+        # promotes it into the library so the move actually persists.
+        add_book(store, entry.path, entry.title)
         if choice == TOP_LEVEL_CHOICE:
             _move_to_folder(store, entry.path, "")
             announce(f"Filed {entry.title} at the top level")

--- a/tests/unit/core/audio_studio/test_audio_studio_library.py
+++ b/tests/unit/core/audio_studio/test_audio_studio_library.py
@@ -8,6 +8,7 @@ from quill.core.audio_studio.library import (
     PINNED_VIEWS,
     BookEntry,
     LibraryState,
+    add_book,
     load_library,
     move_to_folder,
     record_play,
@@ -19,6 +20,35 @@ from quill.core.audio_studio.library import (
 
 def _state(books):
     return LibraryState(books=list(books), folders=[])
+
+
+def test_add_book_adds_new_entry() -> None:
+    s = _state([])
+    entry = add_book(s, "/books/a.m4b", "Alpha", now=123.0)
+    assert entry.path == "/books/a.m4b"
+    assert entry.title == "Alpha"
+    assert entry.added_at == 123.0
+    assert [b.path for b in s.books] == ["/books/a.m4b"]
+
+
+def test_add_book_is_idempotent() -> None:
+    s = _state([BookEntry(path="a", title="Alpha", favorite=True)])
+    same = add_book(s, "a", "Alpha")
+    assert same is s.books[0]  # returns the existing entry, not a duplicate
+    assert len(s.books) == 1
+    assert s.books[0].favorite is True  # unchanged
+
+
+def test_add_book_backfills_blank_title() -> None:
+    s = _state([BookEntry(path="a", title="")])
+    add_book(s, "a", "Real Title")
+    assert s.books[0].title == "Real Title"
+
+
+def test_add_book_defaults_title_to_file_stem() -> None:
+    s = _state([])
+    entry = add_book(s, "/x/My Book.m4b")
+    assert entry.title == "My Book"
 
 
 def test_toggle_favorite_round_trips(tmp_path: Path) -> None:

--- a/tests/unit/ui/audio_studio/test_library_tree.py
+++ b/tests/unit/ui/audio_studio/test_library_tree.py
@@ -5,7 +5,23 @@ from __future__ import annotations
 import pytest
 
 from quill.core.audio_studio.library import BookEntry, LibraryState
-from quill.ui.audio_studio.library_tree import build_library_tree
+from quill.ui.audio_studio.library_tree import LibraryTreeActions, build_library_tree
+
+
+def _view_children(tree, view_name):
+    """Return the (kind, key) tags of the books under a named pinned view."""
+    root = tree.GetRootItem()
+    child, cookie = tree.GetFirstChild(root)
+    while child.IsOk():
+        if tree.GetItemData(child) == ("view", view_name):
+            found = []
+            bchild, bcookie = tree.GetFirstChild(child)
+            while bchild.IsOk():
+                found.append(tree.GetItemData(bchild))
+                bchild, bcookie = tree.GetNextChild(child, bcookie)
+            return found
+        child, cookie = tree.GetNextChild(root, cookie)
+    return None
 
 
 @pytest.fixture
@@ -63,6 +79,41 @@ def test_build_library_tree_tags_book_and_view_items(app) -> None:
     assert "view" in kinds
     assert "book" in kinds
     frame.Destroy()
+
+
+def test_pinned_views_are_populated(app) -> None:
+    """Regression: the Favorites/In Progress/Recently Played views must list
+    their books, not render as empty headers."""
+    import wx
+
+    frame = wx.Frame(None)
+    tree = wx.TreeCtrl(frame, style=wx.TR_HAS_BUTTONS | wx.TR_LINES_AT_ROOT)
+    state = LibraryState(
+        books=[
+            BookEntry(path="a", title="Alpha", favorite=True, last_played_at=10.0),
+            BookEntry(path="b", title="Beta"),
+        ],
+        folders=[],
+    )
+    build_library_tree(tree, state)
+    assert ("book", "a") in _view_children(tree, "Favorites")
+    assert ("book", "a") in _view_children(tree, "Recently Played")
+    # A never-played, non-favorite book is in neither of those views.
+    assert ("book", "b") not in _view_children(tree, "Favorites")
+    frame.Destroy()
+
+
+def test_toggle_favorite_ingests_an_unknown_book(app) -> None:
+    """Favoriting a book that only exists as an Inbox entry adds it to the
+    library so the favorite actually persists (and the announcement is true)."""
+    store = LibraryState(books=[], folders=[])
+    inbox_entry = BookEntry(path="/inbox/x.m4b", title="Inbox Book")
+    said: list[str] = []
+    ok = LibraryTreeActions.toggle_favorite(store, inbox_entry, announce=said.append)
+    assert ok
+    assert [b.path for b in store.books] == ["/inbox/x.m4b"]
+    assert store.books[0].favorite is True
+    assert said == ["Added Inbox Book to Favorites"]
 
 
 def test_build_library_tree_preserves_selection(app) -> None:


### PR DESCRIPTION
The Studio home library rendered but never worked: the four pinned views built as empty headers (build_library_tree never called view_query), and nothing ever added a book, so favoriting/filing an Inbox entry announced success while changing nothing.

- `library.add_book`: the ingestion point (idempotent, backfills title, stamps added_at).
- build_library_tree populates each pinned view via view_query.
- toggle_favorite / move_to_folder ingest the book first, so acting on an Inbox entry promotes it and actually persists -- truthful announcements.

Shell-side open/export ingestion and reveal-in-folder are follow-ups. Tests + all audio_studio/persistence/dialog gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)