### PR TITLE
fix(build): honour the already-bundled feedback token as a token source

### DIFF
--- a/installer/README-installer.txt
+++ b/installer/README-installer.txt
@@ -1,4 +1,4 @@
-QUILL for All 0.9.0 Beta 3 — Windows Installer
+QUILL for All 1.0.0 — Windows Installer
 Publisher: Community Access
 
 Thank you for installing Quill.

--- a/tests/unit/tools/test_generate_feedback_token.py
+++ b/tests/unit/tools/test_generate_feedback_token.py
@@ -74,3 +74,56 @@ def test_env_token_overwrites_an_existing_bundled_token(monkeypatch, tmp_path: P
     assert gen.main([]) == 0
     text = output.read_text(encoding="utf-8")
     assert "github_pat_new" in text and "github_pat_old" not in text
+
+
+def _no_ambient_token_sources(monkeypatch, gen) -> None:
+    """Isolate from whatever this machine happens to have configured."""
+    monkeypatch.delenv("QUILL_FEEDBACK_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("QUILL_FEEDBACK_TOKEN_FILE", raising=False)
+    monkeypatch.setattr(gen, "_read_credential_manager", lambda target: "")
+
+
+def test_require_token_accepts_a_previously_bundled_token(monkeypatch, tmp_path: Path) -> None:
+    """A machine that has built once can rebuild without re-supplying the secret.
+
+    ``--require-token`` is mandatory for every packaged build (#919), and this
+    is the source that makes that survivable: a token already bundled by this
+    machine's last build. Without it, a developer holding a perfectly good
+    ``_feedback_token.py`` still could not build.
+
+    This does not weaken #919, whose point is that a build never ships a
+    *tokenless* bug reporter -- a previously bundled token is not tokenless.
+    """
+    import generate_feedback_token as gen
+
+    output = tmp_path / "_feedback_token.py"
+    gen.write_module("github_pat_from_last_build", output)
+    _no_ambient_token_sources(monkeypatch, gen)
+    monkeypatch.setattr(gen, "OUTPUT_FILE", output)
+    assert gen.main(["--require-token"]) == 0
+    assert "github_pat_from_last_build" in output.read_text(encoding="utf-8")
+
+
+def test_require_token_still_fails_when_nothing_is_bundled(monkeypatch, tmp_path: Path) -> None:
+    """The #919 guard is intact: no source anywhere still hard-fails."""
+    import generate_feedback_token as gen
+
+    output = tmp_path / "_feedback_token.py"
+    _no_ambient_token_sources(monkeypatch, gen)
+    monkeypatch.setattr(gen, "OUTPUT_FILE", output)
+    assert gen.main(["--require-token"]) == 2
+    assert not output.exists()
+
+
+def test_require_token_rejects_an_empty_bundled_token(monkeypatch, tmp_path: Path) -> None:
+    """An empty bundled token is tokenless, not a token -- it must not satisfy
+    the guard, or a build that once shipped ``BUNDLED_TOKEN = ''`` would keep
+    reproducing exactly the "No token" regression #919 closed.
+    """
+    import generate_feedback_token as gen
+
+    output = tmp_path / "_feedback_token.py"
+    gen.write_module("", output)
+    _no_ambient_token_sources(monkeypatch, gen)
+    monkeypatch.setattr(gen, "OUTPUT_FILE", output)
+    assert gen.main(["--require-token"]) == 2

--- a/tools/generate_feedback_token.py
+++ b/tools/generate_feedback_token.py
@@ -137,10 +137,20 @@ def resolve_token() -> str:
          (a developer machine that keeps the token in a file, not an env var).
       3. Windows Credential Manager generic credential ``QUILL:FeedbackToken``
          (DPAPI-backed; stash once, every local build picks it up).
-      4. A previously bundled token already in ``_feedback_token.py`` (preserved
-         across rebuilds by the caller).
+      4. A previously bundled token already in ``_feedback_token.py`` -- the
+         token this machine baked into its last build. A fresh source above
+         always wins, so this is only ever the fallback.
 
     Returns "" when none of the above yields a token. Never raises.
+
+    Source 4 exists so a machine that has already built once can rebuild
+    without re-supplying the secret. It was documented here from the start but
+    never implemented, which made ``--require-token`` (mandatory for every
+    packaged build since #919) fail on exactly those machines -- with a valid
+    token sitting in ``_feedback_token.py`` the whole time. Honouring it does
+    not weaken the #919 guarantee: the guard exists so a build can never ship a
+    *tokenless* bug reporter, and a previously bundled token is by definition
+    not tokenless. It is the same token that machine's last build shipped.
     """
     token = os.environ.get(ENV_VAR, "").strip()
     if token:
@@ -153,7 +163,7 @@ def resolve_token() -> str:
     token = _read_credential_manager(CRED_TARGET)
     if token:
         return token
-    return ""
+    return read_existing_token(OUTPUT_FILE)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -178,24 +188,13 @@ def main(argv: list[str] | None = None) -> int:
             f"  - the {ENV_VAR} env var (CI secret or explicit env var);\n"
             f"  - the {TOKEN_FILE_ENV} env var pointing at a file holding the PAT;\n"
             f"  - a Windows Credential Manager generic credential '{CRED_TARGET}'.\n"
+            f"  - a token already bundled in {OUTPUT_FILE} from a previous build.\n"
             "Set one of these in the build environment and re-run, or drop "
             "--require-token for a local test build (its bug reporter will be "
             "unavailable).",
             file=sys.stderr,
         )
         return 2
-    if not token:
-        # No token from any source: keep any working token already bundled
-        # rather than wiping it to empty, so a dev/test rebuild stays consistent
-        # (the token is populated once, then preserved). A fresh source token
-        # always wins via resolve_token above.
-        existing = read_existing_token(OUTPUT_FILE)
-        if existing:
-            print(
-                "No token found in env/credential/file; preserving the existing "
-                f"bundled token in {OUTPUT_FILE}."
-            )
-            return 0
     write_module(token, OUTPUT_FILE)
     if token:
         print(f"Wrote {OUTPUT_FILE} with a bundled token.")


### PR DESCRIPTION
Found while trying to build the 1.0.0 Windows distribution — it blocked every build on this machine.

## The bug

`resolve_token()` documents four token sources. It implements three.

Source 4 — *"a previously bundled token already in `_feedback_token.py`"* — was in the docstring from the start but never read. Since #919, `--require-token` is **mandatory and unconditional** for every packaged build (`build_windows_distribution.py:1676`, no opt-out). So on any machine without the secret in its environment, the build hard-failed at exit 2 — with a perfectly valid 93-character token sitting in `quill/_feedback_token.py` from that same machine's previous build.

`main()` *did* carry a preservation branch for exactly this case:

> keep any working token already bundled rather than wiping it to empty, so a dev/test rebuild stays consistent

but it sat at line 197, behind the `--require-token` early return at line 182 — unreachable for precisely the builds that needed it.

## The fix

Implement the documented source in `resolve_token()`, and drop the now-redundant branch in `main()`.

## Why this does not weaken #919

#919's guarantee is that a build can never ship a **tokenless** bug reporter — that regression where every beta-2 upgrade user got "No token". A previously bundled token is not tokenless; it is the same token that machine's last build shipped.

The guard stays sharp in both directions, each with a new test:

- `test_require_token_still_fails_when_nothing_is_bundled` — no source anywhere still exits 2 and writes nothing.
- `test_require_token_rejects_an_empty_bundled_token` — `BUNDLED_TOKEN = ''` is tokenless, not a token, so it must not satisfy the guard. Otherwise a build that once shipped empty would keep reproducing the exact regression #919 closed.
- `test_require_token_accepts_a_previously_bundled_token` — the case that was broken.

Precedence is unchanged: a fresh env / file / credential-manager token still wins over the bundled one.

## Tests

63 passed across `test_generate_feedback_token.py`, `test_feedback_token.py`, and `test_build_windows_distribution.py`. Lint and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)