### PR TITLE
chore(radio): bump the quill pin to current main

### DIFF
--- a/standalone/radio/pyproject.toml
+++ b/standalone/radio/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 # The whole app lives in the quill package (quill.apps.radio); this
 # project is the thin product wrapper: entry point, docs, installer.
-dependencies = ["quill[ui] @ git+https://github.com/Community-Access/quill.git@ca37c60d18b6003c5139ee905ee4bfe84a601cf8"]
+dependencies = ["quill[ui] @ git+https://github.com/Community-Access/quill.git@16c3eea4314194ec1a9a39f9cac7118bba6a4971"]
 
 [project.gui-scripts]
 quill-radio = "quill_radio:main"


### PR DESCRIPTION
Follow-up to #1357, as flagged in that PR's body.

`standalone/radio/pyproject.toml` pinned `quill` to `ca37c60` (2026-07-20) — **315 commits behind main, 31 of them touching radio code**. A fresh source install of `quill-radio` got a July build, missing three weeks of radio work including the SecureNet player resolver that #1357 just landed.

Bumped to `16c3eea`, the #1357 merge commit.

## Scope

- **Release builds are unaffected either way.** `scripts/build_release.ps1` builds from a local QUILL checkout (`-QuillRepo`), not from this git URL. This pin only governs `pip install` against this project — which is exactly why it drifted unnoticed.
- **Not install-tested.** Verifying it means a clean `pip install` pulling the full `quill[ui]` dependency set; the change is a literal SHA swap and the release path does not consult it.
- `standalone/studio/pyproject.toml` carries the **same** stale `ca37c60` pin. Deliberately left alone so it can be bumped against an actual Audio Studio build rather than blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)