### PR TITLE
Sign-off tool: hide/show checked-off items (accessible toggle)

### DIFF
--- a/docs/planning/signoff/interactive/QUILL-1.0.0-SIGNOFF.html
+++ b/docs/planning/signoff/interactive/QUILL-1.0.0-SIGNOFF.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 — Release Sign-off Test Plan (master)</h1>
 <p><strong>Purpose:</strong> verify <strong>every feature in QUILL</strong> — the editor plus the two public companion apps (<strong>Quill Radio</strong>, <strong>Quill Weather</strong>) — works, presents an exact surface, and is accessible, under <strong>both portable and system installs</strong>. Nothing ships until every applicable box is checked.</p>
@@ -103,12 +112,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -117,9 +166,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-dialogs.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-dialogs.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Dialog surfaces (A11Y-4 registry)</h1>
 <p><strong>647 dialog call-sites</strong> from <code>tests/unit/ui/fixtures/dialog_inventory.json</code>. Each: opens, keyboard-complete, correct accessible name/role, Escape/Close contract, announces outcome. <code>native</code>=stock OS dialog, <code>hardened_custom</code>=QUILL dialog, <code>web</code>=HTML-form dialog.</p>
@@ -699,12 +708,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -713,9 +762,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-editor.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-editor.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Editor commands</h1>
 <p><strong>645 core-editor commands</strong> (of 718 total). Legend per item: <strong>W</strong>=Works · <strong>S</strong>=Surface-exact (label/shortcut/menu path + accessible name) · <strong>A</strong>=Accessible (keyboard + announced). Verify each across every §A environment in the master plan.</p>
@@ -749,12 +758,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -763,9 +812,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-gated-apps.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-gated-apps.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Gated apps: verify ABSENCE from public surfaces</h1>
 <p>With the release/dev flag OFF (default public build), these <strong>44 commands</strong> and their app launchers/menus MUST NOT appear in menus, the command palette, Explorer shell verbs, or QuillVille. Check each is absent.</p>
@@ -75,12 +84,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -89,9 +138,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-install-matrix.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-install-matrix.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Installation-mode matrix (portable vs system, all scenarios)</h1>
 <p>Install-mode behavior is governed by <strong>three independent "portable" signals that can disagree</strong>: (1) <strong>data-dir</strong> (<code>storage_mode.py</code>/<code>storage-mode.json</code>), (2) <strong>secrets</strong> (<code>QUILL_PORTABLE=1</code> → DPAPI <code>keys.enc</code> vs Credential Manager), (3) <strong>update-asset</strong> (<code>updates.running_portable()</code>, subtracts the <code>unins000</code> marker). Every scenario below must be run for <strong>QUILL editor, Quill Radio, and Quill Weather</strong>. Legend per box: <strong>[ ]</strong> = verified.</p>
@@ -86,12 +95,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -100,9 +149,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-radio.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-radio.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Quill Radio (public app)</h1>
 <p><strong>29 commands</strong> + <strong>36 dialog surfaces.</strong> Run across every §A environment (portable + system, Windows + macoS). Legend: W/S/A as in the master.</p>
@@ -109,12 +118,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -123,9 +172,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/SIGNOFF-weather.html
+++ b/docs/planning/signoff/interactive/SIGNOFF-weather.html
@@ -7,21 +7,30 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 Sign-off — Quill Weather (public app)</h1>
 <p>Weather binds menu handlers directly (no palette/registry ids). <strong>11 menu actions</strong> + standalone-app chrome + <strong>4 dialog surfaces.</strong> Run across every §A environment. Legend: W/S/A.</p>
@@ -71,12 +80,52 @@
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -85,9 +134,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/docs/planning/signoff/interactive/index.html
+++ b/docs/planning/signoff/interactive/index.html
@@ -7,32 +7,81 @@
 <style>
   body { font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html { scroll-padding-top: 4em; }
   li { margin: 0.35em 0; }
   input.so { width: 1.1em; height: 1.1em; margin-right: 0.3em; }
   .bar { position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }
   @media (prefers-color-scheme: dark) { body { background: #111; color: #eee; }
     .bar { background: #111; } }
+  .bar button, .bar a { margin-right: 0.5em; }
+  li[hidden] { display: none; }
+  .visually-hidden { position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 <h1>QUILL 1.0.0 sign-off — interactive checklists</h1><p>Open a checklist, check boxes as you verify; state is saved in the browser (localStorage) the moment a box is toggled and restored when you come back — including after closing the browser. Use Export on each page to back up progress to a JSON file.</p><ul><li><a href="QUILL-1.0.0-SIGNOFF.html">QUILL-1.0.0-SIGNOFF</a> (24 boxes)</li><li><a href="SIGNOFF-dialogs.html">SIGNOFF-dialogs</a> (1941 boxes)</li><li><a href="SIGNOFF-editor.html">SIGNOFF-editor</a> (1935 boxes)</li><li><a href="SIGNOFF-gated-apps.html">SIGNOFF-gated-apps</a> (132 boxes)</li><li><a href="SIGNOFF-install-matrix.html">SIGNOFF-install-matrix</a> (33 boxes)</li><li><a href="SIGNOFF-radio.html">SIGNOFF-radio</a> (216 boxes)</li><li><a href="SIGNOFF-weather.html">SIGNOFF-weather</a> (93 boxes)</li></ul>
 <script>
 (function () {
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {
+    if (li.querySelector("input.so")) checkItems.push(li);
+  });
   function refresh() {
     var done = 0;
     boxes.forEach(function (b) { if (b.checked) done++; });
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) { if (!bs[i].checked) return false; }
+    return true;
+  }
+  function hideActive() { return localStorage.getItem(HIDE_KEY) === "1"; }
+  function applyHide() {
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    });
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {
+      if (!arr[i].closest("li").hidden) { arr[i].focus(); return; }
+    }
+    for (var j = start - 1; j >= 0; j--) {
+      if (!arr[j].closest("li").hidden) { arr[j].focus(); return; }
+    }
+    if (toggleBtn) toggleBtn.focus();
   }
   boxes.forEach(function (b) {
     var key = PREFIX + b.dataset.key;
@@ -41,9 +90,34 @@
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }
+      }
     });
   });
   refresh();
+  if (toggleBtn && boxes.length > 0) {
+    applyHide();
+    toggleBtn.addEventListener("click", function () {
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }
+    });
+  } else if (toggleBtn) {
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }
   document.getElementById("export").addEventListener("click", function () {
     var state = {};
     for (var i = 0; i < localStorage.length; i++) {

--- a/scripts/gen_signoff_html.py
+++ b/scripts/gen_signoff_html.py
@@ -122,32 +122,81 @@ _PAGE = """<!DOCTYPE html>
 <style>
   body {{ font-family: system-ui, sans-serif; max-width: 60em; margin: 0 auto;
          padding: 1em; line-height: 1.5; }}
+  /* Keep a focus target clear of the sticky bar when scrolled to (WCAG 2.4.11
+     Focus Not Obscured) -- matters now that hiding an item moves focus. */
+  html {{ scroll-padding-top: 4em; }}
   li {{ margin: 0.35em 0; }}
   input.so {{ width: 1.1em; height: 1.1em; margin-right: 0.3em; }}
   .bar {{ position: sticky; top: 0; background: Canvas; padding: 0.5em 0;
           border-bottom: 1px solid GrayText; }}
   @media (prefers-color-scheme: dark) {{ body {{ background: #111; color: #eee; }}
     .bar {{ background: #111; }} }}
+  .bar button, .bar a {{ margin-right: 0.5em; }}
+  li[hidden] {{ display: none; }}
+  .visually-hidden {{ position: absolute; width: 1px; height: 1px; margin: -1px;
+    padding: 0; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; border: 0; }}
 </style>
 </head>
 <body>
 <div class="bar" role="group" aria-label="Sign-off progress and state">
   <span id="progress" role="status">Loading…</span>
+  <button id="toggleHide" type="button" aria-pressed="false">Hide checked items</button>
   <button id="export">Export progress…</button>
   <button id="import">Import progress…</button>
   <input type="file" id="importFile" accept=".json" hidden>
   <a href="index.html">All checklists</a>
+  <span id="hideStatus" class="visually-hidden" aria-live="polite"></span>
 </div>
 {body}
 <script>
 (function () {{
   var PREFIX = "quill-signoff:";
+  var HIDE_KEY = PREFIX + "__hideChecked__";
   var boxes = document.querySelectorAll("input.so");
+  var toggleBtn = document.getElementById("toggleHide");
+  var hideStatus = document.getElementById("hideStatus");
+  var checkItems = [];
+  document.querySelectorAll("li").forEach(function (li) {{
+    if (li.querySelector("input.so")) checkItems.push(li);
+  }});
   function refresh() {{
     var done = 0;
     boxes.forEach(function (b) {{ if (b.checked) done++; }});
     document.getElementById("progress").textContent =
       done + " of " + boxes.length + " boxes checked";
+  }}
+  // An item is "checked off" only when every checkbox on it (Works / Surface /
+  // Accessible) is ticked; a partly-done item stays visible.
+  function itemDone(li) {{
+    var bs = li.querySelectorAll("input.so");
+    if (bs.length === 0) return false;
+    for (var i = 0; i < bs.length; i++) {{ if (!bs[i].checked) return false; }}
+    return true;
+  }}
+  function hideActive() {{ return localStorage.getItem(HIDE_KEY) === "1"; }}
+  function applyHide() {{
+    var on = hideActive();
+    var hidden = 0;
+    checkItems.forEach(function (li) {{
+      li.hidden = on && itemDone(li);
+      if (li.hidden) hidden++;
+    }});
+    if (toggleBtn) toggleBtn.setAttribute("aria-pressed", on ? "true" : "false");
+    return hidden;
+  }}
+  // When ticking a box hides the item the user is standing on, move focus off
+  // the now-hidden control to the next visible box (else the previous, else the
+  // toggle) so keyboard/screen-reader focus is never stranded.
+  function focusAfterHide(box) {{
+    var arr = Array.prototype.slice.call(boxes);
+    var start = arr.indexOf(box);
+    for (var i = start + 1; i < arr.length; i++) {{
+      if (!arr[i].closest("li").hidden) {{ arr[i].focus(); return; }}
+    }}
+    for (var j = start - 1; j >= 0; j--) {{
+      if (!arr[j].closest("li").hidden) {{ arr[j].focus(); return; }}
+    }}
+    if (toggleBtn) toggleBtn.focus();
   }}
   boxes.forEach(function (b) {{
     var key = PREFIX + b.dataset.key;
@@ -156,9 +205,34 @@ _PAGE = """<!DOCTYPE html>
       if (b.checked) localStorage.setItem(key, "1");
       else localStorage.removeItem(key);
       refresh();
+      if (hideActive()) {{
+        var li = b.closest("li");
+        var willHide = b.checked && li && itemDone(li);
+        applyHide();
+        if (willHide && li.hidden) {{
+          // The item the user just completed is vanishing; say so (brief), then
+          // move focus off the now-hidden control.
+          if (hideStatus) hideStatus.textContent = "Item completed and hidden.";
+          focusAfterHide(b);
+        }}
+      }}
     }});
   }});
   refresh();
+  if (toggleBtn && boxes.length > 0) {{
+    applyHide();
+    toggleBtn.addEventListener("click", function () {{
+      localStorage.setItem(HIDE_KEY, hideActive() ? "0" : "1");
+      var hidden = applyHide();
+      if (hideStatus) {{
+        hideStatus.textContent = hideActive()
+          ? (hidden + (hidden === 1 ? " checked item hidden." : " checked items hidden."))
+          : "Showing all items.";
+      }}
+    }});
+  }} else if (toggleBtn) {{
+    toggleBtn.hidden = true;  // no checkboxes on this page (e.g. the index)
+  }}
   document.getElementById("export").addEventListener("click", function () {{
     var state = {{}};
     for (var i = 0; i < localStorage.length; i++) {{


### PR DESCRIPTION
Adds an accessible **Hide checked items** toggle to the interactive sign-off checklists (`scripts/gen_signoff_html.py`), so a reviewer can declutter a long list to just the outstanding items and bring the completed ones back at will.

## Behaviour
- A native `aria-pressed` toggle button hides every `<li>` whose checkboxes are **all** ticked (via the `hidden` attribute → removed from the accessibility tree); partly-done items stay visible. Click again to show all.
- Preference **persists in localStorage** and restores on load (no intrusive load announcement — `aria-pressed` carries the state).
- **Focus management**: ticking a box that completes-and-hides its item moves focus to the next visible checkbox (else previous, else the toggle), so keyboard/SR focus is never stranded; a brief polite live-region message announces the auto-hide and toggle state.
- Self-hides on the index page (no checkboxes).

## Accessibility
Reviewed by the accessibility lead (consolidating aria / keyboard / live-region / focus specialists): **SHIP, no blockers.** Applied the one Important item — **WCAG 2.2 2.4.11 Focus Not Obscured** (`html { scroll-padding-top }` so a programmatically-focused checkbox clears the sticky bar) — plus the recommended auto-hide announcement. `aria-pressed` + stable label, two non-conflicting live regions, and `hidden`-tree semantics all verified; `itemDone()` guarantees a partly-checked item never hides.

## Validation
Generator is ruff-clean; all 7 interactive pages regenerated; emitted JS passes `node --check` (braces balanced, handlers present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)