### PR TITLE
Resume records for expensive batch AI runs (#1323)

### DIFF
--- a/quill/core/ai/resume_record.py
+++ b/quill/core/ai/resume_record.py
@@ -1,0 +1,151 @@
+"""Resumable, rebuildable records for expensive batch AI runs (#1323).
+
+Idea adopted from HomerScribe: an interrupted batch run resumes where it
+stopped, and a "rebuild" path regenerates final outputs from the stored model
+results with **zero** model calls. Interruption safety matters most on the slow,
+CPU-only machines that are QUILL's core audience -- a two-hour bulk
+transcription that dies at unit 240 of 247 must not start over.
+
+Design:
+
+* Each unit of work has a stable string id. As a unit completes, its model
+  result is written to a JSON record via :func:`core.storage.write_json_atomic`
+  (the same crash-safe, atomic-replace discipline every QUILL store rides), so a
+  kill at any moment leaves either the old record or the fully-written new one --
+  never a half-file.
+* A ``signature`` fingerprints the run's parameters (model, options, ...). If it
+  changes, the old results are stale and are dropped rather than silently reused,
+  so a resume never blends outputs from two different configurations.
+* :func:`run_resumable` drives a run: it skips already-recorded units (resume)
+  and computes only the rest. :func:`rebuild` returns the stored results with no
+  ``compute`` at all -- the "regenerate outputs without re-querying" path.
+
+Pure and unit-tested; ``compute`` is injected, so nothing here touches a real
+model or the network.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from quill.core.storage import read_json, write_json_atomic
+
+_RECORD_VERSION = 1
+
+
+class MissingResult(KeyError):
+    """A rebuild needed a unit's result that the record does not contain."""
+
+
+@dataclass
+class ResumeStore:
+    """A crash-safe map of ``unit_id -> model result`` for one batch run.
+
+    Persisted to ``path`` on every :meth:`record`. Load an existing run with
+    :meth:`load`; a record whose ``signature`` does not match the current run is
+    treated as empty so stale results from a different configuration are never
+    reused.
+    """
+
+    path: Path
+    signature: str = ""
+    results: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def load(cls, path: Path, *, signature: str = "") -> ResumeStore:
+        raw = read_json(path, default={})
+        if (
+            not isinstance(raw, dict)
+            or raw.get("version") != _RECORD_VERSION
+            or raw.get("signature", "") != signature
+        ):
+            # Missing, corrupt, old-version, or a different run configuration:
+            # start clean rather than resume against mismatched results.
+            return cls(path=path, signature=signature, results={})
+        stored = raw.get("results")
+        results = dict(stored) if isinstance(stored, dict) else {}
+        return cls(path=path, signature=signature, results=results)
+
+    def _write(self) -> None:
+        write_json_atomic(
+            self.path,
+            {"version": _RECORD_VERSION, "signature": self.signature, "results": self.results},
+        )
+
+    def is_done(self, unit_id: str) -> bool:
+        return unit_id in self.results
+
+    def result_for(self, unit_id: str) -> Any | None:
+        return self.results.get(unit_id)
+
+    def done_ids(self) -> set[str]:
+        return set(self.results)
+
+    def pending(self, all_ids: Iterable[str]) -> list[str]:
+        """The ids not yet recorded, in the given order (duplicates dropped)."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for unit_id in all_ids:
+            if unit_id not in self.results and unit_id not in seen:
+                seen.add(unit_id)
+                out.append(unit_id)
+        return out
+
+    def record(self, unit_id: str, result: Any) -> None:
+        """Persist one unit's result atomically (safe to call after each unit)."""
+        self.results[unit_id] = result
+        self._write()
+
+    def clear(self) -> None:
+        """Forget all results and remove the record file (start a run over)."""
+        self.results = {}
+        self.path.unlink(missing_ok=True)
+
+
+def run_resumable(
+    all_ids: Iterable[str],
+    compute: Callable[[str], Any],
+    store: ResumeStore,
+    *,
+    on_result: Callable[[str, Any, bool], None] | None = None,
+) -> dict[str, Any]:
+    """Compute a result for every id, skipping ones already in ``store``.
+
+    ``compute(unit_id)`` runs only for pending units; each result is recorded
+    atomically as it lands, so an interruption resumes here next time.
+    ``on_result(unit_id, result, from_cache)`` (optional) is called for every
+    unit in order -- ``from_cache=True`` for a resumed one, so a caller can drive
+    progress. Returns ``{unit_id: result}`` for all ids, in order.
+    """
+    ordered = list(dict.fromkeys(all_ids))  # de-dupe, keep order
+    out: dict[str, Any] = {}
+    for unit_id in ordered:
+        if store.is_done(unit_id):
+            result = store.result_for(unit_id)
+            from_cache = True
+        else:
+            result = compute(unit_id)
+            store.record(unit_id, result)
+            from_cache = False
+        out[unit_id] = result
+        if on_result is not None:
+            on_result(unit_id, result, from_cache)
+    return out
+
+
+def rebuild(store: ResumeStore, all_ids: Iterable[str]) -> dict[str, Any]:
+    """Return stored results for ``all_ids`` with **no** compute (rebuild path).
+
+    Raises :class:`MissingResult` if any id was never recorded -- a rebuild must
+    be honest about an incomplete run rather than silently omitting outputs.
+    """
+    ordered = list(dict.fromkeys(all_ids))
+    missing = [unit_id for unit_id in ordered if not store.is_done(unit_id)]
+    if missing:
+        raise MissingResult(
+            f"cannot rebuild: {len(missing)} unit(s) have no stored result: {missing[:5]}"
+        )
+    return {unit_id: store.result_for(unit_id) for unit_id in ordered}

--- a/tests/unit/core/ai/test_resume_record.py
+++ b/tests/unit/core/ai/test_resume_record.py
@@ -1,0 +1,122 @@
+"""Tests for resumable/rebuildable batch-AI records (#1323)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from quill.core.ai.resume_record import (
+    MissingResult,
+    ResumeStore,
+    rebuild,
+    run_resumable,
+)
+
+
+def test_record_persists_and_reloads(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    store = ResumeStore.load(path, signature="sig-1")
+    store.record("a", {"text": "alpha"})
+    store.record("b", {"text": "beta"})
+
+    reloaded = ResumeStore.load(path, signature="sig-1")
+    assert reloaded.result_for("a") == {"text": "alpha"}
+    assert reloaded.done_ids() == {"a", "b"}
+
+
+def test_signature_mismatch_starts_clean(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    ResumeStore.load(path, signature="model-v1").record("a", "old")
+
+    # A different run configuration must not resume against stale results.
+    fresh = ResumeStore.load(path, signature="model-v2")
+    assert fresh.results == {}
+    assert not fresh.is_done("a")
+
+
+def test_pending_filters_done_keeps_order_dedupes(tmp_path: Path) -> None:
+    store = ResumeStore.load(tmp_path / "r.json")
+    store.record("b", 1)
+    assert store.pending(["a", "b", "c", "a"]) == ["a", "c"]
+
+
+def test_run_resumable_computes_only_pending_and_resumes_after_interruption(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "run.json"
+    ids = ["u1", "u2", "u3"]
+    calls: list[str] = []
+
+    def compute(unit_id: str) -> str:
+        calls.append(unit_id)
+        if unit_id == "u3":
+            raise RuntimeError("simulated crash before u3 completes")
+        return f"result-{unit_id}"
+
+    store = ResumeStore.load(path, signature="s")
+    with pytest.raises(RuntimeError):
+        run_resumable(ids, compute, store)
+    # u1, u2 recorded before the crash; u3 attempted, not recorded.
+    assert calls == ["u1", "u2", "u3"]
+    assert ResumeStore.load(path, signature="s").done_ids() == {"u1", "u2"}
+
+    # Resume: a fresh store reloads the record and computes only u3.
+    calls.clear()
+    resumed = ResumeStore.load(path, signature="s")
+    out = run_resumable(ids, lambda u: f"result-{u}", resumed)
+    assert calls == []  # compute passed above never raised; count via output
+    assert out == {"u1": "result-u1", "u2": "result-u2", "u3": "result-u3"}
+    assert resumed.done_ids() == {"u1", "u2", "u3"}
+
+
+def test_run_resumable_reports_cache_vs_computed(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    store = ResumeStore.load(path)
+    store.record("u1", "cached")
+
+    seen: list[tuple[str, bool]] = []
+    run_resumable(
+        ["u1", "u2"],
+        lambda u: "computed",
+        store,
+        on_result=lambda uid, _res, from_cache: seen.append((uid, from_cache)),
+    )
+    assert seen == [("u1", True), ("u2", False)]
+
+
+def test_rebuild_returns_stored_without_recompute(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    store = ResumeStore.load(path)
+    store.record("u1", "one")
+    store.record("u2", "two")
+
+    # A brand-new store (no compute available at all) rebuilds from disk.
+    loaded = ResumeStore.load(path)
+    assert rebuild(loaded, ["u1", "u2"]) == {"u1": "one", "u2": "two"}
+
+
+def test_rebuild_raises_on_incomplete_run(tmp_path: Path) -> None:
+    store = ResumeStore.load(tmp_path / "run.json")
+    store.record("u1", "one")
+    with pytest.raises(MissingResult):
+        rebuild(store, ["u1", "u2"])
+
+
+def test_clear_removes_the_record(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    store = ResumeStore.load(path)
+    store.record("u1", "one")
+    assert path.exists()
+    store.clear()
+    assert not path.exists()
+    assert ResumeStore.load(path).results == {}
+
+
+def test_corrupt_or_old_record_starts_clean(tmp_path: Path) -> None:
+    path = tmp_path / "run.json"
+    path.write_text("{ not valid json", encoding="utf-8")
+    assert ResumeStore.load(path).results == {}
+
+    path.write_text('{"version": 0, "results": {"a": 1}}', encoding="utf-8")
+    assert ResumeStore.load(path).results == {}


### PR DESCRIPTION
Closes #1323. Idea adopted from HomerScribe.

`quill/core/ai/resume_record.py` — a crash-safe `unit_id -> model result` store for expensive batch AI operations (bulk transcription, batch OCR-with-AI, future media description). Interruption safety matters most on the slow CPU-only machines that are QUILL's core audience: a two-hour run that dies at unit 240/247 must not start over.

- Each unit's result is persisted **atomically** via `core.storage.write_json_atomic` as it lands (same crash-safe discipline every QUILL store rides) — a kill leaves the old record or the fully-written new one, never a half-file.
- `run_resumable()` skips already-recorded units (resume) and computes only the rest; `rebuild()` regenerates outputs from stored results with **zero** model calls, raising `MissingResult` on an incomplete run rather than silently omitting.
- A run `signature` fingerprints the parameters, so a resume never blends results from two configurations.

Pure and fully unit-tested (`compute` injected — nothing touches a real model): **9 tests**, including an interrupt-and-resume scenario and rebuild-without-recompute. Ready for the batch transcription flow to adopt as its first consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)