### PR TITLE
fix(installer): correct the installer README version to 1.0.0

### DIFF
--- a/installer/README-installer.txt
+++ b/installer/README-installer.txt
@@ -1,4 +1,4 @@
-QUILL for All 0.9.0 Beta 3 — Windows Installer
+QUILL for All 1.0.0 — Windows Installer
 Publisher: Community Access
 
 Thank you for installing Quill.


### PR DESCRIPTION
Found while attempting the 1.0.0 Windows build.

`installer/README-installer.txt` — the file the installer ships and shows — still announced:

```
QUILL for All 0.9.0 Beta 3 — Windows Installer
```

So the 1.0.0 installer would have told users they had installed a beta.

`build_windows_distribution.py` regenerates this file from `build/version.toml`, which is how a 1.0.0 build surfaced it; the tracked copy had simply never been refreshed since the Beta 3 build that last wrote it.

One line changed. Line endings (CRLF) untouched.

### Note on `installer/quill.iss`

The same build also rewrote `quill.iss` — 666 lines replaced — but that diff is **purely CRLF vs LF** (`git diff --ignore-cr-at-eol` is empty). The tracked copy is LF; the build writes CRLF on Windows. Discarded rather than committed, since it is pure churn. Flagging it because it will reappear on every Windows build; if it becomes annoying, `installer/*.iss text eol=lf` in `.gitattributes` would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)