### PR TITLE
Two-pass observe-then-rewrite with a word budget for local summarize (#1320)

### DIFF
--- a/quill/core/ai/assistant.py
+++ b/quill/core/ai/assistant.py
@@ -19,6 +19,7 @@ from quill.core.ai.quality_filter import (
     retry_instruction,
 )
 from quill.core.ai.tools import AITool, build_tools_from_registry, run_tool
+from quill.core.ai.two_pass import DEFAULT_WORD_BUDGET, observe_prompt, rewrite_prompt
 
 if TYPE_CHECKING:
     from quill.core.ai.agent import AgentDecision
@@ -232,6 +233,13 @@ class Assistant:
         self.backend = backend
         self._style_preamble = ""
         self._instructions_preamble = ""
+        #: Two-pass observe-then-rewrite for summarize on a local model (#1320):
+        #: pass 1 extracts observations, pass 2 rewrites them under a word budget
+        #: without the source, cutting hallucination. Defaults on but only ever
+        #: fires on a local backend; the UI's single-pass escape hatch flips this
+        #: off to preserve speed on slow CPUs.
+        self.two_pass_summarize = True
+        self.summary_word_budget = DEFAULT_WORD_BUDGET
         #: After answer()/answer_stream()/write_for_document(): a user-facing
         #: sentence describing any silent trimming that shaped the request
         #: ("The answer used the first N of the document's M characters."),
@@ -294,6 +302,8 @@ class Assistant:
         template = _OPERATION_PROMPTS[operation]
         shape = operation in _GENERATIVE_OPS
         if len(text) <= _CHUNK_CHARS:
+            if operation == "summarize":
+                return self._summarize(text)
             return self._respond_quality(self._wrap(template.format(text=text)), shape=shape)
         # Input is larger than the window: process in chunks.
         chunks = _split_into_chunks(text, _CHUNK_CHARS)
@@ -305,8 +315,34 @@ class Assistant:
             combined = "\n\n".join(pieces)
             if len(combined) > _CHUNK_CHARS:
                 combined = combined[:_CHUNK_CHARS]
-            return self._respond_quality(self._wrap(template.format(text=combined)), shape=shape)
+            return self._summarize(combined)
         return "\n".join(pieces)
+
+    def _use_two_pass_summarize(self) -> bool:
+        # Only ever on a local backend; cloud models don't need it and would just
+        # pay for a second call. ``getattr`` tolerates a backend without the
+        # ``is_local`` marker (treated as cloud).
+        return self.two_pass_summarize and bool(getattr(self.backend, "is_local", False))
+
+    def _summarize(self, text: str) -> str:
+        """Summarize *text*, two-pass observe-then-rewrite on a local backend.
+
+        Pass 1 extracts plain observations (source visible, unwrapped -- it is
+        faithful extraction, not user-voiced writing); pass 2 rewrites them under
+        the word budget with the source unseen, wrapped so the user's
+        instructions/style still shape the final summary. Falls back to the
+        single-pass summary on a cloud backend or when disabled.
+        """
+        if self._use_two_pass_summarize():
+            observations = self.backend.respond(observe_prompt(text, kind="text"))
+            return self._respond_quality(
+                self._wrap(rewrite_prompt(observations, word_budget=self.summary_word_budget)),
+                shape=True,
+            )
+        # Single-pass summary still gets the #1319 hedging/filler shaping.
+        return self._respond_quality(
+            self._wrap(_OPERATION_PROMPTS["summarize"].format(text=text)), shape=True
+        )
 
     def change_tone(self, text: str, tone: str) -> str:
         prompt = (

--- a/quill/core/ai/two_pass.py
+++ b/quill/core/ai/two_pass.py
@@ -1,0 +1,51 @@
+"""Two-pass observe-then-rewrite for small-local-model summarize/describe (#1320).
+
+Idea adopted from HomerScribe: small vision/text models hallucinate less when
+you split the work. Pass 1 *observes* -- it extracts concrete facts from the
+source. Pass 2 *rewrites* those observations into concise output under an
+explicit word budget, **without the source in front of it**, so the model can
+only reword what it already extracted rather than inventing interpretation.
+
+Both prompts are pure and unit-tested here; the two backend calls and the
+opt-in / local-only gating live in :class:`quill.core.ai.assistant.Assistant`.
+A single-pass escape hatch preserves speed on slow CPUs.
+"""
+
+from __future__ import annotations
+
+#: Default output ceiling for the rewrite pass. Deliberately modest -- the point
+#: of the second pass is a tight, faithful summary, not a long one.
+DEFAULT_WORD_BUDGET = 150
+
+
+def observe_prompt(text: str, *, kind: str = "text") -> str:
+    """Pass 1: extract plain observations from the source, no interpretation."""
+    return (
+        f"Read the following {kind} and list the concrete observations and facts it "
+        "contains, one per line, as plain statements. Do not interpret, judge, "
+        "summarize, or add anything that is not actually present.\n\n"
+        f"{kind.capitalize()}:\n{text}"
+    )
+
+
+def rewrite_prompt(
+    observations: str, *, word_budget: int = DEFAULT_WORD_BUDGET, output: str = "summary"
+) -> str:
+    """Pass 2: rewrite the observations into a budgeted output, source unseen."""
+    if word_budget < 1:
+        raise ValueError("word_budget must be at least 1")
+    return (
+        f"Using ONLY the observations below, write a {output} of at most "
+        f"{word_budget} words. Include nothing that is not in the observations; do "
+        f"not speculate or embellish. Return only the {output}, with no preamble.\n\n"
+        f"Observations:\n{observations}"
+    )
+
+
+def word_count(text: str) -> int:
+    """Whitespace word count (how the budget is measured)."""
+    return len(text.split())
+
+
+def within_budget(text: str, word_budget: int) -> bool:
+    return word_count(text) <= word_budget

--- a/tests/unit/core/ai/test_assistant_two_pass.py
+++ b/tests/unit/core/ai/test_assistant_two_pass.py
@@ -1,0 +1,64 @@
+"""The assistant uses two-pass summarize only on a local backend, opt-in (#1320)."""
+
+from __future__ import annotations
+
+from quill.core.ai.assistant import Assistant
+
+
+class _Backend:
+    def __init__(self, *, is_local: bool) -> None:
+        self.is_local = is_local
+        self.prompts: list[str] = []
+
+    def is_available(self):  # noqa: ANN201
+        return True, None
+
+    def respond(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        # Distinct replies so the caller's return value reveals which pass won.
+        return f"reply-{len(self.prompts)}"
+
+    def respond_stream(self, prompt: str, on_delta) -> str:  # noqa: ANN001
+        return self.respond(prompt)
+
+
+def test_local_summarize_runs_observe_then_rewrite() -> None:
+    backend = _Backend(is_local=True)
+    assistant = Assistant(backend=backend)
+    assistant.summary_word_budget = 40
+
+    result = assistant.transform("summarize", "The quarterly report covers three regions.")
+
+    assert len(backend.prompts) == 2  # observe, then rewrite
+    assert "The quarterly report" in backend.prompts[0]  # pass 1 sees the source
+    assert "40 words" in backend.prompts[1]  # pass 2 carries the budget
+    assert "The quarterly report" not in backend.prompts[1]  # pass 2 hides the source
+    assert result == "reply-2"  # the rewrite's output is returned
+
+
+def test_disabled_flag_falls_back_to_single_pass_on_local() -> None:
+    backend = _Backend(is_local=True)
+    assistant = Assistant(backend=backend)
+    assistant.two_pass_summarize = False
+
+    assistant.transform("summarize", "some source text")
+
+    assert len(backend.prompts) == 1  # single pass
+
+
+def test_cloud_backend_stays_single_pass() -> None:
+    backend = _Backend(is_local=False)
+    assistant = Assistant(backend=backend)
+
+    assistant.transform("summarize", "some source text")
+
+    assert len(backend.prompts) == 1  # cloud never pays for the second call
+
+
+def test_non_summarize_op_is_never_two_pass() -> None:
+    backend = _Backend(is_local=True)
+    assistant = Assistant(backend=backend)
+
+    assistant.transform("rewrite", "some source text")
+
+    assert len(backend.prompts) == 1

--- a/tests/unit/core/ai/test_two_pass.py
+++ b/tests/unit/core/ai/test_two_pass.py
@@ -1,0 +1,44 @@
+"""Tests for the two-pass observe-then-rewrite prompts (#1320)."""
+
+from __future__ import annotations
+
+import pytest
+
+from quill.core.ai.two_pass import (
+    DEFAULT_WORD_BUDGET,
+    observe_prompt,
+    rewrite_prompt,
+    within_budget,
+    word_count,
+)
+
+
+def test_observe_prompt_shows_source_and_asks_for_plain_facts() -> None:
+    prompt = observe_prompt("The cat sat on the mat.", kind="passage")
+    assert "The cat sat on the mat." in prompt
+    assert "observations" in prompt.lower()
+    assert "do not interpret" in prompt.lower()
+
+
+def test_rewrite_prompt_budgets_and_hides_the_source() -> None:
+    prompt = rewrite_prompt("- A cat\n- A mat", word_budget=40, output="summary")
+    assert "40 words" in prompt
+    assert "ONLY the observations" in prompt
+    assert "- A cat" in prompt
+    # The rewrite pass must not carry the original source, only the observations.
+    assert "summary" in prompt.lower()
+
+
+def test_rewrite_prompt_rejects_a_nonpositive_budget() -> None:
+    with pytest.raises(ValueError):
+        rewrite_prompt("obs", word_budget=0)
+
+
+def test_default_budget_is_modest() -> None:
+    assert 0 < DEFAULT_WORD_BUDGET <= 300
+
+
+def test_word_count_and_within_budget() -> None:
+    assert word_count("one two three") == 3
+    assert within_budget("one two three", 3)
+    assert not within_budget("one two three four", 3)


### PR DESCRIPTION
Closes #1320. Idea adopted from HomerScribe.

For small on-device-model summarize, split the work to cut hallucinated interpretation:
- **Pass 1 (observe)** extracts concrete facts from the source.
- **Pass 2 (rewrite)** rewrites those observations into a summary under an explicit **word budget**, with the **source unseen** — so the model can only reword what it already extracted, not invent.

## Details
- `quill/core/ai/two_pass.py` (pure, unit-tested prompts) + wiring in `Assistant.transform`'s summarize path (both the direct and map-reduce-combine calls) via `_summarize`. Pass 1 is unwrapped faithful extraction; pass 2 is wrapped so the user's instructions/style still shape the final summary.
- **Opt-in, local-only**: gated on `two_pass_summarize` (default on) **and** a local backend (`is_local`, from #1319), so cloud models never pay for the second call. The single-pass escape hatch (`two_pass_summarize=False`) preserves speed on slow CPUs; `summary_word_budget` is configurable.

> Note: activates together with #1319's `AIBackend.is_local` marker — dormant (single-pass) until that lands, so merge order is safe either way.

## Testing
5 prompt tests + 4 wiring tests (call order, budget carried, source hidden in pass 2; disabled/cloud/non-summarize all stay single-pass). Full `core/ai` suite green — **821 passed**. Ruff/format/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)