### PR TITLE
Fix the two pre-existing tool-gate failures (persistence audit + signature status)

### DIFF
--- a/quill/tools/persistence_audit.py
+++ b/quill/tools/persistence_audit.py
@@ -167,6 +167,10 @@ _REVIEWED_PERSISTENCE: dict[str, str] = {
     "core/ai/sessions.py::save_session": "content",
     "core/ai/style.py::save_style": "content",
     "core/bookmarks.py::save": "content",
+    # Per-book media time-point bookmarks (position_ms + optional label/note),
+    # keyed by book. User-created, additive/self-describing, tolerant loader
+    # (a corrupt file degrades to {}) -- same shape as core/bookmarks.py::save.
+    "core/media/bookmarks.py::_write": "content",
     "core/clip_library.py::_save": "content",
     "core/copy_tray.py::_save": "content",
     "core/favorite_folders.py::save": "content",

--- a/quill/tools/signing.py
+++ b/quill/tools/signing.py
@@ -197,6 +197,14 @@ def signature_status(artifact_path: Path, sidecar: Path | None = None) -> Signat
     """
     import os
 
+    # A missing sidecar means "unsigned" -- knowable from the filesystem alone,
+    # without the public key or even PyNaCl. Decide it here so a build/env where
+    # the key or nacl is unavailable reports an unsigned artifact as unsigned,
+    # not (wrongly) as signed-but-unverifiable via the key-load error paths below.
+    resolved_sidecar = sidecar if sidecar is not None else sidecar_path(artifact_path)
+    if not resolved_sidecar.exists():
+        return SignatureStatus(False, False, None, "no sidecar .minisig")
+
     env_path = os.environ.get("SIGNING_PUBLIC_KEY_PATH")
     if env_path and Path(env_path).exists():
         try:


### PR DESCRIPTION
## What

Fixes the two pre-existing tool-gate failures on `main` (unrelated to any feature work).

### 1. Persistence-audit gate
`core/media/bookmarks.py::_write` was an unclassified `write_json_atomic` site, failing `test_no_unreviewed_persistence_sites`. Classified as **`content`** — per-book media time-point bookmarks (`position_ms` + optional label/note) are user-created, additive/self-describing data with a tolerant loader (corrupt file → `{}`), the same shape as `core/bookmarks.py::save`.

### 2. Signature-status robustness
`signing.signature_status()` reported an **unsigned** artifact (no `.minisig` sidecar) as `signed=True` whenever the public key or PyNaCl couldn't be loaded — it tried to load the key *before* checking for a sidecar, so the "public key unavailable" path returned `signed=True` without ever looking. Whether a file is signed is knowable from sidecar existence alone; deciding that up front fixes `test_validate_unsigned_artifact_marks_signature_missing` (which fails in any environment where `nacl` isn't importable, e.g. the system-Python dev/test setup) and is strictly more correct in every environment.

## Testing

Full `tests/unit/tools` suite: **343 passed, 1 skipped** (previously 2 failed). Persistence-audit gate: OK (134 sites classified). Ruff / format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
