### PR TITLE
fix(audio-studio): sleep timer end-of-chapter suppresses the delay watcher

### DIFF
--- a/quill/core/audio_studio/sleep_timer.py
+++ b/quill/core/audio_studio/sleep_timer.py
@@ -40,8 +40,14 @@ class SleepTimerSetting:
 
 
 def should_fire(setting: SleepTimerSetting, now: float, *, started_at: float) -> bool:
-    """Pure check: has ``delay_minutes`` elapsed since ``started_at``?"""
-    if not setting.enabled:
+    """Pure check for the *delay* watcher: has ``delay_minutes`` elapsed?
+
+    Returns ``False`` in end-of-chapter mode: that stop is resolved by the host
+    at the player's end-of-track callback, so the elapsed-delay watcher must not
+    also fire -- otherwise it would cut playback off mid-chapter after
+    ``delay_minutes`` regardless of the chapter boundary the user asked for.
+    """
+    if not setting.enabled or setting.end_of_chapter:
         return False
     return (now - started_at) >= setting.delay_minutes * 60
 

--- a/tests/unit/core/audio_studio/test_sleep_timer.py
+++ b/tests/unit/core/audio_studio/test_sleep_timer.py
@@ -25,6 +25,13 @@ def test_disabled_never_fires() -> None:
     assert should_fire(s, now=999.0, started_at=0.0) is False
 
 
+def test_end_of_chapter_mode_suppresses_the_delay_watcher() -> None:
+    # In end-of-chapter mode the host stops at the chapter boundary; the delay
+    # watcher must not also fire and cut playback off mid-chapter.
+    s = SleepTimerSetting(enabled=True, delay_minutes=1.0, end_of_chapter=True)
+    assert should_fire(s, now=999.0, started_at=0.0) is False
+
+
 def test_watcher_calls_on_sleep_once() -> None:
     fired: list[bool] = []
     w = SleepTimerWatcher(on_sleep=lambda: fired.append(True), check_interval=0.05)


### PR DESCRIPTION
The sleep timer's 'stop at end of chapter' option was persisted but ineffective -- should_fire still fired after delay_minutes in end-of-chapter mode, cutting playback mid-chapter. End-of-chapter is a host concern (resolved at the player's end-of-track callback), so should_fire now stands down when end_of_chapter is set. Host-side chapter-boundary stop is wired in the standalone shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)