### PR TITLE
chore(release): bundle the feed-signing public key + pin wxPython exactly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,15 @@ dependencies = [
 
 [project.optional-dependencies]
 ui = [
-    "wxPython>=4.2.5",
+    # Pinned exactly for 1.0.0, not floored. wxPython 4.3.x tracks the
+    # wxWidgets master branch, which upstream documents as API/ABI UNSTABLE
+    # between 4.3.x releases -- so a bare floor means a release build can
+    # silently ship a wx the acceptance run never tested, and QUILL's whole
+    # product is screen-reader behavior on those widgets. 4.3.1 (wxWidgets
+    # 3.3.3) is the version the 1.0.0 suite and JAWS/NVDA pass ran against.
+    # Same rationale as the llama-cpp-python exact pin below. Re-test the
+    # editor, dialogs, and braille surfaces before bumping.
+    "wxPython==4.3.1",
     # Accessible wx.html2.WebView surfaces (chat, preview, dialogs) — extracted
     # from Quill and published so any wxPython app can reuse it.
     "wx-accessible-webview>=0.2.0",

--- a/quill/core/feed-pub.key
+++ b/quill/core/feed-pub.key
@@ -1,1 +1,1 @@
-m1oUUJ8wAvRwmO8b+1PaAcfI9IjXITZOun1909AEy28=
+qg3CgfxIDONxMjjPz4d/kZK44zFBf2t/BoyzYv2ywLY=

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,9 @@ defusedxml>=0.7.1
 comtypes>=1.4.16; sys_platform == "win32"
 
 # UI
-wxPython>=4.2.5
+# Exact pin (not a floor): wxPython 4.3.x tracks wxWidgets master, which is
+# API/ABI unstable between 4.3.x releases. Ship what acceptance tested.
+wxPython==4.3.1
 # Accessible wx.html2.WebView surfaces (chat, preview, About, update dialogs).
 wx-accessible-webview>=0.2.0
 # pywin32 — win32gui for active-window screen capture (AI image description) and


### PR DESCRIPTION
## Summary

Two release-readiness items:

**1. Feed signing is now actually armed.** The `QUILL_FEED_SIGNING_KEY` repo secret is provisioned with a dedicated Ed25519 seed (generated fresh, private half kept outside the repo). This commits its public half to `quill/core/feed-pub.key` so shipped clients can verify. Without this commit, a CI-signed feed would hard-fail verification on every client built from main — the verifier added in #1347 treats a present-but-invalid signature as forged.

The feed key is deliberately distinct from `quill-pub.key` (artifact signing): different purpose, different blast radius, independently rotatable.

**2. wxPython pinned `==4.3.1`** instead of floored at `>=4.2.5`. The floor was never conservative — it resolved to whatever PyPI had latest, so release builds were already going to ship 4.3.1 while local testing sat on 4.2.5. wxPython 4.3.x tracks the wxWidgets master branch, which upstream documents as API/ABI unstable *between* 4.3.x releases, and QUILL's entire product is screen-reader behavior on those widgets. Ship exactly what the acceptance run tested. Mirrors the existing `llama-cpp-python==0.3.32` pin.

## Checks
Structure + scripts suites (126) pass, GATE-VC passes, `pip check` clean, wx resolves to 4.3.1 / wxWidgets 3.3.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)