### PR TITLE
fix(tests): reclaim leaked wx window handles (root cause + fix)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -99,41 +99,25 @@ jobs:
         # deadlocked on the dead worker). In a fresh process it is fast and
         # boring.
         #
-        # tests\unit\ui runs as its OWN step below rather than sharing this
-        # pool. Two reasons, both learned the hard way on 2026-08-07:
-        #   1. Determinism. With one shared pool, --dist=loadfile assigns files
-        #      across workers by position, so merely ADDING an unrelated test
-        #      file (a core property-test module) reshuffled the split, landed
-        #      more wx files on one worker, and tipped it past the handle
-        #      ceiling -- 27 failures in code that commit never touched. With
-        #      the wx files in their own pool, non-UI additions cannot move
-        #      them.
-        #   2. Headroom. The UI pool gets more workers than cores precisely
-        #      because the constraint is per-PROCESS Windows USER handles, not
-        #      CPU: more processes means fewer wx files each, and roughly half
-        #      the peak handle count per worker. These tests are GUI- and
-        #      I/O-bound, so oversubscribing cores costs little wall clock.
-        # The underlying leak (widget tests that never Destroy their windows)
-        # is still real and worth fixing at the source; see the note in
-        # tests\unit\ui\conftest.py.
+        # The window-handle exhaustion this comment describes was ROOT-CAUSED
+        # and fixed on 2026-08-08: widget tests created wx.Frame/wx.Dialog
+        # without Destroy(), and a wx window outlives Python's garbage
+        # collector. The _reclaim_leaked_wx_windows fixture in tests\conftest.py
+        # now destroys each test's leaked windows and pumps the pending-delete
+        # list. Measured effect on a single-process run of tests\unit\ui:
+        # 71 failed / 25 errors and handles pinned at the 10,000 ceiling,
+        # became 2609 passed / 0 failed with handles peaking at 523.
+        # -n 4 --dist=loadfile is kept for wall-clock and because loadfile
+        # keeps each file's tests together so module-scoped wx_app fixtures
+        # still work -- no longer as a handle workaround.
         run: |
           pytest tests\unit tests\accessibility -q -n 4 --dist=loadfile `
             --timeout=300 --timeout-method=thread `
-            --ignore=tests\unit\ui `
             --ignore=tests\unit\core\test_net_tls.py `
             --ignore=tests\unit\core\test_thesaurus.py `
-            --cov=quill.core --cov=quill.io `
-            --cov-report=
-      - name: Run UI widget tests (own worker pool, more headroom)
-        # --cov-append: this is a second pytest process writing to the same
-        # .coverage data the floor check reads, so it must add to the first
-        # step's measurements rather than replace them.
-        run: |
-          pytest tests\unit\ui -q -n 8 --dist=loadfile `
-            --timeout=300 --timeout-method=thread `
             --ignore=tests\unit\ui\test_dialog_inventory.py `
             --cov=quill.core --cov=quill.io `
-            --cov-append --cov-report=
+            --cov-report=
       - name: Run dialog-inventory gate tests (isolated process)
         run: |
           pytest tests\unit\ui\test_dialog_inventory.py -q `

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,78 @@ def _enable_dev_build_for_tests() -> None:
     paths_mod._DEV_BUILD = True
 
 
+@pytest.fixture(autouse=True)
+def _reclaim_leaked_wx_windows():
+    """Destroy wx top-level windows a test created but never destroyed.
+
+    Windows caps a process at 10,000 User (window) handles. A wx.Frame or
+    wx.Dialog that simply falls out of scope keeps its native window alive for
+    the life of the process -- Python's garbage collector does not destroy a wx
+    window, only ``Destroy()`` does. Measured: an App plus one Frame, one
+    Dialog and twenty controls is 28 USER objects; dropping the frame without
+    destroying it leaks 2, and at roughly 2-4 leaked per widget test the suite
+    reaches the ceiling about three quarters of the way through. Past it every
+    CreateWindowEx fails and the run collapses into failures that look
+    unrelated to their own tests ("Failed to create dialog. Incorrect
+    DLGTEMPLATE?", "can't append invalid menu to menubar").
+
+    ``Destroy()`` only SCHEDULES deletion -- the handle is reclaimed when wx
+    processes its pending-delete list -- so the event loop must be pumped
+    afterwards or nothing is actually freed. (A first attempt at this fixture
+    pumped with ``app.ProcessIdle()``, which does not exist on ``wx.App``; the
+    AttributeError was swallowed by a broad except and the fixture silently did
+    nothing, which is why it appeared not to help.)
+
+    Only windows that appeared *during* the test are destroyed, so a module- or
+    session-scoped fixture's window survives. Teardown never fails a test.
+    """
+    import sys
+
+    def _live_wx():
+        """The real wx module with a running App, else None.
+
+        Some tests install a ``types.SimpleNamespace`` stub as ``sys.modules
+        ["wx"]``, so the module being importable proves nothing -- check that
+        the functions actually exist before calling them. Explicit rather than
+        a broad try/except: swallowing AttributeError here is what hid the
+        ``ProcessIdle`` mistake described above.
+        """
+        wx = sys.modules.get("wx")
+        get_app = getattr(wx, "GetApp", None)
+        if (
+            wx is None
+            or not callable(get_app)
+            or not callable(getattr(wx, "GetTopLevelWindows", None))
+        ):
+            return None
+        return wx if get_app() is not None else None
+
+    def _top_level_ids() -> set[int]:
+        wx = _live_wx()
+        if wx is None:
+            return set()
+        return {id(win) for win in wx.GetTopLevelWindows()}
+
+    before = _top_level_ids()
+    yield
+    wx = _live_wx()
+    if wx is None:
+        return
+    leaked = [win for win in wx.GetTopLevelWindows() if id(win) not in before]
+    if not leaked:
+        return  # nothing to reclaim: skip the pump entirely (it is not free)
+    for win in leaked:
+        try:
+            win.Destroy()
+        except Exception:  # noqa: BLE001 - an already-dead window is fine
+            pass
+    try:
+        wx.GetApp().ProcessPendingEvents()
+        wx.SafeYield()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 @pytest.fixture()
 def quill_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     """Isolated QUILL_DATA_DIR guaranteed to be accepted by paths.app_data_dir().

--- a/tests/unit/ui/conftest.py
+++ b/tests/unit/ui/conftest.py
@@ -1,23 +1,10 @@
 """Shared fixtures for the UI unit tests.
 
-KNOWN ISSUE -- window-handle leak (not yet fixed at the source). Windows caps
-a process at 10,000 User (Window Manager) handles. Widget tests that create a
-wx.Frame or wx.Dialog and let it fall out of scope leak the native HWND for
-the life of the process: Python's garbage collector does not destroy a wx
-window, only an explicit Destroy() does. A single-process run of this
-directory exhausts the ceiling about three quarters of the way through and
-collapses into a cascade of failures that look unrelated to their tests
-("Failed to create dialog. Incorrect DLGTEMPLATE?", "can't append invalid
-menu to menubar", "'NoneType' object has no attribute 'Enable'").
-
-CI works around it by running this directory in its own xdist pool with more
-workers than cores, so no single process gets close (see pr-ci.yml). An
-autouse teardown that destroyed each test's leaked top-level windows was
-tried on 2026-08-07 and made no measurable difference to the failure count,
-so the leak is not (only) un-destroyed top-level windows -- diagnosing it
-properly means instrumenting GetGuiResources per test. Until then, run this
-directory with -n to reproduce CI locally; a bare single-process
-`pytest tests/unit/ui` is expected to fail late.
+The window-handle exhaustion that used to make a single-process run of this
+directory collapse three quarters of the way through is FIXED -- see
+``_reclaim_leaked_wx_windows`` in ``tests/conftest.py``. A bare
+``pytest tests/unit/ui`` passes again (2609 tests, handles peaking at 523
+against the 10,000 ceiling).
 
 The one fixture here exists because of a wxPython 4.3 (wxWidgets 3.3)
 interaction: constructing a REAL ``wx.media.MediaCtrl`` with the WMP10


### PR DESCRIPTION
## Root cause

Instrumented the test process with `GetGuiResources` to measure Windows USER (window) handles per test. The leak is widget tests creating `wx.Frame`/`wx.Dialog` and letting them fall out of scope: **a wx window outlives Python''s garbage collector** — only `Destroy()` frees the native window.

Measured directly:

| State | USER objects |
|---|---|
| App + Frame + Dialog + 20 controls | 28 |
| after `Destroy()` + pump | 6 (fully reclaimed) |
| after dropping the frame, no `Destroy()`, + `gc.collect()` | leaks 2 permanently |

At 2-4 leaked per widget test, `tests\unit\ui` reaches the 10,000 ceiling about three quarters through, after which every `CreateWindowEx` fails and the run collapses into failures that look unrelated to their own tests.

**The detail that made this hard:** `Destroy()` only *schedules* deletion — the handle returns when wx processes its pending-delete list, so the event loop must be pumped. An earlier attempt at this fixture pumped with `app.ProcessIdle()`, **which does not exist on `wx.App`**; the AttributeError was swallowed by a broad `except Exception`, so it destroyed nothing, reported nothing, and appeared to disprove the hypothesis. The working sequence is `ProcessPendingEvents()` + `SafeYield()`.

## Result

Single-process `pytest tests/unit/ui`:

| | Result | Peak handles |
|---|---|---|
| Before | 71 failed, 25 errors | at the 10,000 ceiling |
| After | **2609 passed, 0 failed** | **523** |

## Also reverts today''s CI workaround

Since the leak is genuinely fixed, the separate `-n 8` UI worker pool added earlier today is removed — `tests\unit\ui` returns to the shared `-n 4 --dist=loadfile` pool.

## Two deliberate details
- Only windows created *during* a test are destroyed, so module/session-scoped fixture windows survive.
- The live-wx check is explicit (some tests install a `types.SimpleNamespace` as `sys.modules["wx"]`) rather than a broad `try/except` — swallowing `AttributeError` is exactly what hid this bug the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)