### PR TITLE
Sidecar context convention: auto-load a doc's .quill-context.md as AI context (#1322)

### DIFF
--- a/quill/core/ai/assistant.py
+++ b/quill/core/ai/assistant.py
@@ -233,6 +233,7 @@ class Assistant:
         self.backend = backend
         self._style_preamble = ""
         self._instructions_preamble = ""
+        self._context_preamble = ""
         #: Two-pass observe-then-rewrite for summarize on a local model (#1320):
         #: pass 1 extracts observations, pass 2 rewrites them under a word budget
         #: without the source, cutting hallucination. Defaults on but only ever
@@ -257,11 +258,22 @@ class Assistant:
         """Pin the user's durable writing instructions (AI-21; empty to disable)."""
         self._instructions_preamble = preamble or ""
 
+    def set_context_preamble(self, preamble: str) -> None:
+        """Pin auto-loaded sidecar reference context (#1322; empty to disable)."""
+        self._context_preamble = preamble or ""
+
     def _wrap(self, prompt: str) -> str:
         # Instructions (explicit user rules) lead, then the trained style
-        # (voice), then the task. Both are visible, user-owned conditioning.
+        # (voice), then the sidecar reference context (facts), then the task —
+        # all visible, user-owned conditioning.
         segments = [
-            segment for segment in (self._instructions_preamble, self._style_preamble) if segment
+            segment
+            for segment in (
+                self._instructions_preamble,
+                self._style_preamble,
+                self._context_preamble,
+            )
+            if segment
         ]
         if not segments:
             return prompt

--- a/quill/core/ai/sidecar_context.py
+++ b/quill/core/ai/sidecar_context.py
@@ -1,0 +1,103 @@
+"""Auto-loaded sidecar context beside a document (#1322).
+
+Idea adopted from HomerScribe, which auto-uses ``video.md`` beside ``video.mkv``
+as description context with zero flags. This is the reference-material companion
+to :mod:`quill.core.ai.writing_instructions`: where the ``.quill-instructions.md``
+sidecar carries *rules* (how to write), the ``.quill-context.md`` sidecar carries
+*facts* -- character names, domain terminology, project background -- that the
+assistant should treat as accurate reference when working on that document.
+
+It reuses the convention-file pattern that already works in QUILL (writing
+instructions, the dictation profile): a plain Markdown file the user manages
+entirely in a file manager, next to the document, with **zero UI**. Nothing is
+hidden -- when a sidecar is picked up it is announced, never applied silently,
+and it rides wherever the document already goes (Safe Mode and consent
+semantics unchanged: no new file leaves the document's own location).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+#: The sidecar name convention: ``report.docx`` -> ``report.docx.quill-context.md``.
+#: Mirrors ``writing_instructions.DOCUMENT_SIDECAR_SUFFIX`` so the two sidecars
+#: sit side by side and read the same way.
+DOCUMENT_CONTEXT_SUFFIX = ".quill-context.md"
+_MAX_CONTEXT_CHARS = 8000
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarContext:
+    """Reference context resolved from a document's sidecar (empty if none)."""
+
+    text: str = ""
+    path: Path | None = None
+    truncated: bool = False
+
+    @property
+    def is_present(self) -> bool:
+        return bool(self.text.strip())
+
+
+def document_context_path(document_path: Path | str | None) -> Path | None:
+    """The sidecar context file for a document, or None if it has no path."""
+    if not document_path:
+        return None
+    path = Path(document_path)
+    if not path.name:
+        return None
+    return path.with_name(path.name + DOCUMENT_CONTEXT_SUFFIX)
+
+
+def load_sidecar_context(document_path: Path | str | None) -> SidecarContext:
+    """Read the sidecar context beside *document_path* (live, no caching).
+
+    Returns an empty :class:`SidecarContext` when the document has no path, the
+    sidecar is absent, unreadable, or blank -- so callers can treat
+    ``is_present`` as "there is something to inject and announce".
+    """
+    path = document_context_path(document_path)
+    if path is None or not path.exists():
+        return SidecarContext()
+    try:
+        raw = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return SidecarContext()
+    truncated = len(raw) > _MAX_CONTEXT_CHARS
+    text = raw[:_MAX_CONTEXT_CHARS].strip()
+    if not text:
+        return SidecarContext(path=path)
+    return SidecarContext(text=text, path=path, truncated=truncated)
+
+
+def context_preamble(context: SidecarContext) -> str:
+    """Build the reference-context preamble segment (empty when none).
+
+    Framed as *reference material to use for accuracy*, deliberately NOT as
+    mandatory instructions -- it informs the answer (names, terminology, facts)
+    without licensing the model to shorten or skip the actual task.
+    """
+    if not context.is_present:
+        return ""
+    return (
+        "Reference context for this document (names, terminology, and facts to "
+        "use for accuracy -- this is background, not instructions, and not a "
+        "reason to shorten or skip the task):\n" + context.text.strip()
+    )
+
+
+def announcement(context: SidecarContext) -> str:
+    """The user-facing sentence announcing a picked-up sidecar (empty if none).
+
+    Auto-loaded context must never be applied silently: a blind user cannot see
+    that a sidecar shaped the answer, so the UI speaks this.
+    """
+    if not context.is_present or context.path is None:
+        return ""
+    name = context.path.name
+    if context.truncated:
+        return (
+            f"Using context from {name} (trimmed to the first {_MAX_CONTEXT_CHARS:,} characters)."
+        )
+    return f"Using context from {name}."

--- a/tests/unit/core/ai/test_sidecar_context.py
+++ b/tests/unit/core/ai/test_sidecar_context.py
@@ -1,0 +1,91 @@
+"""Tests for the auto-loaded document sidecar context (#1322)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from quill.core.ai.assistant import Assistant
+from quill.core.ai.sidecar_context import (
+    DOCUMENT_CONTEXT_SUFFIX,
+    announcement,
+    context_preamble,
+    document_context_path,
+    load_sidecar_context,
+)
+
+
+class _Backend:
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def is_available(self):  # noqa: ANN201
+        return True, None
+
+    def respond(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return "ok"
+
+    def respond_stream(self, prompt: str, on_delta) -> str:  # noqa: ANN001
+        return self.respond(prompt)
+
+
+def test_sidecar_path_is_beside_the_document() -> None:
+    assert document_context_path("book.docx") == Path("book.docx" + DOCUMENT_CONTEXT_SUFFIX)
+    assert document_context_path(None) is None
+    assert document_context_path("") is None
+
+
+def test_absent_sidecar_is_not_present(tmp_path: Path) -> None:
+    ctx = load_sidecar_context(tmp_path / "novel.md")
+    assert not ctx.is_present
+    assert context_preamble(ctx) == ""
+    assert announcement(ctx) == ""
+
+
+def test_present_sidecar_loads_and_builds_preamble_and_announcement(tmp_path: Path) -> None:
+    doc = tmp_path / "novel.md"
+    doc.write_text("chapter one", encoding="utf-8")
+    sidecar = tmp_path / ("novel.md" + DOCUMENT_CONTEXT_SUFFIX)
+    sidecar.write_text("Protagonist: Ada Vance. Setting: Titan Station.", encoding="utf-8")
+
+    ctx = load_sidecar_context(doc)
+    assert ctx.is_present
+    assert "Ada Vance" in context_preamble(ctx)
+    assert "not instructions" in context_preamble(ctx)  # framed as reference, not rules
+    assert announcement(ctx) == f"Using context from novel.md{DOCUMENT_CONTEXT_SUFFIX}."
+
+
+def test_blank_sidecar_is_not_present(tmp_path: Path) -> None:
+    doc = tmp_path / "novel.md"
+    sidecar = tmp_path / ("novel.md" + DOCUMENT_CONTEXT_SUFFIX)
+    sidecar.write_text("   \n\n  ", encoding="utf-8")
+    assert not load_sidecar_context(doc).is_present
+
+
+def test_oversized_sidecar_is_truncated_and_announced(tmp_path: Path) -> None:
+    doc = tmp_path / "novel.md"
+    sidecar = tmp_path / ("novel.md" + DOCUMENT_CONTEXT_SUFFIX)
+    sidecar.write_text("x" * 20_000, encoding="utf-8")
+    ctx = load_sidecar_context(doc)
+    assert ctx.truncated
+    assert "trimmed to the first" in announcement(ctx)
+
+
+def test_assistant_injects_context_after_instructions_and_style() -> None:
+    backend = _Backend()
+    assistant = Assistant(backend=backend)
+    assistant.set_instructions_preamble("RULES")
+    assistant.set_style_preamble("STYLE")
+    assistant.set_context_preamble("CONTEXT-FACTS")
+
+    assistant.ask("do the thing")
+
+    prompt = backend.prompts[-1]
+    assert prompt.index("RULES") < prompt.index("STYLE") < prompt.index("CONTEXT-FACTS")
+    assert prompt.index("CONTEXT-FACTS") < prompt.index("do the thing")
+
+
+def test_assistant_without_context_is_unchanged() -> None:
+    backend = _Backend()
+    Assistant(backend=backend).ask("plain")
+    assert backend.prompts[-1] == "plain"


### PR DESCRIPTION
Closes #1322. Idea adopted from HomerScribe (auto-uses `video.md` beside `video.mkv`).

`quill/core/ai/sidecar_context.py` — when an AI feature runs against a document, auto-load a convention-named sidecar **`<document>.quill-context.md`** beside it and inject its contents (character names, terminology, project facts) as reference context. This mirrors the existing `.quill-instructions.md` writing-instructions sidecar, so the two sit side by side and read the same way — the convention-file pattern already proven in QUILL (writing instructions, dictation profile): **zero UI, zero flags**, a plain Markdown file the user manages in a file manager.

- **Reference, not rules.** Framed as background facts *for accuracy*, deliberately not mandatory instructions, so it can never license the model to shorten or skip the task.
- **Never silent.** `announcement()` gives the UI a sentence to speak when a sidecar is picked up — a blind user can't see that a file shaped the answer. Bounded read; oversize is trimmed and the trim is announced.
- **Safe Mode / consent unchanged** — the sidecar rides wherever the document already lives; no new file leaves that location.
- Wired via a new `Assistant.set_context_preamble` seam, composed after instructions and style, before the task.

## Testing
7 tests (path resolution, present/absent/blank/oversize, announcement, and assistant ordering); full `core/ai` suite green — **819 passed**. Ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)