### PR TITLE
fix(weather): observation time in the location's local zone

### DIFF
--- a/quill/core/weather/models.py
+++ b/quill/core/weather/models.py
@@ -199,6 +199,7 @@ class WeatherReport:
     office: str = ""
     forecast_zone: str = ""
     county_zone: str = ""
+    time_zone: str = ""  # IANA name, for showing observation times in local time
     retrieved_at: str = ""  # ISO 8601, stamped by the caller (wx-free: no clock here)
     #: Non-fatal notes (e.g. "observation unavailable"); shown in status.
     notes: list[str] = field(default_factory=list)

--- a/quill/core/weather/nws.py
+++ b/quill/core/weather/nws.py
@@ -55,6 +55,7 @@ class PointMetadata:
     county_zone: str
     city: str
     state: str
+    time_zone: str = ""  # IANA name, e.g. "America/Phoenix"
 
 
 # -- unit helpers -------------------------------------------------------------
@@ -129,6 +130,7 @@ def point_from_json(data: object) -> PointMetadata:
             county_zone=str(props.get("county", "")).rsplit("/", 1)[-1],
             city=str(rel.get("city", "")),
             state=str(rel.get("state", "")),
+            time_zone=str(props.get("timeZone", "")),
         )
     except (TypeError, ValueError) as error:
         raise WeatherError("The weather service location metadata was unreadable.") from error
@@ -300,6 +302,7 @@ def fetch_report(
         office=point.office,
         forecast_zone=point.forecast_zone,
         county_zone=point.county_zone,
+        time_zone=point.time_zone,
     )
     if point.city and not location.resolved_name:
         location.resolved_name = f"{point.city}, {point.state}".strip(", ")

--- a/quill/core/weather/render.py
+++ b/quill/core/weather/render.py
@@ -104,36 +104,45 @@ def uv_phrase(index: int | None) -> str:
     return f"The ultraviolet index reaches {index} today, which is {level}."
 
 
-def friendly_datetime(iso: str) -> str:
-    """'2026-07-19T18:30:00-07:00' -> 'July 19 at 6:30 PM' (pure display of the
-    local time the provider already returned; no time-zone math)."""
+_MONTHS = (
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+)
+
+
+def friendly_datetime(iso: str, tz_name: str = "") -> str:
+    """'2026-07-19T20:55:00+00:00' -> 'July 19 at 1:55 PM', converting a
+    timestamp that carries a UTC offset into the location's local zone when
+    ``tz_name`` (an IANA name like 'America/Phoenix') is given. Pure: it parses
+    an existing timestamp, it never reads the clock."""
+    from datetime import datetime
+
     if not isinstance(iso, str) or "T" not in iso:
         return ""
-    date_part, rest = iso.split("T", 1)
-    months = (
-        "January",
-        "February",
-        "March",
-        "April",
-        "May",
-        "June",
-        "July",
-        "August",
-        "September",
-        "October",
-        "November",
-        "December",
-    )
     try:
-        _year, month, day = (int(p) for p in date_part.split("-"))
-        hour, minute = (int(p) for p in rest[:5].split(":"))
-    except (ValueError, IndexError):
+        moment = datetime.fromisoformat(iso)
+    except (ValueError, TypeError):
         return ""
-    if not 1 <= month <= 12:
-        return ""
-    suffix = "AM" if hour < 12 else "PM"
-    hour12 = hour % 12 or 12
-    return f"{months[month - 1]} {day} at {hour12}:{minute:02d} {suffix}"
+    if tz_name and moment.tzinfo is not None:
+        try:
+            from zoneinfo import ZoneInfo
+
+            moment = moment.astimezone(ZoneInfo(tz_name))
+        except Exception:  # noqa: BLE001 - unknown zone: fall back to the given time
+            pass
+    suffix = "AM" if moment.hour < 12 else "PM"
+    hour12 = moment.hour % 12 or 12
+    return f"{_MONTHS[moment.month - 1]} {moment.day} at {hour12}:{moment.minute:02d} {suffix}"
 
 
 def air_quality_phrase(air: object) -> str:

--- a/quill/ui/weather/weather_center_dialog.py
+++ b/quill/ui/weather/weather_center_dialog.py
@@ -321,11 +321,10 @@ class WeatherCenterDialog:
             block = render.current_conditions_block(
                 result.current, today, self._settings, result.air_quality
             )
-            when = (
-                f" Observed {render.friendly_datetime(result.current.observed_at)}."
-                if result.current.observed_at
-                else ""
-            )
+            when = ""
+            if result.current.observed_at:
+                observed = render.friendly_datetime(result.current.observed_at, result.time_zone)
+                when = f" Observed {observed}."
             self._current.SetValue(f"Weather for {place}. {block}{when}")
         else:
             self._current.SetValue(f"Current conditions for {place} are unavailable right now.")

--- a/tests/unit/core/test_weather_domain.py
+++ b/tests/unit/core/test_weather_domain.py
@@ -186,6 +186,12 @@ def test_friendly_datetime() -> None:
     assert render.friendly_datetime("2026-07-19T18:30:00-07:00") == "July 19 at 6:30 PM"
     assert render.friendly_datetime("2026-07-19T05:05") == "July 19 at 5:05 AM"
     assert render.friendly_datetime("bad") == ""
+    # A UTC observation converts into the location's local zone (Arizona is
+    # UTC-7 and does not observe daylight saving): 8:55 PM UTC -> 1:55 PM local.
+    assert (
+        render.friendly_datetime("2026-07-19T20:55:00+00:00", "America/Phoenix")
+        == "July 19 at 1:55 PM"
+    )
 
 
 def test_current_conditions_block_is_complete_and_toggleable() -> None:


### PR DESCRIPTION
The NWS observation timestamp is UTC; it was shown raw, so a 2:35 PM Arizona reading appeared as '9:35 PM'. Now converted to the location's IANA zone (from NWS point metadata). 🤖 Generated with [Claude Code](https://claude.com/claude-code)