### PR TITLE
fix(audio-studio): route converter progress through the tray-aware task callback (#1255 §8)

### DIFF
--- a/quill/ui/audio_studio/convert_audio_dialog.py
+++ b/quill/ui/audio_studio/convert_audio_dialog.py
@@ -29,6 +29,7 @@ import wx
 
 from quill.core.audio.convert import (
     Channels,
+    ConversionJob,
     ConversionSpec,
     OnExisting,
     available_output_formats,
@@ -167,13 +168,13 @@ def plan_and_run(host: Any, request: ConvertRequest) -> None:
 
     Uses the host's ``_run_background_task`` (protected on close) so a long batch
     never owns the window and closing while converting routes through the shared
-    confirm. Progress feeds the status bar; the final summary is spoken. wx-free
-    logic lives in the engine; this only marshals progress back via the host.
+    confirm. Progress is reported through the task's ``progress(message, current,
+    total)`` callback — the shared contract that updates the status bar, the
+    **tray tooltip** (so a batch stays reviewable while minimized), and the
+    25/50/75 percent milestone announcements. wx-free logic lives in the engine;
+    this only marshals progress back via that callback.
     """
-    from quill.core.audio.convert import (
-        CancelToken,
-        run_conversion_batch,
-    )
+    from quill.core.audio.convert import run_conversion_batch
     from quill.core.speech.ffmpeg import find_ffmpeg
 
     ffmpeg = find_ffmpeg()
@@ -198,20 +199,14 @@ def plan_and_run(host: Any, request: ConvertRequest) -> None:
         return
 
     total = len(jobs)
-    cancel = CancelToken()
 
-    def work(progress: Any) -> Any:
-        def on_progress(done: int, total_jobs: int, _job: Any) -> None:
-            pct = int(done * 100 / total_jobs) if total_jobs else 100
-            host._wx.CallAfter(host._set_status, f"Converting {done}/{total_jobs} ({pct}%)")
-            if (
-                progress is not None
-                and hasattr(progress, "is_cancelled")
-                and progress.is_cancelled()
-            ):
-                cancel.cancel()
+    def work(progress: Callable[[str, int, int], None]) -> Any:
+        def on_progress(done: int, total_jobs: int, job: ConversionJob) -> None:
+            # Route through the task progress callback so the status bar AND the
+            # tray tooltip AND the milestone announcements all update together.
+            progress(f"Converting {done} of {total_jobs}: {job.source.name}", done, total_jobs)
 
-        return run_conversion_batch(ffmpeg, jobs, on_progress=on_progress, cancel=cancel)
+        return run_conversion_batch(ffmpeg, jobs, on_progress=on_progress)
 
     def on_success(result: Any) -> None:
         summary = result.summary(total)

--- a/tests/unit/ui/audio_studio/test_convert_audio_dialog.py
+++ b/tests/unit/ui/audio_studio/test_convert_audio_dialog.py
@@ -177,6 +177,35 @@ def test_plan_and_run_starts_background_task(monkeypatch, tmp_path: Path) -> Non
     assert "1 file" in label
 
 
+def test_work_reports_progress_through_task_callback(monkeypatch, tmp_path: Path) -> None:
+    # The batch progress must flow through the task's progress(message, current,
+    # total) callback so the status bar AND the tray tooltip AND the milestone
+    # announcements update — not a bare _set_status that bypasses the tray.
+    monkeypatch.setattr("quill.core.speech.ffmpeg.find_ffmpeg", lambda: "ffmpeg")
+    jobs = [
+        ConversionJob(tmp_path / "in1.wav", tmp_path / "out1.mp3", ConversionSpec(fmt="mp3")),
+        ConversionJob(tmp_path / "in2.wav", tmp_path / "out2.mp3", ConversionSpec(fmt="mp3")),
+    ]
+    monkeypatch.setattr(cad, "plan_jobs", lambda *a, **k: (jobs, []))
+
+    def fake_batch(_ffmpeg, batch_jobs, *, on_progress=None, **_k):
+        for done, job in enumerate(batch_jobs, start=1):
+            on_progress(done, len(batch_jobs), job)
+        return SimpleNamespace(summary=lambda total: f"Converted {total} of {total} files.")
+
+    monkeypatch.setattr("quill.core.audio.convert.run_conversion_batch", fake_batch)
+
+    host = _host()
+    cad.plan_and_run(host, _req(tmp_path))
+    _label, work, _on_success = host._calls["bg"]
+
+    progress_calls: list[tuple[str, int, int]] = []
+    work(lambda message, current, total: progress_calls.append((message, current, total)))
+
+    assert [(c, t) for _m, c, t in progress_calls] == [(1, 2), (2, 2)]  # current/total for the bar
+    assert "in1.wav" in progress_calls[0][0] and "in2.wav" in progress_calls[1][0]
+
+
 # --------------------------------------------------------------------------- #
 # Dialog contract (source scrape — no wx needed)
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
Fixes a real progress-reporting bug in the batch converter surfaced while polishing send-to-tray progress.

`_run_background_task` hands `work` a **callable** `progress(message, current, total)` — the shared contract that updates the status bar, the **tray tooltip** (so a batch stays reviewable while minimized), and the 25/50/75 percent milestone announcements. But the converter's `work`:
- treated `progress` as a **cancel-token object** (`hasattr(progress, "is_cancelled")`) — a function never has that attribute, so that branch was **dead code**, and
- pushed updates straight to `_set_status`, **bypassing the tray tooltip and the milestone announcements** entirely.

So a conversion minimized to the tray showed no progress and spoke no milestones.

**Fix:** report each completed job through `progress(message, done, total)` — naming the file — so the batch stays reviewable in the tray and screen-reader users hear milestones. Drops the unreachable cancel-token wiring.

## Test
Drives the stored `work` with a fake progress sink + fake batch and asserts the `(current, total)` fractions and per-file messages flow through the callback (not a bare `_set_status`).

All gates green (ruff, banned-patterns, budget, accessible-name, z-order, 16 dialog tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)