### PR TITLE
test(tooling): pre-commit active, Hypothesis + pytest-randomly added

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -98,14 +98,42 @@ jobs:
         # on 2026-07-14 (same test, different workers, then the xdist scheduler
         # deadlocked on the dead worker). In a fresh process it is fast and
         # boring.
+        #
+        # tests\unit\ui runs as its OWN step below rather than sharing this
+        # pool. Two reasons, both learned the hard way on 2026-08-07:
+        #   1. Determinism. With one shared pool, --dist=loadfile assigns files
+        #      across workers by position, so merely ADDING an unrelated test
+        #      file (a core property-test module) reshuffled the split, landed
+        #      more wx files on one worker, and tipped it past the handle
+        #      ceiling -- 27 failures in code that commit never touched. With
+        #      the wx files in their own pool, non-UI additions cannot move
+        #      them.
+        #   2. Headroom. The UI pool gets more workers than cores precisely
+        #      because the constraint is per-PROCESS Windows USER handles, not
+        #      CPU: more processes means fewer wx files each, and roughly half
+        #      the peak handle count per worker. These tests are GUI- and
+        #      I/O-bound, so oversubscribing cores costs little wall clock.
+        # The underlying leak (widget tests that never Destroy their windows)
+        # is still real and worth fixing at the source; see the note in
+        # tests\unit\ui\conftest.py.
         run: |
           pytest tests\unit tests\accessibility -q -n 4 --dist=loadfile `
             --timeout=300 --timeout-method=thread `
+            --ignore=tests\unit\ui `
             --ignore=tests\unit\core\test_net_tls.py `
             --ignore=tests\unit\core\test_thesaurus.py `
-            --ignore=tests\unit\ui\test_dialog_inventory.py `
             --cov=quill.core --cov=quill.io `
             --cov-report=
+      - name: Run UI widget tests (own worker pool, more headroom)
+        # --cov-append: this is a second pytest process writing to the same
+        # .coverage data the floor check reads, so it must add to the first
+        # step's measurements rather than replace them.
+        run: |
+          pytest tests\unit\ui -q -n 8 --dist=loadfile `
+            --timeout=300 --timeout-method=thread `
+            --ignore=tests\unit\ui\test_dialog_inventory.py `
+            --cov=quill.core --cov=quill.io `
+            --cov-append --cov-report=
       - name: Run dialog-inventory gate tests (isolated process)
         run: |
           pytest tests\unit\ui\test_dialog_inventory.py -q `

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -293,6 +293,13 @@ dev = [
   "pytest-xdist>=3.8.0",
   "pytest-timeout>=2.4.0",
   "pytest-cov>=7.1.0",
+  # Property-based testing for the pure parsers (find_model, regex_helper,
+  # quill/io readers): generates edge cases a hand-written example never
+  # thinks of. See tests/unit/core/test_find_model_properties.py.
+  "hypothesis>=6.165.2",
+  # Randomized test ordering, DISABLED by default via addopts (-p no:randomly).
+  # Opt in with `pytest -p randomly ...` to hunt order-dependent coupling.
+  "pytest-randomly>=4.1.0",
   "ruff>=0.15.21",
   "mypy>=2.3.0",
   # I18N: string extraction, .po update, .mo compile
@@ -361,6 +368,15 @@ python_files = ["test_*.py"]
 timeout = 30
 log_cli = true
 log_level = "INFO"
+# pytest-randomly is installed but OFF by default. It shuffles test order on
+# every run, which is exactly how you find order-dependent coupling (the wx
+# 4.3 MediaCtrl/COM crash on 2026-08-07 was one) -- but an unpredictable
+# ordering in the required CI gates would turn a real failure into a
+# can't-reproduce. Opt in deliberately when hunting that class of bug:
+#     pytest -p randomly tests/unit/core
+#     pytest -p randomly -p no:cacheprovider tests/unit/ui   # a suspect area
+# Reproduce a specific shuffle with the seed it prints: -p randomly -p randomly.seed=12345
+addopts = "-p no:randomly"
 markers = [
     "perf: wall-clock performance budgets; run with RUN_PERF=1 or exclude with -m 'not perf'",
     "smoke: fast, high-signal core checks; run the quick subset with -m smoke",

--- a/quill/core/find_model.py
+++ b/quill/core/find_model.py
@@ -362,6 +362,14 @@ def context_sentence(text: str, match: FindMatch, *, max_chars: int = 120) -> st
             sent_end = j
             break
     sentence = _collapse(text[sent_start:sent_end])
+    if not sentence:
+        # The surrounding "sentence" was whitespace only -- searching for a
+        # space or a tab on an otherwise blank line. Returning "" would make
+        # the caller announce nothing at all, and a silent success is an
+        # accessibility failure (the acceptance book's own rubric): the
+        # listener cannot tell a found match from a failed search. Fall back
+        # to the position, which is always speakable.
+        return f"line {match.line}, column {match.column}"
     if len(sentence) <= max_chars:
         return sentence
     center = (match.start + match.end) // 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,29 @@ def pytest_configure(config: pytest.Config) -> None:
     """
     if config.option.basetemp is None:
         config.option.basetemp = str(Path.home() / ".quill-pytest-tmp")
+    _configure_hypothesis()
+
+
+def _configure_hypothesis() -> None:
+    """Register the suite's Hypothesis profile (no-op if it isn't installed).
+
+    ``deadline=None`` disables Hypothesis's per-example time limit. The default
+    (200ms) measures wall-clock per generated example, which on a loaded CI
+    runner -- four xdist workers plus AST-scanning gates -- turns an otherwise
+    passing property into an intermittent DeadlineExceeded. Correctness, not
+    latency, is what these properties assert; the suite-wide pytest ``timeout``
+    still bounds a genuinely hung test.
+    """
+    try:
+        from hypothesis import HealthCheck, settings
+    except ModuleNotFoundError:  # property tests skip themselves without it
+        return
+    settings.register_profile(
+        "quill",
+        deadline=None,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    settings.load_profile("quill")
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/unit/core/test_find_model_properties.py
+++ b/tests/unit/core/test_find_model_properties.py
@@ -1,0 +1,179 @@
+"""Property-based tests for the find model (Hypothesis).
+
+The example-based suite in ``test_find_model.py`` pins the behaviors we
+designed for. These properties assert the invariants that must hold for
+*every* input, which is how the generator earns its keep: the caller-side
+anchor bug fixed on 2026-08-07 (a repeated backwards search that re-found
+the same match forever) is exactly the shape of defect a hand-written
+example set can miss and a shrinking counterexample names precisely. The
+first run of this file found a real one -- ``context_sentence`` returned an
+empty string for a match on a whitespace-only line, which would have
+announced a found match as silence.
+
+Properties only, no timing assertions -- see ``_configure_hypothesis`` in
+``tests/conftest.py`` for why the Hypothesis deadline is disabled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import assume, given  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+from quill.core.find_model import (  # noqa: E402
+    FindQuery,
+    all_matches,
+    compile_query,
+    context_sentence,
+    count_matches,
+    find_next,
+)
+
+# Deliberately nasty alphabet: regex metacharacters (the literal path must
+# escape them), newlines (line/column arithmetic and sentence boundaries),
+# and non-ASCII (word boundaries and case folding).
+_ALPHABET = "ab.*+?[]()\\|^$ \nÉé "
+_TEXT = st.text(alphabet=_ALPHABET, max_size=200)
+_NEEDLE = st.text(alphabet=_ALPHABET, min_size=1, max_size=8)
+
+
+@st.composite
+def _document_and_needle(draw: st.DrawFn) -> tuple[str, str]:
+    """A document that is GUARANTEED to contain its needle.
+
+    Random text almost never contains a random needle, so the naive
+    ``assume(match is not None)`` filters out nearly every example and
+    Hypothesis (rightly) fails the health check. Joining chunks *with* the
+    needle puts real matches in every document, which is what the
+    search-advances properties need to exercise anything.
+    """
+    needle = draw(_NEEDLE)
+    chunks = draw(st.lists(st.text(alphabet=_ALPHABET, max_size=20), min_size=2, max_size=5))
+    return needle.join(chunks), needle
+
+
+def _compiled(needle: str, **kwargs: object) -> object:
+    return compile_query(FindQuery(text=needle, **kwargs))  # type: ignore[arg-type]
+
+
+@given(text=_TEXT, needle=_NEEDLE, case_sensitive=st.booleans())
+def test_reported_offsets_always_describe_the_real_text(
+    text: str, needle: str, case_sensitive: bool
+) -> None:
+    """Every match's offsets slice exactly the text the match reports."""
+    matches, _truncated = all_matches(_compiled(needle, case_sensitive=case_sensitive), text)
+    for match in matches:
+        assert 0 <= match.start <= match.end <= len(text)
+        assert text[match.start : match.end] == match.text
+
+
+@given(text=_TEXT, needle=_NEEDLE)
+def test_matches_are_ordered_and_non_overlapping(text: str, needle: str) -> None:
+    """all_matches walks left to right without revisiting consumed text."""
+    matches, _truncated = all_matches(_compiled(needle), text)
+    for earlier, later in zip(matches, matches[1:], strict=False):
+        assert earlier.end <= later.start
+
+
+@given(text=_TEXT, needle=_NEEDLE)
+def test_count_agrees_with_the_match_list(text: str, needle: str) -> None:
+    """count_matches is a cheaper path to the same answer as all_matches."""
+    compiled = _compiled(needle)
+    count, count_truncated = count_matches(compiled, text)
+    matches, list_truncated = all_matches(compiled, text)
+    if not count_truncated and not list_truncated:
+        assert count == len(matches)
+
+
+@given(doc=_document_and_needle(), start=st.integers(min_value=-50, max_value=250))
+def test_forward_search_always_advances(doc: tuple[str, str], start: int) -> None:
+    """A forward find from a match's end never returns that same match.
+
+    The invariant that keeps repeated Find Next from looping forever, and the
+    forward twin of the backwards anchor bug fixed in the Find dialog.
+    """
+    text, needle = doc
+    compiled = _compiled(needle, wrap=False)
+    first, _wrapped = find_next(compiled, text, from_pos=start, backwards=False)
+    assume(first is not None)
+    assert first is not None
+    second, _wrapped2 = find_next(compiled, text, from_pos=first.end, backwards=False)
+    if second is not None:
+        assert (second.start, second.end) != (first.start, first.end)
+        assert second.start >= first.start
+
+
+@given(doc=_document_and_needle(), start=st.integers(min_value=-50, max_value=250))
+def test_backward_search_always_retreats(doc: tuple[str, str], start: int) -> None:
+    """A backwards find anchored at a match's start never re-finds it.
+
+    This is the exact invariant the Find dialog violated by anchoring its
+    backwards repeat at ``match.end`` instead of ``match.start``.
+    """
+    text, needle = doc
+    compiled = _compiled(needle, wrap=False)
+    first, _wrapped = find_next(compiled, text, from_pos=start, backwards=True)
+    assume(first is not None)
+    assert first is not None
+    second, _wrapped2 = find_next(compiled, text, from_pos=first.start, backwards=True)
+    if second is not None:
+        assert (second.start, second.end) != (first.start, first.end)
+        assert second.end <= first.end
+
+
+@given(text=_TEXT, needle=_NEEDLE)
+def test_line_and_column_match_the_offset(text: str, needle: str) -> None:
+    """The spoken position (line N, column M) agrees with the raw offset."""
+    matches, _truncated = all_matches(_compiled(needle), text)
+    for match in matches:
+        expected_line = text.count("\n", 0, match.start) + 1
+        line_start = text.rfind("\n", 0, match.start) + 1
+        assert match.line == expected_line
+        assert match.column == match.start - line_start + 1
+
+
+@given(text=_TEXT, needle=_NEEDLE)
+def test_case_insensitive_finds_at_least_as_much(text: str, needle: str) -> None:
+    """Relaxing case can only ever find more matches, never fewer."""
+    sensitive, s_trunc = count_matches(_compiled(needle, case_sensitive=True), text)
+    insensitive, i_trunc = count_matches(_compiled(needle, case_sensitive=False), text)
+    if not s_trunc and not i_trunc:
+        assert insensitive >= sensitive
+
+
+@given(text=_TEXT, needle=_NEEDLE)
+def test_context_sentence_is_never_silent(text: str, needle: str) -> None:
+    """Every match yields a non-empty, newline-free announcement.
+
+    A screen reader reads this aloud verbatim: an empty string announces a
+    found match as silence (indistinguishable from "not found"), and an
+    embedded newline splits one announcement into two. Hypothesis found the
+    empty case on a whitespace-only line; context_sentence now falls back to
+    the match position.
+    """
+    matches, _truncated = all_matches(_compiled(needle), text)
+    for match in matches[:5]:
+        sentence = context_sentence(text, match)
+        assert sentence.strip(), f"silent announcement for {match!r} in {text!r}"
+        assert "\n" not in sentence
+
+
+@given(needle=_NEEDLE)
+def test_empty_document_never_matches(needle: str) -> None:
+    matches, truncated = all_matches(_compiled(needle), "")
+    assert len(matches) == 0
+    assert not truncated
+
+
+@given(text=_TEXT)
+def test_empty_query_never_matches(text: str) -> None:
+    """An empty needle finds nothing rather than matching everywhere."""
+    compiled = compile_query(FindQuery(text=""))
+    matches, truncated = all_matches(compiled, text)
+    assert len(matches) == 0
+    assert not truncated
+    assert count_matches(compiled, text) == (0, False)
+    assert find_next(compiled, text, from_pos=0) == (None, False)

--- a/tests/unit/ui/conftest.py
+++ b/tests/unit/ui/conftest.py
@@ -1,5 +1,24 @@
 """Shared fixtures for the UI unit tests.
 
+KNOWN ISSUE -- window-handle leak (not yet fixed at the source). Windows caps
+a process at 10,000 User (Window Manager) handles. Widget tests that create a
+wx.Frame or wx.Dialog and let it fall out of scope leak the native HWND for
+the life of the process: Python's garbage collector does not destroy a wx
+window, only an explicit Destroy() does. A single-process run of this
+directory exhausts the ceiling about three quarters of the way through and
+collapses into a cascade of failures that look unrelated to their tests
+("Failed to create dialog. Incorrect DLGTEMPLATE?", "can't append invalid
+menu to menubar", "'NoneType' object has no attribute 'Enable'").
+
+CI works around it by running this directory in its own xdist pool with more
+workers than cores, so no single process gets close (see pr-ci.yml). An
+autouse teardown that destroyed each test's leaked top-level windows was
+tried on 2026-08-07 and made no measurable difference to the failure count,
+so the leak is not (only) un-destroyed top-level windows -- diagnosing it
+properly means instrumenting GetGuiResources per test. Until then, run this
+directory with -n to reproduce CI locally; a bare single-process
+`pytest tests/unit/ui` is expected to fail late.
+
 The one fixture here exists because of a wxPython 4.3 (wxWidgets 3.3)
 interaction: constructing a REAL ``wx.media.MediaCtrl`` with the WMP10
 ActiveX backend deep into a long single-process test run access-violates on


### PR DESCRIPTION
## Summary

Adds the three tooling items, and fixes a real accessibility defect the new property tests found on their first run.

**pre-commit is now active.** The repo already had a hand-repaired hook (fixed 2026-07-17 after pre-commit''s generated version hard-coded an uninstalled interpreter and hung `git commit` on a Windows volume prompt). It has been silently exiting 0 ever since, because the package was never installed — every commit in this repo printed `pre-commit not installed ... skipping`. Installing the package is the entire fix; the repaired shim is kept rather than letting `pre-commit install` overwrite it with the fragile generated one. Eight gates now run before a commit is accepted — including the module-size budget, which is what failed CI earlier today.

**Hypothesis** — property-based tests for `quill/core/find_model`, the pure parser behind Find. Ten properties covering offset/text agreement, ordering, count-vs-list consistency, forward-advance and backward-retreat (the exact invariant the Find dialog violated), line/column arithmetic, case-insensitivity monotonicity, and announcement quality. The Hypothesis deadline is disabled via a registered profile in `tests/conftest.py`: the 200ms default measures wall clock, which on a loaded CI runner turns a passing property into an intermittent failure.

**pytest-randomly** — installed but **off by default** (`addopts = "-p no:randomly"`). Shuffled ordering is how order-dependent coupling gets found (the wx 4.3 MediaCtrl/COM crash was one), but unpredictable ordering inside the required gates would turn a real failure into a can''t-reproduce. Opt in deliberately with `pytest -p randomly tests/unit/core`.

## Real defect found and fixed

`context_sentence()` returned `""` for a match on a whitespace-only line — e.g. searching for a space in `"\n \n"`. The Find dialog announces that string verbatim, so a **found match would have been announced as silence**, indistinguishable from "no matches" for a screen-reader user. That is a direct violation of the acceptance book''s own rubric ("a silent success is an accessibility failure"). It now falls back to `"line N, column M"`, which is always speakable.

This is the case for property testing in one example: the behavior is correct for every hand-written example anyone thought to write, and wrong for an input nobody imagined.

## Checks
10 new properties pass; the 70 existing find-model and find-dialog tests still pass; ruff, mypy, and smoke clean; randomly verified both off-by-default and working when opted into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)