### PR TITLE
feat(radio): Favorites branch + Play/Stop toggle + folder-favoriting in Browse

### DIFF
--- a/quill/ui/radio/browse_tree_dialog.py
+++ b/quill/ui/radio/browse_tree_dialog.py
@@ -2,14 +2,17 @@
 
 A dedicated, search-free browse experience (its counterpart, Search Stations,
 keeps the old field-based dialog). The whole window is a single ``wx.TreeCtrl``
-whose top-level branches are the sources -- Popular, Weather/NOAA, ACB Media,
-NFB Radio, SomaFM, TuneIn, and the genre catalogs (Community M3U, Xiph). You
-expand a branch to reveal its stations (or its genres/folders, then their
-stations); everything loads lazily on first open, off the UI thread. Enter (or
-the Play button) plays the highlighted station; a rich Shift+F10 / right-click
-context menu offers Play/Stop, Add/Remove Favorite, Copy stream link, and Open
-website. Playback is the shared ``RadioPlayerController`` passed in, so closing
-the window never stops the stream.
+whose top-level branches are the sources -- Favorites (your own saved folders
+and streams, at the top for a quick jump), then Popular, Weather/NOAA, ACB
+Media, NFB Radio, SomaFM, TuneIn, and the genre catalogs (Community M3U, Xiph).
+You expand a branch to reveal its stations (or its genres/folders, then their
+stations); internet sources load lazily on first open, off the UI thread, while
+Favorites is built instantly from local data. Enter (or the Play button) plays
+the highlighted station -- the Play button reads "Stop" while that station is
+the one playing. A rich Shift+F10 / right-click context menu offers Play/Stop,
+Add/Remove Favorite (and "Add all stations to Favorites" on a folder), Copy
+stream link, and Open website. Playback is the shared ``RadioPlayerController``
+passed in, so closing the window never stops the stream.
 """
 
 from __future__ import annotations
@@ -34,6 +37,7 @@ from quill.ui.dialog_contract import apply_modal_ids
 #: expand straight to stations; "genres" sources expand to genre folders; the
 #: "tunein" source expands to TuneIn's own folder tree.
 _SOURCES: tuple[tuple[str, str, Any], ...] = (
+    ("Favorites", "favorites", None),
     ("Popular Stations", "stations", "popular"),
     ("Weather / NOAA", "stations", "weather"),
     ("ACB Media", "stations", "acb"),
@@ -236,6 +240,36 @@ class BrowseTreeDialog:
             if first.IsOk():
                 tree.SelectItem(first)
 
+    def _add_favorites(self, node: Any) -> None:
+        """Build the local Favorites branch: unfiled stations first, then a
+        node per folder holding its stations. Favorite leaves reuse the plain
+        "station" kind, so Play / Add-Remove Favorite / context menu all work
+        unchanged. Local data, so no network fetch."""
+        tree = self._tree
+        if not node.IsOk():
+            return
+        tree.DeleteChildren(node)
+        by_folder: dict[str, list[Any]] = {}
+        for fav in self._favorites.favorites_in_display_order():
+            by_folder.setdefault(fav.folder, []).append(fav)
+        for fav in by_folder.get("", []):  # top-level (unfiled) stations
+            leaf = tree.AppendItem(node, fav.display_label)
+            tree.SetItemData(leaf, {"kind": "station", "station": fav.station})
+        for folder in self._favorites.folders_in_display_order():  # then folders
+            fnode = tree.AppendItem(node, f"{folder}  [folder]")
+            tree.SetItemData(fnode, {"kind": "fav-folder", "folder": folder, "loaded": True})
+            for fav in by_folder.get(folder, []):
+                leaf = tree.AppendItem(fnode, fav.display_label)
+                tree.SetItemData(leaf, {"kind": "station", "station": fav.station})
+        count = tree.GetChildrenCount(node, False)
+        if not count:
+            empty = tree.AppendItem(node, "No favorites yet -- add stations from any source below.")
+            tree.SetItemData(empty, {"kind": "placeholder"})
+        self._announce(f"Favorites: {count} item{'' if count == 1 else 's'}.")
+        first, _cookie = tree.GetFirstChild(node)
+        if first.IsOk():
+            tree.SelectItem(first)
+
     # -- events -----------------------------------------------------------------
 
     def _node_data(self, node: Any) -> dict | None:
@@ -253,6 +287,11 @@ class BrowseTreeDialog:
     def _on_expanding(self, event: Any) -> None:
         node = event.GetItem()
         data = self._node_data(node)
+        if data is not None and data.get("kind") == "favorites":
+            if not data.get("loaded"):
+                data["loaded"] = True
+                self._add_favorites(node)
+            return
         if data is None or data.get("kind") not in _EXPANDABLE:
             return
         if data.get("loaded"):
@@ -285,16 +324,24 @@ class BrowseTreeDialog:
             station = data["station"]
             self._details.SetValue(station.details_text)
             self._play_btn.Enable(True)
+            self._refresh_play_button(station)
             self._favorite_btn.Enable(True)
             self._update_favorite_label(station)
         elif data and data.get("kind") == "tunein-station":
             self._details.SetValue(f"{data['title']}\nTuneIn -- Enter or Play to tune in.")
             self._play_btn.Enable(True)
+            self._play_btn.SetLabel("&Play")
             self._favorite_btn.Enable(False)  # unresolved until it plays
         else:
             self._details.SetValue("")
             self._play_btn.Enable(False)
+            self._play_btn.SetLabel("&Play")
             self._favorite_btn.Enable(False)
+
+    def _refresh_play_button(self, station: RadioStation) -> None:
+        """Label the Play button 'Stop' when the highlighted station is the one
+        currently playing, so it reads as a live toggle (like the main window)."""
+        self._play_btn.SetLabel("&Stop" if self._is_playing(station) else "&Play")
 
     # -- play / favorite --------------------------------------------------------
 
@@ -314,6 +361,7 @@ class BrowseTreeDialog:
         else:
             self._controller.play_station(station)
             self._announce(f"Playing {station.display_name}")
+        self._refresh_play_button(station)
 
     def _play_tunein(self, guide_id: str, title: str) -> None:
         self._details.SetValue(f"Resolving {title}...")
@@ -369,15 +417,50 @@ class BrowseTreeDialog:
         self._update_favorite_label(station)
         self._on_favorites_changed()
 
+    def _favorite_folder(self, node: Any) -> None:
+        """Add every loaded station under a folder to Favorites in one go.
+        Only the stations already loaded into the tree are added; if the folder
+        hasn't been opened yet, ask the user to open it first (so a huge genre
+        isn't fetched-and-favorited blind)."""
+        tree = self._tree
+        if not node.IsOk():
+            return
+        added = 0
+        child, cookie = tree.GetFirstChild(node)
+        loaded_any = False
+        while child.IsOk():
+            data = self._node_data(child)
+            if data is not None and data.get("kind") == "station":
+                loaded_any = True
+                station = data["station"]
+                if not self._favorites.contains(station):
+                    self._favorites.add(station)
+                    added += 1
+            child, cookie = tree.GetNextChild(node, cookie)
+        if not loaded_any:
+            self._announce("Open the folder first to load its stations, then try again.")
+            return
+        if added:
+            self._on_favorites_changed()
+        self._announce(
+            f"Added {added} station{'' if added == 1 else 's'} to Favorites."
+            if added
+            else "Those stations are already in Favorites."
+        )
+
     def _refresh_selected(self) -> None:
         """Re-fetch the highlighted node's source (or its parent source)."""
         node = self._tree.GetSelection()
         data = self._node_data(node)
-        # Walk up to the nearest expandable node and reload it.
-        while data is not None and data.get("kind") not in _EXPANDABLE:
+        # Walk up to the nearest reloadable node (an internet source or the
+        # local Favorites branch) and reload it.
+        while data is not None and data.get("kind") not in (*_EXPANDABLE, "favorites"):
             node = self._tree.GetItemParent(node)
             data = self._node_data(node)
         if data is None:
+            return
+        if data.get("kind") == "favorites":
+            self._add_favorites(node)  # local rebuild, no network
             return
         data["loaded"] = False
         self._tree.DeleteChildren(node)
@@ -411,11 +494,11 @@ class BrowseTreeDialog:
                 entries.append(("Open &Website", lambda: self._open_url(station.homepage)))
         elif kind == "tunein-station":
             entries = [("&Play", self._play_selected)]
-        elif kind in _EXPANDABLE:
-            entries = [
-                ("&Open", lambda: self._tree.Expand(node)),
-                ("&Refresh", self._refresh_selected),
-            ]
+        elif kind in _EXPANDABLE or kind == "fav-folder":
+            entries = [("&Open", lambda: self._tree.Expand(node))]
+            if kind in _EXPANDABLE:
+                entries.append(("&Refresh", self._refresh_selected))
+            entries.append(("Add All Stations to &Favorites", lambda: self._favorite_folder(node)))
         if not entries:
             return
         menu = wx.Menu()

--- a/tests/unit/ui/test_browse_tree_dialog.py
+++ b/tests/unit/ui/test_browse_tree_dialog.py
@@ -48,7 +48,12 @@ class _FakeTree:
 
     def GetFirstChild(self, node):  # noqa: N802
         kids = self.children.get(node, [])
-        return (kids[0][0] if kids else _Node(False), None)
+        return (kids[0][0] if kids else _Node(False), 0)
+
+    def GetNextChild(self, node, cookie):  # noqa: N802
+        kids = self.children.get(node, [])
+        nxt = cookie + 1
+        return (kids[nxt][0] if nxt < len(kids) else _Node(False), nxt)
 
     def SelectItem(self, node):  # noqa: N802
         self._selection = node
@@ -64,7 +69,7 @@ def _dialog() -> Any:
     d._announce = d._announced.append
     d._favorites = RadioFavoritesStore(favorites=[])
     d._details = SimpleNamespace(SetValue=lambda _v: None)
-    d._play_btn = SimpleNamespace(Enable=lambda _v: None)
+    d._play_btn = SimpleNamespace(Enable=lambda _v: None, SetLabel=lambda _l: None)
     d._favorite_btn = SimpleNamespace(Enable=lambda _v: None, SetLabel=lambda _l: None)
     d._on_favorites_changed = lambda: None
     return d
@@ -149,3 +154,51 @@ def test_toggle_favorite_adds_and_removes() -> None:
     assert d._favorites.contains(station)
     d._toggle_favorite()
     assert not d._favorites.contains(station)
+
+
+def test_add_favorites_builds_unfiled_stations_then_folders() -> None:
+    d = _dialog()
+    top = RadioStation(name="Top FM", stream_url="https://x/t", station_uuid="t")
+    filed = RadioStation(name="News One", stream_url="https://x/n", station_uuid="n")
+    d._favorites.add(top)
+    d._favorites.add(filed, folder="News")
+    root = _Node()
+    d._add_favorites(root)
+    kids = d._tree.children[root]
+    labels = [label for _n, label in kids]
+    kinds = [d._tree.GetItemData(n).get("kind") for n, _label in kids]
+    # unfiled station leaf first, then the folder node
+    assert labels[0] == "Top FM" and kinds[0] == "station"
+    assert "News" in labels[1] and kinds[1] == "fav-folder"
+    # the folder holds its station
+    folder_node = kids[1][0]
+    assert _child_data(d, folder_node)[0]["station"].name == "News One"
+
+
+def test_add_favorites_empty_shows_placeholder() -> None:
+    d = _dialog()
+    root = _Node()
+    d._add_favorites(root)
+    assert _child_data(d, root)[0]["kind"] == "placeholder"
+
+
+def test_favorite_folder_adds_all_loaded_stations() -> None:
+    d = _dialog()
+    changed: list = []
+    d._on_favorites_changed = lambda: changed.append(True)
+    folder = _Node()
+    s1 = RadioStation(name="A", stream_url="https://x/a", station_uuid="a")
+    s2 = RadioStation(name="B", stream_url="https://x/b", station_uuid="b")
+    for s in (s1, s2):
+        leaf = d._tree.AppendItem(folder, s.name)
+        d._tree.SetItemData(leaf, {"kind": "station", "station": s})
+    d._favorite_folder(folder)
+    assert d._favorites.contains(s1) and d._favorites.contains(s2)
+    assert changed == [True]
+
+
+def test_favorite_folder_unloaded_asks_to_open() -> None:
+    d = _dialog()
+    folder = _Node()  # no children loaded
+    d._favorite_folder(folder)
+    assert any("Open the folder first" in m for m in d._announced)

--- a/x.md
+++ b/x.md
@@ -1379,4 +1379,180 @@ Process and quality:
 - Timers: the family default of 2 s polling UI timers (recordings
   dialog) should give way to event-driven updates via the existing
   callback contracts; write it into the toolkit's UI guidelines.
+
+## 24. Installer strategy and execution state (2026-07-17, current)
+
+### Lean vs full: decided direction
+
+One embeddable-Python-plus-pip payload, delivered as two installer
+variants - exactly what QUILL already does (standard vs Offline Edition;
+the two portable zips in S:\QUILL prove it).
+
+- Standard installer = LEAN (the default). Ships the runtime + core +
+  ffmpeg/mpv (basic audio must work offline), and DOWNLOADS neural
+  engines (Kokoro, Whisper, Vosk) and optional voices on demand via
+  Voices > Download Optional Components. Small download. This is the
+  answer to "people want a smaller install and download components."
+- Offline installer = FULL (a second, additive artifact). Same payload
+  plus a staged wheelhouse (wheels\kokoro, wheels\faster-whisper,
+  wheels\vosk, wheels\mp3) and the engine binaries, for field/ACB use
+  without reliable internet. QUILL's engine_install.py already looks for
+  {app}\wheels\<name>, so this is staging, not new code.
+- "Lean now, full later" is zero-risk to the now: the offline variant is
+  a superset build that does not change the lean one. Lean ships first;
+  offline improves later.
+
+The hard prerequisite for lean to WORK is that the installer wraps the
+embeddable-Python-plus-pip payload (so on-demand downloads can run). This
+is the crux fix below.
+
+### The Audio Studio installer must switch payloads
+
+Today build_release.ps1 produces BOTH the portable zip and the system
+installer from the PyInstaller freeze (dist\QuillAudioStudio, _internal,
+no pip). That frozen build is the exact artifact the portable script's
+docstring calls "the root cause of the Kokoro/audio breakage" - it cannot
+run on-demand engine installs. So the installed Audio Studio is broken
+for engines, and today's dependency fixes (below) only reach the ZIP.
+
+Fix (the golden installer): restructure so ONE embeddable-Python payload
+(build_studio_portable.py output) feeds both artifacts, mirroring QUILL:
+- portable zip = payload WITH data\ (portable mode);
+- installer = same payload WITHOUT data\ (installed mode -> %APPDATA%\Quill),
+  .iss [Files] Source pointed at dist\QuillAudioStudio-portable\QuillAudioStudio;
+- retire the PyInstaller spec + freeze path for AS;
+- lean by default (exclude the heavy engine/wheel trees), offline variant
+  additive.
+This needs a real build + install + launch to validate, so it is NOT a
+blind edit - do it in a validated build session, not as a "no-risk-now"
+change.
+
+### Per-app installer verdict (payload today)
+
+- QUILL: wraps ..\portable\* (embeddable Python + pip + wheels\ offline
+  cache). GOLDEN - lean install with working + offline downloads.
+- Quill Radio: wraps a PyInstaller freeze; no runtime pip needed
+  (libmpv/ffmpeg staged natively). GOLDEN.
+- Quill Cast: PyInstaller freeze; ffmpeg staged, libmpv intentionally
+  absent (wx.media fallback). GOLDEN.
+- Audio Studio: PyInstaller freeze - NOT golden (needs runtime pip for
+  engines but has none). Fix = switch to the embeddable payload above.
+
+### Done now (safe, no commits yet)
+
+- AS dependency completeness: pyproject.toml gained speech
+  (sounddevice), elevenlabs, feedback (feedback-hub), audio (sound_lib)
+  extras; build_studio_portable.py now bundles base + ui + ssh + speech
+  + feedback + audio (was base + ui only). paramiko pulls cryptography,
+  fixing the PuTTY-key hard-import crash path. Validated by a real build:
+  all 23 requirements install into the bundle and the app imports under
+  the bundle's own Python. Fixes SFTP publish, mic capture / cloud-TTS
+  preview, earcon mixing, and the accessible Report-a-Bug dialog.
+- ElevenLabs is deliberately NOT bundled: the SDK ships auto-generated
+  filenames long enough to exceed the Windows 260-char path limit under
+  the deep bundle tree, which breaks BOTH the ISCC installer compile and
+  the zip step (and even blocks deletion). It is optional cloud TTS that
+  needs a user API key anyway, so it is now on-demand like the neural
+  engines (extra still declared for a future in-app installer). Caught by
+  the validated build, not on a user machine.
+- build_studio_portable.py tool staging now HARD-FAILS if ffmpeg is
+  absent (searches QAS_TOOLS_DIR, repo tools\, then legacy C:\qas) - no
+  more silent shipping of a build with no audio.
+- Vendor tooling hardened: vendor_from_quill.py rewrite() now covers
+  quill.build_info / branding / __main__ / _feedback_token (the class of
+  imports that became perpetual hand-fixed deltas and ImportErrors on
+  re-vendor); PRESERVE now protects the genuinely-behavioral deltas
+  (storage_mode, diagnostics, accessibility_agent, ai/__init__). Verified
+  by direct rewrite() checks. The next re-vendor is now safe.
+
+### Needs a validated build (do in a build session, not blind)
+
+- AS installer payload switch (above) + lean/offline variants.
+- Full build-install-launch of AS to prove SFTP/ElevenLabs/preview/
+  bug-dialog reachability and on-demand engine install in the INSTALLED
+  build.
+- Offline wheelhouse staging for the FULL variant.
+
+### Needs a tested PR into quill (branch; main is protected)
+
+- Data-store hardening (preserve-unknown-fields, rewrite-only-on-legacy,
+  last-writer stamp) - shared-store correctness, must run the GATE suite.
+- AS P1 feature fixes upstream (library ingestion, speaking _set_status,
+  context-menu crash, queue double-advance, sleep-timer end-of-chapter,
+  Reveal, Favorite/Move honesty, resume default).
+- The two shared _show_message_box crashes (chapter_workbench.py:781,
+  publish_dialog.py:610).
+
+### Needs an explicit go (hygiene)
+
+- git init + first commit in S:\qrm (entire repo unversioned).
+- Commit the S:\QUILL-AS working-tree deltas (vendoring fixes + today's
+  dependency/tooling edits), now that PRESERVE protects them.
  
+## 25. Queued: reverse-vendor Audio Studio into quill/apps/ (post-release)
+
+Committed direction (section 17-18, Option D). Do this immediately AFTER the
+Audio Studio 1.0.0 / Quill Radio 2.0.0 build wave ships, not during it. The
+feature code (quill/core/audio_studio, quill/ui/audio_studio, speech, publish)
+already lives in QUILL as the source of truth; quillas/ is only a vendored
+snapshot, so this is a small lift, not a rewrite.
+
+End state: Audio Studio is quill/apps/studio.py (beside radio.py, podcasts.py);
+quill-audio-studio becomes a thin wrapper (launcher + spec + installer + docs)
+pinned to a QUILL tag; the 283-file quillas/ closure and the vendor tooling are
+deleted; the GATE suite covers Audio Studio automatically.
+
+Ordered tasks:
+
+Phase A - land the app in quill/ (one branch, PR to main):
+1. Move quillas/apps/studio.py -> quill/apps/studio.py, rewriting quillas.* ->
+   quill.* imports. Add the entry point quill.apps.studio:main (mirror
+   radio.py/podcasts.py) and register it wherever radio/podcasts are.
+2. Upstream the app-owned deltas that only existed in quillas (so nothing is
+   lost when the closure is deleted). From the vendor design doc "Upstream sync
+   policy" + this session's PRESERVE list:
+   - core/recent.py remove_recent_audiobook_file (already upstreamed - verify).
+   - ui/main_frame_speech_downloads.py _optional_component_allowlist opt-in
+     attribute (MainFrame keeps the full list; the Studio sets the six).
+   - core/storage_mode.py: QuillAudioStudio.exe portable detection.
+   - The lazy-glow shims (core/diagnostics.py, core/accessibility_agent.py) OR,
+     better, land the audio-studio-optimization Phase 1 guarding upstream so the
+     denylist works without per-file deltas (preferred - removes the shims).
+   - core/feedback_token.py bundled-token import (build_info/branding wired to
+     quill's own).
+3. Move the standalone-only tests (tests/unit/ui/test_studio_shell_*,
+   test_no_stray_quill_imports is obsolete once vendoring is gone) into QUILL's
+   suite, rewriting imports. Delete the reachability analyzer.
+4. GATE compliance for the new app: register studio.py's dialogs in the dialog
+   inventory, run accessible_name_audit, persistence_audit (audio_studio save
+   sites already classified as content), and module_size_budget (studio.py is a
+   new tracked file - give it a deliberate entry, ratchet-down thereafter).
+   pytest -q green in QUILL.
+
+Phase B - turn quill-audio-studio into a thin wrapper:
+5. Replace quillas/ with a ~55-line quill_audio_studio/__init__.py that exports
+   QUILL_APP_ROOT/QUILL_PORTABLE and calls quill.apps.studio.main (mirror
+   quill_radio/__init__.py). Delete the vendored closure, scripts/vendor_*.py,
+   scripts/analyze_reachability.py, and the vendored test tree.
+6. pyproject: dependencies = ["quill[ui] @ git+...@<QUILL tag>"] (pinned like
+   Radio/Cast). Keep the audio extras (ssh/speech/feedback/audio) so the
+   wrapper build installs them - or fold them into quill's bundled groups.
+7. Packaging decision (section 3/17 "split by need"): Audio Studio needs the
+   pip-capable embeddable-Python payload for on-demand engines. Either (a) keep
+   build_studio_portable.py + build_release.ps1 in the wrapper (they already
+   produce the right artifact), or (b) hook Audio Studio into QUILL's
+   build_windows_distribution.py (which is the embeddable-Python builder) as a
+   second app target. (a) is less work and already proven this release.
+8. Installer: the quill-audio-studio.iss already wraps the embeddable payload;
+   keep it in the wrapper.
+
+Phase C - validate and cut over:
+9. Build the wrapper (portable + installer, token-embedded), install, launch,
+   exercise: a narrate run, the Workbench, a voice preview + on-demand Kokoro
+   install, SFTP publish reachability, the library, sleep/queue/media keys.
+10. Tag QUILL, pin the wrapper to that tag, ship. Retire the vendoring docs.
+
+Risk notes: this is safe to do because the feature code is unchanged (it is
+already in quill/); the only genuinely new code moving is studio.py + app_shell
+deltas. The main work is GATE registration and the wrapper conversion. Do it on
+a branch with the full QUILL suite + GATE green before merging.


### PR DESCRIPTION
Follow-up Quill Radio 2.1.0 Browse improvements from live feedback.

- **Favorites branch** at the top of the Browse tree: your saved folders and streams, built instantly from local data, for a quick jump. Favorite leaves reuse the plain `station` node kind so play/favorite/context-menu work unchanged.
- **Play button reads "Stop"** while the highlighted station is the one playing (live toggle, matching the context menu and main window).
- **"Add All Stations to Favorites"** on a source/genre/TuneIn folder's context menu (only already-loaded stations; asks you to open the folder first so a huge genre isn't fetched-and-favorited blind).

Tests: 9/9 in tests/unit/ui/test_browse_tree_dialog.py (added 4). ruff clean, budget under cap.

Also lands the pending x.md installer lean-vs-full strategy note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)