### PR TITLE
fix(weather+radio): Add Location/Settings open; labeled fields; force-manual reorder

### DIFF
--- a/quill/apps/radio.py
+++ b/quill/apps/radio.py
@@ -284,22 +284,43 @@ class RadioAppFrame(
         folder_sort = self._radio_history.folder_sort_orders.get(
             favorite.folder, self._radio_history.favorites_sort
         )
+        switched = False
         if folder_sort != "manual":
-            self._announce(
-                "Reordering works in manual order. Set Favorites sort order to "
-                "Unsorted (manual order) in Preferences, or from a folder's Sort menu."
-            )
-            return
+            # Force the point: rather than refuse, bake the current on-screen
+            # order in as the manual order (so nothing visibly jumps) and switch
+            # to manual, then do the move -- pressing the reorder key is a clear
+            # intent to reorder.
+            self._force_favorites_manual_order()
+            switched = True
         from quill.ui.radio.favorites_manager_dialog import move_announcement
 
         if not self._radio_favorites.move(favorite.key, delta=delta):
             self._announce("Already at the edge of its folder.")
+            if switched:
+                self._reload_favorites_tree(keep_key=favorite.key)
             return
         # Speak the new position before the tree reload re-announces the item, so
         # "Moved down, now above X" is what the listener hears.
-        self._announce(move_announcement(self._radio_favorites, favorite.key, delta))
+        prefix = "Switched to manual order. " if switched else ""
+        self._announce(prefix + move_announcement(self._radio_favorites, favorite.key, delta))
         self._save_radio_favorites()
         self._reload_favorites_tree(keep_key=favorite.key)
+
+    def _force_favorites_manual_order(self) -> None:
+        """Commit the current display order as the stored (manual) order and set
+        the sort to manual, so Alt+Shift+Up/Down can reorder without the list
+        first jumping to a different order."""
+        from quill.core.paths import app_data_dir
+        from quill.core.radio import history as radio_history
+
+        ordered = self._radio_favorites.favorites_in_display_order(
+            self._radio_history.favorites_sort, self._radio_history.folder_sort_orders
+        )
+        self._radio_favorites.favorites = list(ordered)
+        self._radio_history.favorites_sort = "manual"
+        self._radio_history.folder_sort_orders = {}
+        radio_history.save_history(app_data_dir(), self._radio_history)
+        self._save_radio_favorites()
 
     def _on_favorites_context_menu(self, _event: object) -> None:
         from quill.ui.radio.player_controller import RadioPlayerState

--- a/quill/ui/weather/add_location_dialog.py
+++ b/quill/ui/weather/add_location_dialog.py
@@ -14,7 +14,7 @@ from typing import Any
 from quill.core.weather import geocoding
 from quill.core.weather import locations as loc_store
 from quill.core.weather.models import WeatherLocation
-from quill.ui.dialog_contract import apply_modal_ids
+from quill.ui.dialog_contract import apply_modal_ids, set_accessible_name
 
 
 class AddLocationDialog:
@@ -51,7 +51,7 @@ class AddLocationDialog:
             10,
         )
         self._query = wx.TextCtrl(self.dialog, style=wx.TE_PROCESS_ENTER)
-        self._query.SetName("Location to add: ZIP, city and state, or coordinates")
+        set_accessible_name(self._query, "Location to add: ZIP, city and state, or coordinates")
         root.Add(self._query, 0, wx.EXPAND | wx.LEFT | wx.RIGHT, 10)
 
         name_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -62,12 +62,12 @@ class AddLocationDialog:
             6,
         )
         self._name = wx.TextCtrl(self.dialog)
-        self._name.SetName("Friendly name for this location, for example Home")
+        set_accessible_name(self._name, "Friendly name for this location, for example Home")
         name_row.Add(self._name, 1, wx.EXPAND)
         root.Add(name_row, 0, wx.EXPAND | wx.ALL, 10)
 
         self._status = wx.StaticText(self.dialog, label="")
-        self._status.SetName("Resolution status")
+        set_accessible_name(self._status, "Resolution status")
         root.Add(self._status, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         btn_row = wx.BoxSizer(wx.HORIZONTAL)
@@ -85,7 +85,13 @@ class AddLocationDialog:
     def show(self) -> bool:
         """Modal; returns True if a location was added."""
         self.dialog.CentreOnParent()
-        apply_modal_ids(self.dialog, ok_id=self._wx.ID_OK, cancel_id=self._wx.ID_CANCEL)
+        apply_modal_ids(
+            self.dialog,
+            affirmative_id=self._wx.ID_OK,
+            affirmative_label="Add",
+            cancel_id=self._wx.ID_CANCEL,
+            cancel_label="Cancel",
+        )
         from quill.ui.dialog_contract import show_modal_dialog
 
         self._query.SetFocus()

--- a/quill/ui/weather/settings_dialog.py
+++ b/quill/ui/weather/settings_dialog.py
@@ -15,7 +15,7 @@ from quill.core.weather.settings import (
     WIND_UNITS,
     WeatherSettings,
 )
-from quill.ui.dialog_contract import apply_modal_ids
+from quill.ui.dialog_contract import apply_modal_ids, set_accessible_name
 
 _SEVERITY_LABELS = {
     "all": "Show all alerts",
@@ -56,13 +56,13 @@ class WeatherSettingsDialog:
         # units
         label("&Temperature unit:")
         self._temp = wx.Choice(self.dialog, choices=["Fahrenheit", "Celsius"])
-        self._temp.SetName("Temperature unit")
+        set_accessible_name(self._temp, "Temperature unit")
         self._temp.SetSelection(TEMPERATURE_UNITS.index(settings.temperature_unit))
         grid.Add(self._temp, 0, wx.EXPAND)
 
         label("&Wind unit:")
         self._wind = wx.Choice(self.dialog, choices=list(WIND_UNITS))
-        self._wind.SetName("Wind speed unit")
+        set_accessible_name(self._wind, "Wind speed unit")
         self._wind.SetSelection(WIND_UNITS.index(settings.wind_unit))
         grid.Add(self._wind, 0, wx.EXPAND)
 
@@ -71,20 +71,20 @@ class WeatherSettingsDialog:
         self._periods = wx.SpinCtrl(
             self.dialog, min=1, max=14, initial=settings.forecast_period_count
         )
-        self._periods.SetName("Number of forecast periods to show")
+        set_accessible_name(self._periods, "Number of forecast periods to show")
         grid.Add(self._periods, 0)
 
         label("Alert &severity to show:")
         self._severity = wx.Choice(
             self.dialog, choices=[_SEVERITY_LABELS[s] for s in SEVERITY_FLOOR]
         )
-        self._severity.SetName("Minimum alert severity to show")
+        set_accessible_name(self._severity, "Minimum alert severity to show")
         self._severity.SetSelection(SEVERITY_FLOOR.index(settings.alert_severity_floor))
         grid.Add(self._severity, 0, wx.EXPAND)
 
         label("&Refresh every (minutes):")
         self._refresh = wx.SpinCtrl(self.dialog, min=1, max=180, initial=settings.refresh_minutes)
-        self._refresh.SetName("Auto-refresh interval in minutes")
+        set_accessible_name(self._refresh, "Auto-refresh interval in minutes")
         grid.Add(self._refresh, 0)
 
         root.Add(grid, 0, wx.EXPAND | wx.ALL, 12)
@@ -128,7 +128,7 @@ class WeatherSettingsDialog:
             12,
         )
         self._muted = wx.TextCtrl(self.dialog, style=wx.TE_MULTILINE)
-        self._muted.SetName("Alert events to hide, one per line")
+        set_accessible_name(self._muted, "Alert events to hide, one per line")
         self._muted.SetValue("\n".join(settings.muted_events))
         self._muted.SetMinSize((-1, 70))
         root.Add(self._muted, 1, wx.EXPAND | wx.ALL, 12)
@@ -153,7 +153,13 @@ class WeatherSettingsDialog:
     def show(self) -> bool:
         """Modal; returns True if settings were saved."""
         self.dialog.CentreOnParent()
-        apply_modal_ids(self.dialog, ok_id=self._wx.ID_OK, cancel_id=self._wx.ID_CANCEL)
+        apply_modal_ids(
+            self.dialog,
+            affirmative_id=self._wx.ID_OK,
+            affirmative_label="Save",
+            cancel_id=self._wx.ID_CANCEL,
+            cancel_label="Cancel",
+        )
         from quill.ui.dialog_contract import show_modal_dialog
 
         try:

--- a/quill/ui/weather/weather_center_dialog.py
+++ b/quill/ui/weather/weather_center_dialog.py
@@ -22,7 +22,7 @@ from quill.core.weather import locations as loc_store
 from quill.core.weather import nws, render
 from quill.core.weather import settings as settings_mod
 from quill.core.weather.models import WeatherLocation, WeatherReport
-from quill.ui.dialog_contract import apply_modal_ids
+from quill.ui.dialog_contract import apply_modal_ids, set_accessible_name
 
 
 def _alert_list_label(alert: Any) -> str:
@@ -96,7 +96,7 @@ class WeatherCenterDialog:
             6,
         )
         self._location_choice = wx.Choice(self.dialog)
-        self._location_choice.SetName("Weather location")
+        set_accessible_name(self._location_choice, "Weather location")
         loc_row.Add(self._location_choice, 1, wx.EXPAND | wx.RIGHT, 6)
         self._refresh_btn = wx.Button(self.dialog, label="&Refresh")
         self._add_btn = wx.Button(self.dialog, label="&Add Location...")
@@ -109,12 +109,12 @@ class WeatherCenterDialog:
         self._alerts_label = wx.StaticText(self.dialog, label="Active &Alerts:")
         root.Add(self._alerts_label, 0, wx.LEFT | wx.RIGHT, 10)
         self._alerts_list = wx.ListBox(self.dialog)
-        self._alerts_list.SetName("Active weather alerts")
+        set_accessible_name(self._alerts_list, "Active weather alerts")
         root.Add(self._alerts_list, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
         self._alert_detail = wx.TextCtrl(
             self.dialog, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP
         )
-        self._alert_detail.SetName("Selected alert, full official text")
+        set_accessible_name(self._alert_detail, "Selected alert, full official text")
         root.Add(self._alert_detail, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         # -- current conditions --
@@ -124,25 +124,25 @@ class WeatherCenterDialog:
         self._current = wx.TextCtrl(
             self.dialog, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP
         )
-        self._current.SetName("Current conditions")
+        set_accessible_name(self._current, "Current conditions")
         self._current.SetMinSize((-1, 48))
         root.Add(self._current, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         # -- forecast --
         root.Add(wx.StaticText(self.dialog, label="&Forecast:"), 0, wx.LEFT | wx.RIGHT, 10)
         self._forecast_list = wx.ListBox(self.dialog)
-        self._forecast_list.SetName("Forecast periods")
+        set_accessible_name(self._forecast_list, "Forecast periods")
         root.Add(self._forecast_list, 1, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
         self._period_detail = wx.TextCtrl(
             self.dialog, style=wx.TE_MULTILINE | wx.TE_READONLY | wx.TE_WORDWRAP
         )
-        self._period_detail.SetName("Selected forecast period, details")
+        set_accessible_name(self._period_detail, "Selected forecast period, details")
         self._period_detail.SetMinSize((-1, 60))
         root.Add(self._period_detail, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
 
         # -- status + close --
         self._status = wx.TextCtrl(self.dialog, style=wx.TE_READONLY)
-        self._status.SetName("Weather source and freshness status")
+        set_accessible_name(self._status, "Weather source and freshness status")
         root.Add(self._status, 0, wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, 10)
         btn_row = wx.BoxSizer(wx.HORIZONTAL)
         btn_row.AddStretchSpacer()

--- a/tests/unit/ui/test_radio_app_close_and_keys.py
+++ b/tests/unit/ui/test_radio_app_close_and_keys.py
@@ -112,6 +112,7 @@ def _move_frame(*, folder_sort: str, moved: bool = True):
         _announce=lambda m: calls.append(f"say:{m}"),
         _save_radio_favorites=lambda: calls.append("save"),
         _reload_favorites_tree=lambda keep_key=None: calls.append(f"reload:{keep_key}"),
+        _force_favorites_manual_order=lambda: calls.append("force-manual"),
     )
     return frame, calls
 
@@ -130,11 +131,42 @@ def test_move_favorite_manual_order_reorders_and_announces(monkeypatch) -> None:
     assert "save" in calls and "reload:k1" in calls
 
 
-def test_move_favorite_blocked_when_not_manual_order() -> None:
+def test_move_favorite_non_manual_forces_manual_then_moves(monkeypatch) -> None:
+    # "Force the point": pressing the reorder key while sorted A-Z switches to
+    # manual order and performs the move, rather than refusing.
+    import quill.ui.radio.favorites_manager_dialog as fm
+
+    monkeypatch.setattr(fm, "move_announcement", lambda store, key, delta: "Moved up, now below Y")
     frame, calls = _move_frame(folder_sort="az")
     RadioAppFrame._move_selected_favorite(frame, -1)  # type: ignore[arg-type]
-    assert not any("store.move" in c for c in calls)  # nothing moved
-    assert any("manual order" in c.lower() for c in calls)  # told how to enable it
+    assert "force-manual" in calls  # switched to manual first
+    assert "store.move(-1)" in calls  # then actually moved
+    assert any("Switched to manual order" in c for c in calls)
+
+
+def test_force_favorites_manual_order_bakes_order_and_persists(monkeypatch) -> None:
+    from quill.core.radio import history as rh
+
+    saved: dict = {}
+    monkeypatch.setattr(
+        rh, "save_history", lambda data_dir, history: saved.setdefault("h", history)
+    )
+    calls: list[str] = []
+    store = SimpleNamespace(
+        favorites_in_display_order=lambda sort, folder_sorts: ["a", "b", "c"],
+        favorites=[],
+    )
+    hist = SimpleNamespace(favorites_sort="az", folder_sort_orders={"News": "az"})
+    frame = SimpleNamespace(
+        _radio_favorites=store,
+        _radio_history=hist,
+        _save_radio_favorites=lambda: calls.append("save"),
+    )
+    RadioAppFrame._force_favorites_manual_order(frame)  # type: ignore[arg-type]
+    assert store.favorites == ["a", "b", "c"]  # display order baked in as manual
+    assert hist.favorites_sort == "manual"
+    assert hist.folder_sort_orders == {}
+    assert saved["h"] is hist and "save" in calls
 
 
 def test_move_favorite_at_edge_announces_and_does_not_reload() -> None:

--- a/tests/unit/ui/weather/test_weather_dialogs.py
+++ b/tests/unit/ui/weather/test_weather_dialogs.py
@@ -121,6 +121,42 @@ def test_add_location_dialog_builds(app, tmp_path) -> None:
     dlg.dialog.Destroy()
 
 
+def test_add_location_show_applies_modal_ids(app, tmp_path, monkeypatch) -> None:
+    # Regression: show() must call apply_modal_ids with valid kwargs
+    # (affirmative_id, not ok_id) -- the old ok_id= raised TypeError so the
+    # dialog never appeared.
+    import quill.ui.dialog_contract as dc
+    from quill.core.weather.locations import WeatherLocationStore
+
+    monkeypatch.setattr(dc, "show_modal_dialog", lambda *a, **k: None)
+    dlg = AddLocationDialog(
+        None,
+        store=WeatherLocationStore(),
+        data_dir=tmp_path,
+        task_manager=_FakeTaskManager(),
+        safe_mode=False,
+    )
+    assert dlg.show() is False  # no exception; nothing added
+
+
+def test_settings_show_applies_modal_ids(app, tmp_path, monkeypatch) -> None:
+    import quill.ui.dialog_contract as dc
+
+    monkeypatch.setattr(dc, "show_modal_dialog", lambda *a, **k: None)
+    dlg = WeatherSettingsDialog(None, settings=WeatherSettings(), data_dir=tmp_path)
+    assert dlg.show() is False  # no exception
+
+
+def test_weather_center_show_applies_modal_ids(app, tmp_path, monkeypatch) -> None:
+    import quill.ui.dialog_contract as dc
+
+    monkeypatch.setattr(dc, "show_modal_dialog", lambda *a, **k: None)
+    dlg = WeatherCenterDialog(
+        None, data_dir=tmp_path, task_manager=_FakeTaskManager(), safe_mode=False
+    )
+    dlg.show()  # no exception (no locations -> no fetch)
+
+
 class _MenuHost:
     def __init__(self, frame, wx_mod) -> None:
         self.frame = frame


### PR DESCRIPTION
Fixes from live testing:
- **Add Location / Settings did not open** -- `show()` passed `ok_id=` to `apply_modal_ids` (kwarg is `affirmative_id`); the TypeError aborted before the window showed. Fixed both; added regression tests that actually drive `show()`.
- **Weather Now read-only fields announced unlabeled** -- `SetName()` isn't the reliable MSAA name for read-only TextCtrls; switched every weather control to `set_accessible_name`.
- **Favorites reorder forces the point** -- Alt+Shift+Up/Down while sorted A-Z now switches to manual order (baking the on-screen order in first) and moves, instead of refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)