### PR TITLE
AI prompt quality: negative examples + banned-word retry filter for local models (#1319)

### DIFF
--- a/quill/core/ai/assistant.py
+++ b/quill/core/ai/assistant.py
@@ -13,6 +13,11 @@ from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
 
 from quill.core.ai.backend import AIBackend, ContextWindowExceeded
+from quill.core.ai.quality_filter import (
+    find_quality_issues,
+    negative_examples_block,
+    retry_instruction,
+)
 from quill.core.ai.tools import AITool, build_tools_from_registry, run_tool
 
 if TYPE_CHECKING:
@@ -108,6 +113,15 @@ _OPERATION_PROMPTS: dict[str, str] = {
     "summarize, add, remove, or invent content. Return only the Markdown, with no "
     "preamble:\n\n{text}",
 }
+
+
+#: Generative operations whose output the small-local-model quality shaping
+#: (#1319) applies to: the model *writes* here, so negative-example prompting
+#: and the hedging/filler post-filter help. The faithful transforms
+#: (``fix_grammar``, ``structure``, ``reading_order``) are deliberately excluded
+#: -- they must preserve the source exactly, so a "banned word" that is in the
+#: source must never trigger a rewrite.
+_GENERATIVE_OPS: frozenset[str] = frozenset({"rewrite", "summarize", "continue", "shorten"})
 
 
 #: Set by :func:`make_default_backend` when resolution fell back past a
@@ -245,6 +259,29 @@ class Assistant:
             return prompt
         return "\n\n".join([*segments, prompt])
 
+    def _respond_quality(self, prompt: str, *, shape: bool) -> str:
+        """Respond, applying small-local-model quality shaping when ``shape``.
+
+        On a local backend (#1319): prepend negative worked examples to teach
+        concision, then run the deterministic hedging/filler post-filter on the
+        output and, on a hit, do exactly one cheap retry naming the offending
+        phrases. Cloud backends and faithful transforms skip all of this and
+        get the plain response, byte-for-byte as before.
+        """
+        local = shape and bool(getattr(self.backend, "is_local", False))
+        if local:
+            prompt = f"{negative_examples_block()}\n\n{prompt}"
+        result = self.backend.respond(prompt)
+        if local:
+            issues = find_quality_issues(result)
+            if issues:
+                revised = self.backend.respond(
+                    f"{retry_instruction(issues)}\n\nYour previous answer:\n{result}"
+                )
+                if revised.strip():
+                    return revised
+        return result
+
     def is_available(self) -> tuple[bool, str | None]:
         return self.backend.is_available()
 
@@ -255,17 +292,20 @@ class Assistant:
         if operation not in _OPERATION_PROMPTS:
             raise ValueError(f"Unknown operation: {operation}")
         template = _OPERATION_PROMPTS[operation]
+        shape = operation in _GENERATIVE_OPS
         if len(text) <= _CHUNK_CHARS:
-            return self.backend.respond(self._wrap(template.format(text=text)))
+            return self._respond_quality(self._wrap(template.format(text=text)), shape=shape)
         # Input is larger than the window: process in chunks.
         chunks = _split_into_chunks(text, _CHUNK_CHARS)
-        pieces = [self.backend.respond(self._wrap(template.format(text=c))) for c in chunks]
+        pieces = [
+            self._respond_quality(self._wrap(template.format(text=c)), shape=shape) for c in chunks
+        ]
         if operation == "summarize":
             # Map-reduce: summarize the combined chunk summaries.
             combined = "\n\n".join(pieces)
             if len(combined) > _CHUNK_CHARS:
                 combined = combined[:_CHUNK_CHARS]
-            return self.backend.respond(self._wrap(template.format(text=combined)))
+            return self._respond_quality(self._wrap(template.format(text=combined)), shape=shape)
         return "\n".join(pieces)
 
     def change_tone(self, text: str, tone: str) -> str:
@@ -273,7 +313,7 @@ class Assistant:
             f"Rewrite the following text in a {tone} tone. "
             f"Return only the rewritten text:\n\n{text}"
         )
-        return self.backend.respond(self._wrap(prompt))
+        return self._respond_quality(self._wrap(prompt), shape=True)
 
     def ask(self, prompt: str) -> str:
         return self.backend.respond(self._wrap(prompt))

--- a/quill/core/ai/backend.py
+++ b/quill/core/ai/backend.py
@@ -17,6 +17,13 @@ class ContextWindowExceeded(CodedError):
 class AIBackend(ABC):
     name: str = "ai"
 
+    #: True for small on-device models (llama.cpp, Apple Foundation Models),
+    #: whose consistent failure modes justify the extra output-quality shaping
+    #: in :mod:`quill.core.ai.quality_filter` (#1319). Cloud provider backends
+    #: leave this False so they never pay for the negative-example prompt or the
+    #: post-filter retry.
+    is_local: bool = False
+
     @abstractmethod
     def is_available(self) -> tuple[bool, str | None]:
         """Return (available, reason). reason is a message when unavailable."""

--- a/quill/core/ai/foundation_models.py
+++ b/quill/core/ai/foundation_models.py
@@ -31,6 +31,7 @@ _DECIDE_INSTRUCTIONS = (
 
 class FoundationModelsBackend(AIBackend):
     name = "Apple Foundation Models"
+    is_local = True
 
     def __init__(self) -> None:
         self._fm = None

--- a/quill/core/ai/llama_cpp_backend.py
+++ b/quill/core/ai/llama_cpp_backend.py
@@ -87,6 +87,7 @@ def _extract_message_content(response: object) -> str:
 
 class LlamaCppBackend(AIBackend):
     name = "llama.cpp (local CPU)"
+    is_local = True
 
     def __init__(
         self,

--- a/quill/core/ai/quality_filter.py
+++ b/quill/core/ai/quality_filter.py
@@ -1,0 +1,134 @@
+"""Deterministic output-quality shaping for small local models (#1319).
+
+QUILL's free-AI-for-everyone path leans on small on-device models (llama.cpp,
+Apple Foundation Models) whose failure modes are consistent and cheap to catch
+without a second model call:
+
+* **hedging** ("it seems", "arguably") that softens prose into mush,
+* **editorializing** ("clearly", "obviously") that a rewrite/summary should not
+  add, and
+* **filler openers** ("In today's world", "It is important to note") that pad
+  without informing.
+
+Two complementary techniques, both pure text — no provider or model changes,
+consistent with the no-hardcoded-model-lists rule:
+
+1. :func:`negative_examples_block` — a few *wrong then corrected* pairs to put
+   in the prompt. The HomerScribe finding QUILL adopts here: on small models,
+   examples beat instructions ("He looks furious." -> "He clenches his fist.").
+2. :func:`find_quality_issues` + :func:`retry_instruction` — a deterministic
+   post-filter over the model's own output; a hit names the offending phrases
+   for a single, cheap retry, with no second model call needed to *judge*.
+
+Everything here is pure and unit-tested; the wiring (local-backend gate, one
+retry) lives in :mod:`quill.core.ai.assistant`.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Hedges that drain confidence from generated prose. Distinctive phrases only
+#: -- bare common words like "may"/"might" are excluded to avoid false hits on
+#: legitimate source content.
+HEDGING_PHRASES: tuple[str, ...] = (
+    "it seems",
+    "it appears that",
+    "arguably",
+    "it could be argued",
+    "one could argue",
+    "one might argue",
+    "somewhat",
+    "kind of",
+    "sort of",
+)
+
+#: Editorializing / judgment adverbs a neutral rewrite or summary must not add.
+JUDGMENT_WORDS: tuple[str, ...] = (
+    "clearly",
+    "obviously",
+    "of course",
+    "undoubtedly",
+    "certainly",
+    "surely",
+    "needless to say",
+)
+
+#: Padding openers that announce writing instead of doing it.
+FILLER_OPENERS: tuple[str, ...] = (
+    "in today's world",
+    "in this day and age",
+    "it is important to note",
+    "it's important to note",
+    "it is worth noting",
+    "it's worth noting",
+    "as we all know",
+    "at the end of the day",
+    "first and foremost",
+    "when it comes to",
+)
+
+#: Wrong -> corrected pairs that teach the same lessons by example (small models
+#: learn more from these than from bare rules).
+NEGATIVE_EXAMPLE_PAIRS: tuple[tuple[str, str], ...] = (
+    ("He looks furious.", "He clenches his fist."),
+    ("In today's world, technology is important.", "Technology shapes daily life."),
+    ("It seems that the results were positive.", "The results were positive."),
+    ("Clearly, this is the best approach.", "This is the best approach."),
+    ("It is important to note that the deadline is Friday.", "The deadline is Friday."),
+)
+
+
+def _all_terms() -> tuple[str, ...]:
+    return HEDGING_PHRASES + JUDGMENT_WORDS + FILLER_OPENERS
+
+
+def _pattern_for(term: str) -> re.Pattern[str]:
+    # Word-boundary match so "surely" never fires inside "surely" != "insurely"
+    # and multi-word phrases match across a single run of whitespace.
+    escaped = r"\s+".join(re.escape(word) for word in term.split())
+    return re.compile(rf"(?<!\w){escaped}(?!\w)", re.IGNORECASE)
+
+
+_COMPILED: tuple[tuple[str, re.Pattern[str]], ...] = tuple(
+    (term, _pattern_for(term)) for term in _all_terms()
+)
+
+
+def find_quality_issues(text: str) -> list[str]:
+    """Return the distinctive low-quality phrases present in *text*.
+
+    Deterministic and case-insensitive; each offending term is reported once,
+    in a stable order (hedging, then judgment, then filler). "" when clean.
+    """
+    if not text or not text.strip():
+        return []
+    found: list[str] = []
+    for term, pattern in _COMPILED:
+        if pattern.search(text) and term not in found:
+            found.append(term)
+    return found
+
+
+def retry_instruction(issues: list[str]) -> str:
+    """A one-line instruction naming the offending phrases, for a single retry.
+
+    Empty when there is nothing to fix, so the caller can treat "" as "no
+    retry needed".
+    """
+    if not issues:
+        return ""
+    quoted = ", ".join(f'"{issue}"' for issue in issues)
+    return (
+        "Revise your previous answer to remove these weakening words and phrases: "
+        f"{quoted}. Keep the same meaning and roughly the same length -- just cut "
+        "the hedging, editorializing, and filler. Return only the revised text."
+    )
+
+
+def negative_examples_block() -> str:
+    """A compact prompt block of wrong -> corrected pairs (teach by example)."""
+    lines = ["Follow the style of these corrections (avoid the 'weak' form):"]
+    for weak, better in NEGATIVE_EXAMPLE_PAIRS:
+        lines.append(f'- Weak: "{weak}"  Better: "{better}"')
+    return "\n".join(lines)

--- a/tests/unit/core/ai/test_assistant_quality.py
+++ b/tests/unit/core/ai/test_assistant_quality.py
@@ -1,0 +1,72 @@
+"""The assistant applies small-local-model quality shaping only where it should (#1319)."""
+
+from __future__ import annotations
+
+from quill.core.ai.assistant import Assistant
+
+
+class _ScriptedBackend:
+    """Fake backend returning queued responses and recording every prompt."""
+
+    def __init__(self, responses: list[str], *, is_local: bool) -> None:
+        self._responses = list(responses)
+        self.is_local = is_local
+        self.prompts: list[str] = []
+
+    def is_available(self):  # noqa: ANN201 - protocol shape
+        return True, None
+
+    def respond(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self._responses.pop(0) if self._responses else "fallback"
+
+    def respond_stream(self, prompt: str, on_delta) -> str:  # noqa: ANN001
+        result = self.respond(prompt)
+        on_delta(result)
+        return result
+
+
+def test_local_generative_op_adds_negative_examples_and_retries_on_hedging() -> None:
+    backend = _ScriptedBackend(["Clearly, it seems fine.", "It is fine."], is_local=True)
+    assistant = Assistant(backend=backend)
+
+    result = assistant.transform("rewrite", "some text")
+
+    assert result == "It is fine."  # the retried, cleaned answer wins
+    assert len(backend.prompts) == 2  # first attempt + one retry
+    assert "Weak:" in backend.prompts[0]  # negative examples prepended
+    assert "Revise your previous answer" in backend.prompts[1]  # named-word retry
+
+
+def test_local_generative_op_does_not_retry_on_clean_output() -> None:
+    backend = _ScriptedBackend(["A crisp, direct rewrite."], is_local=True)
+    assistant = Assistant(backend=backend)
+
+    result = assistant.transform("rewrite", "some text")
+
+    assert result == "A crisp, direct rewrite."
+    assert len(backend.prompts) == 1  # clean output -> no retry
+
+
+def test_cloud_backend_gets_no_shaping_even_when_output_hedges() -> None:
+    backend = _ScriptedBackend(["Clearly, it seems fine."], is_local=False)
+    assistant = Assistant(backend=backend)
+
+    result = assistant.transform("rewrite", "some text")
+
+    assert result == "Clearly, it seems fine."  # not retried
+    assert len(backend.prompts) == 1
+    assert "Weak:" not in backend.prompts[0]  # no negative-example block for cloud
+
+
+def test_faithful_transform_is_never_reshaped_on_a_local_backend() -> None:
+    # fix_grammar must preserve the source; a hedge in the corrected text must
+    # not trigger a rewrite that could change meaning.
+    backend = _ScriptedBackend(["It seems the cat sat."], is_local=True)
+    assistant = Assistant(backend=backend)
+
+    result = assistant.transform("fix_grammar", "it seem the cat sat")
+
+    assert result == "It seems the cat sat."
+    assert len(backend.prompts) == 1
+    assert "Weak:" not in backend.prompts[0]

--- a/tests/unit/core/ai/test_quality_filter.py
+++ b/tests/unit/core/ai/test_quality_filter.py
@@ -1,0 +1,69 @@
+"""Tests for the deterministic output-quality filter (#1319)."""
+
+from __future__ import annotations
+
+from quill.core.ai.quality_filter import (
+    NEGATIVE_EXAMPLE_PAIRS,
+    find_quality_issues,
+    negative_examples_block,
+    retry_instruction,
+)
+
+
+def test_clean_text_has_no_issues() -> None:
+    assert find_quality_issues("The results were positive. The deadline is Friday.") == []
+
+
+def test_empty_and_blank_are_clean() -> None:
+    assert find_quality_issues("") == []
+    assert find_quality_issues("   \n ") == []
+
+
+def test_detects_hedging_judgment_and_filler() -> None:
+    text = (
+        "In today's world, it seems the plan is clearly the best. "
+        "It is important to note the risks."
+    )
+    issues = find_quality_issues(text)
+    assert "in today's world" in issues
+    assert "it seems" in issues
+    assert "clearly" in issues
+    assert "it is important to note" in issues
+
+
+def test_matching_is_case_insensitive() -> None:
+    assert "clearly" in find_quality_issues("CLEARLY this works.")
+    assert "arguably" in find_quality_issues("Arguably the best.")
+
+
+def test_word_boundary_avoids_false_positives() -> None:
+    # "surely" must not fire inside "measurely"/"insurely"; "of course" needs the
+    # whole phrase, not "course" alone.
+    assert find_quality_issues("The measurement of the golf course was exact.") == []
+
+
+def test_each_issue_reported_once_in_stable_order() -> None:
+    text = "Clearly, clearly, it seems it seems."
+    issues = find_quality_issues(text)
+    assert issues.count("clearly") == 1
+    assert issues.count("it seems") == 1
+    # hedging group is scanned before the judgment group
+    assert issues.index("it seems") < issues.index("clearly")
+
+
+def test_retry_instruction_is_empty_without_issues() -> None:
+    assert retry_instruction([]) == ""
+
+
+def test_retry_instruction_names_each_issue() -> None:
+    instruction = retry_instruction(["it seems", "clearly"])
+    assert '"it seems"' in instruction
+    assert '"clearly"' in instruction
+    assert "revised text" in instruction.lower()
+
+
+def test_negative_examples_block_carries_the_pairs() -> None:
+    block = negative_examples_block()
+    for weak, better in NEGATIVE_EXAMPLE_PAIRS:
+        assert weak in block
+        assert better in block


### PR DESCRIPTION
Closes #1319.

Two pure, deterministic techniques that improve small on-device-model output with **no provider or model changes** (consistent with the no-hardcoded-model-lists rule):

## `quill/core/ai/quality_filter.py` (new, pure, fully unit-tested)
- **Negative worked examples** — `negative_examples_block()` returns wrong→corrected pairs ("He looks furious." → "He clenches his fist."). Small models learn more from examples than rules.
- **Deterministic post-filter + retry** — `find_quality_issues()` flags hedging ("it seems", "arguably"), editorializing ("clearly", "obviously"), and filler openers ("In today's world", "It is important to note"); `retry_instruction()` names the offenders for a **single** cheap retry. No second model call needed to *judge*.

## Wiring
- New `AIBackend.is_local` marker (True for llama.cpp / Foundation Models; False for cloud). Only local backends pay for the negative-example prompt and the retry.
- Applied in `Assistant` to the **generative** ops (rewrite, summarize, continue, shorten, change tone) via `_respond_quality`. **Faithful** transforms (fix_grammar, structure, reading_order) are excluded so a hedge already in the source can never trigger a meaning-changing rewrite.

## Testing
9 filter tests + 4 wiring tests (local retries on a hit; clean output doesn't retry; cloud gets no shaping; faithful transforms untouched). Full `core/ai` suite green — **825 passed**. Ruff/format/mypy clean; GATE-11/GATE-12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)