### PR TITLE
feat(audio): expose tempo + fade in/out in the converter Advanced panel (#1255 §6)

### DIFF
--- a/quill/ui/audio_studio/convert_audio_dialog.py
+++ b/quill/ui/audio_studio/convert_audio_dialog.py
@@ -380,12 +380,26 @@ class ConvertAudioDialog(wx.Dialog):
             "&Loudness:", lambda: choice(tuple(loudness_choices()), "Loudness normalization")
         )
 
-        # Gain: manual label-then-control (correct z-order; not a helper call).
-        box.Add(wx.StaticText(self, label="&Gain (dB):"), 0, wx.LEFT | wx.TOP, 6)
-        self._adv_gain = wx.SpinCtrlDouble(self, min=-30.0, max=30.0, inc=0.5)
-        self._adv_gain.SetDigits(1)
-        set_accessible_name(self._adv_gain, "Gain in decibels")
-        box.Add(self._adv_gain, 0, wx.LEFT | wx.RIGHT, 6)
+        def new_spin(lo: float, hi: float, inc: float, digits: int, name: str) -> wx.SpinCtrlDouble:
+            spin = wx.SpinCtrlDouble(self, min=lo, max=hi, inc=inc)
+            spin.SetDigits(digits)
+            set_accessible_name(spin, name)
+            return spin
+
+        self._adv_gain = labeled(
+            "&Gain (dB):", lambda: new_spin(-30.0, 30.0, 0.5, 1, "Gain in decibels")
+        )
+        self._adv_gain.SetValue(0.0)  # 0 dB = no change
+        self._adv_tempo = labeled(
+            "&Speed (tempo):", lambda: new_spin(0.5, 2.0, 0.05, 2, "Speed, tempo multiplier")
+        )
+        self._adv_tempo.SetValue(1.0)  # 1.0x = unchanged; no pitch shift
+        self._adv_fade_in = labeled(
+            "Fade &in (seconds):", lambda: new_spin(0.0, 10.0, 0.5, 1, "Fade-in seconds")
+        )
+        self._adv_fade_out = labeled(
+            "Fade &out (seconds):", lambda: new_spin(0.0, 10.0, 0.5, 1, "Fade-out seconds")
+        )
 
         self._adv_highpass = wx.CheckBox(self, label="Remove low-frequency r&umble (high-pass)")
         self._adv_trim = wx.CheckBox(self, label="&Trim leading and trailing silence")
@@ -529,8 +543,11 @@ class ConvertAudioDialog(wx.Dialog):
             gain_db=float(self._adv_gain.GetValue()),
             high_pass=self._adv_highpass.GetValue(),
             trim_silence=self._adv_trim.GetValue(),
+            tempo=float(self._adv_tempo.GetValue()),
             compressor=self._adv_compressor.GetValue(),
             leveler=self._adv_leveler.GetValue(),
+            fade_in_s=float(self._adv_fade_in.GetValue()),
+            fade_out_s=float(self._adv_fade_out.GetValue()),
         )
         return {
             "bitrate_kbps": int(bitrate) if bitrate else None,

--- a/tests/unit/ui/audio_studio/test_convert_audio_dialog.py
+++ b/tests/unit/ui/audio_studio/test_convert_audio_dialog.py
@@ -102,6 +102,15 @@ def test_apply_advanced_dsp_populates_filters() -> None:
     assert any("loudnorm" in f for f in out.filters)
 
 
+def test_apply_advanced_carries_tempo_and_fades() -> None:
+    base = ConversionSpec(fmt="mp3")
+    out = cad.apply_advanced(base, dsp=DspOptions(tempo=1.5, fade_in_s=2.0, fade_out_s=3.0))
+    joined = ",".join(out.filters)
+    assert "atempo" in joined
+    assert "afade=t=in:st=0:d=2" in joined
+    assert out.filters.count("areverse") == 2  # fade-out via reverse-fade-reverse
+
+
 def test_advanced_choice_tables_start_neutral() -> None:
     # Index 0 of every Advanced table is the "keep preset/source" sentinel.
     assert cad._BITRATE_CHOICES[0][0] == ""

--- a/tests/unit/ui/fixtures/accessible_name_inventory.json
+++ b/tests/unit/ui/fixtures/accessible_name_inventory.json
@@ -173,7 +173,7 @@
   "quill/ui/audio_studio/convert_audio_dialog.py::ConvertAudioDialog._build::wx.ListBox": "named",
   "quill/ui/audio_studio/convert_audio_dialog.py::ConvertAudioDialog._build::wx.TextCtrl": "named",
   "quill/ui/audio_studio/convert_audio_dialog.py::ConvertAudioDialog._build_advanced.choice::wx.Choice": "named",
-  "quill/ui/audio_studio/convert_audio_dialog.py::ConvertAudioDialog._build_advanced::wx.SpinCtrlDouble": "named",
+  "quill/ui/audio_studio/convert_audio_dialog.py::ConvertAudioDialog._build_advanced.new_spin::wx.SpinCtrlDouble": "named",
   "quill/ui/audio_studio/feed_dialog.py::FolderFeedDialog.__init__::wx.ListBox": "named",
   "quill/ui/audio_studio/feed_dialog.py::FolderFeedDialog._field::wx.TextCtrl": "named",
   "quill/ui/audio_studio/pages_audio.py::AudioSourcePage.__init__::wx.ComboBox": "named",


### PR DESCRIPTION
## Summary
Surfaces the last two DSP capabilities the Advanced-mode core already supported (#1262) but the UI didn't yet expose: **speed (tempo, no pitch shift)** and **fade in / fade out**.

- Adds a shared `new_spin` factory routed through the existing z-order-safe `labeled(caption, lambda: …)` helper, and four spin fields — gain, speed, fade-in, fade-out — with neutral defaults (0 dB, 1.0×, 0 s) so an untouched Advanced panel stays a no-op.
- `_collect_advanced` now carries `tempo` / `fade_in_s` / `fade_out_s` into `DspOptions`, which compose into `ConversionSpec.filters` via the already-tested `build_dsp_filters`.

## Contract / gates
- `apply_advanced` round-trips tempo + fades into the filter graph (`atempo`, reverse-fade-reverse) — new test.
- House dialog contract + **A11Y-Z-ORDER** gate green (spins created via lambda factory, after their labels). Accessible-name snapshot regenerated (spin signature now under `new_spin`). ruff, budget, banned-patterns all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)