### PR TITLE
feat(weather-ios): first-cut SwiftUI scaffold for the Weather iOS app

### DIFF
--- a/standalone/weather-ios/.gitignore
+++ b/standalone/weather-ios/.gitignore
@@ -1,0 +1,10 @@
+# XcodeGen output (regenerate with `xcodegen generate`).
+*.xcodeproj
+*.xcworkspace
+
+# Xcode / SwiftPM
+.DS_Store
+xcuserdata/
+DerivedData/
+.build/
+*.xcuserstate

--- a/standalone/weather-ios/QuillWeather/App/BackgroundRefresh.swift
+++ b/standalone/weather-ios/QuillWeather/App/BackgroundRefresh.swift
@@ -1,0 +1,34 @@
+import BackgroundTasks
+import WidgetKit
+
+/// Opportunistic background refresh (PRD §8.1 second tier) that keeps the badge
+/// and widgets current when the app is closed. It is best-effort by design: iOS
+/// schedules it when it sees fit and the user can disable Background App
+/// Refresh, so the badge is labeled "approximate, last known" rather than live.
+enum BackgroundRefresh {
+    static let identifier = "com.communityaccess.quillweather.refresh"
+
+    /// Ask iOS to run us again in roughly an hour. Call after each run and on
+    /// launch.
+    static func schedule() {
+        let request = BGAppRefreshTaskRequest(identifier: identifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 60 * 60)
+        try? BGTaskScheduler.shared.submit(request)
+    }
+
+    /// Refresh the primary location, cache it, reconcile the badge, and reload
+    /// widget timelines. Always reschedules, even on failure.
+    static func run() async {
+        defer { schedule() }
+        guard let primary = SharedStore.primaryLocation else { return }
+        let service = WeatherService()
+        guard let report = try? await service.report(for: primary) else { return }
+        SharedStore.cacheReport(report)
+        await BadgeManager.update(
+            from: report,
+            enabled: SharedStore.showTemperatureBadge,
+            unit: SharedStore.temperatureUnit
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}

--- a/standalone/weather-ios/QuillWeather/App/QuillWeatherApp.swift
+++ b/standalone/weather-ios/QuillWeather/App/QuillWeatherApp.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+@main
+struct QuillWeatherApp: App {
+    @State private var settings = AppSettings()
+    @State private var locations = SavedLocationsStore()
+    @State private var store = WeatherStore()
+    @State private var announcer = SpeechAnnouncer()
+    @State private var accessibilityActions = AccessibilityActionSettings()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(settings)
+                .environment(locations)
+                .environment(store)
+                .environment(announcer)
+                .environment(accessibilityActions)
+        }
+        // Keeps the badge (W-8) and widgets (W-1) fresh while the app is closed.
+        // Opportunistic and user-disable-able, per PRD §8.1 — never a guarantee.
+        .backgroundTask(.appRefresh(BackgroundRefresh.identifier)) {
+            await BackgroundRefresh.run()
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/App/RootView.swift
+++ b/standalone/weather-ios/QuillWeather/App/RootView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct RootView: View {
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(WeatherStore.self) private var store
+    @Environment(AppSettings.self) private var settings
+
+    var body: some View {
+        TabView {
+            Tab("Weather", systemImage: "cloud.sun") {
+                WeatherTab()
+            }
+            Tab("Quick", systemImage: "bolt.fill") {
+                NavigationStack { QuickWeatherView() }
+            }
+            Tab("Settings", systemImage: "gearshape") {
+                NavigationStack { SettingsView() }
+            }
+        }
+        .task {
+            BackgroundRefresh.schedule()
+            await store.refreshAll(locations.locations, settings: settings)
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Badge/BadgeManager.swift
+++ b/standalone/weather-ios/QuillWeather/Badge/BadgeManager.swift
@@ -1,0 +1,54 @@
+import Foundation
+import UserNotifications
+
+/// PRD §9 W-8 — the opt-in app-icon temperature badge, with the honest iOS
+/// constraints baked in:
+///
+/// - The badge is a **whole, non-negative integer**: it shows `112`, never
+///   `112°` and never a decimal.
+/// - **No 99 ceiling** — `setBadgeCount` accepts any non-negative Int; the badge
+///   pill widens, so triple-digit temperatures display in full.
+/// - It **cannot show below 1**: `setBadgeCount(0)` *clears* the badge, so 0 and
+///   any negative temperature have no badge representation and fall back to the
+///   Lock Screen widget (W-1).
+///
+/// Never driven by push — the app updates it on foreground and via background
+/// refresh only, so QuillPush stays location-blind (PRD §8.3).
+enum BadgeManager {
+    /// The integer to badge, or `nil` when the temperature cannot be represented
+    /// (below 1 degree, where 0 would clear the badge). `nil` means "leave it to
+    /// the widget".
+    static func badgeValue(
+        for temperature: Measurement<UnitTemperature>, unit: TemperatureUnit
+    ) -> Int? {
+        let degrees = temperature.wholeDegrees(in: unit)
+        return degrees >= 1 ? degrees : nil
+    }
+
+    /// Ask for badge authorization (needed before the badge shows). Idempotent.
+    @discardableResult
+    static func requestAuthorization() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        return (try? await center.requestAuthorization(options: [.badge])) ?? false
+    }
+
+    /// Set or clear the badge from a report, honoring the user's toggle.
+    static func update(
+        from report: WeatherReport?, enabled: Bool, unit: TemperatureUnit
+    ) async {
+        let center = UNUserNotificationCenter.current()
+        guard
+            enabled,
+            let report,
+            let value = badgeValue(for: report.current.temperature, unit: unit)
+        else {
+            try? await center.setBadgeCount(0)
+            return
+        }
+        try? await center.setBadgeCount(value)
+    }
+
+    static func clear() async {
+        try? await UNUserNotificationCenter.current().setBadgeCount(0)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Locations/AddLocationView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Locations/AddLocationView.swift
@@ -1,0 +1,125 @@
+import CoreLocation
+import SwiftUI
+
+struct AddLocationView: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(WeatherStore.self) private var store
+    @Environment(AppSettings.self) private var settings
+
+    @State private var locationManager = LocationManager()
+    @State private var query = ""
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Search") {
+                    TextField("City or place", text: $query)
+                        .submitLabel(.search)
+                        .onSubmit { Task { await search() } }
+                    Button("Search", systemImage: "magnifyingglass") {
+                        Task { await search() }
+                    }
+                    .disabled(query.trimmingCharacters(in: .whitespaces).isEmpty || isWorking)
+                }
+                Section {
+                    Button("Use My Current Location", systemImage: "location") {
+                        Task { await useCurrentLocation() }
+                    }
+                    .disabled(isWorking)
+                }
+                if let errorMessage {
+                    Section {
+                        Text(errorMessage).foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Add Location")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+            .overlay {
+                if isWorking { ProgressView().controlSize(.large) }
+            }
+        }
+    }
+
+    private func search() async {
+        await withWork {
+            let placemarks = try await geocode(address: query)
+            guard let placemark = placemarks.first, let location = location(from: placemark) else {
+                errorMessage = "No place matched “\(query)”."
+                return
+            }
+            await add(location)
+        }
+    }
+
+    private func useCurrentLocation() async {
+        await withWork {
+            locationManager.requestWhenInUseAuthorization()
+            let clLocation = try await locationManager.requestLocation()
+            let placemarks = try await reverseGeocode(clLocation)
+            guard let placemark = placemarks.first, let location = location(from: placemark) else {
+                errorMessage = "Couldn't name your current location."
+                return
+            }
+            await add(location)
+        }
+    }
+
+    private func add(_ location: Location) async {
+        locations.add(location)
+        await store.refresh(location)
+        dismiss()
+    }
+
+    private func location(from placemark: CLPlacemark) -> Location? {
+        guard let coordinate = placemark.location?.coordinate else { return nil }
+        let name = placemark.locality ?? placemark.name ?? query
+        let region = [placemark.administrativeArea, placemark.country]
+            .compactMap { $0 }
+            .joined(separator: ", ")
+        return Location(
+            name: name,
+            adminRegion: region,
+            latitude: coordinate.latitude,
+            longitude: coordinate.longitude,
+            timeZoneIdentifier: placemark.timeZone?.identifier ?? TimeZone.current.identifier
+        )
+    }
+
+    private func withWork(_ body: () async throws -> Void) async {
+        isWorking = true
+        errorMessage = nil
+        defer { isWorking = false }
+        do {
+            try await body()
+        } catch {
+            errorMessage = "Something went wrong. Please try again."
+        }
+    }
+
+    // CLGeocoder is completion-based; wrap its two calls as async.
+    private func geocode(address: String) async throws -> [CLPlacemark] {
+        try await withCheckedThrowingContinuation { continuation in
+            CLGeocoder().geocodeAddressString(address) { placemarks, error in
+                if let error { continuation.resume(throwing: error) }
+                else { continuation.resume(returning: placemarks ?? []) }
+            }
+        }
+    }
+
+    private func reverseGeocode(_ location: CLLocation) async throws -> [CLPlacemark] {
+        try await withCheckedThrowingContinuation { continuation in
+            CLGeocoder().reverseGeocodeLocation(location) { placemarks, error in
+                if let error { continuation.resume(throwing: error) }
+                else { continuation.resume(returning: placemarks ?? []) }
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Locations/LocationRow.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Locations/LocationRow.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+/// One row in the locations list. The whole row is a single VoiceOver element
+/// whose label is the narrator's full sentence, so a swipe reads "In Phoenix
+/// it's 112 degrees and sunny…" rather than three disconnected fragments.
+///
+/// The row also carries VoiceOver *actions* (PRD §5.2): from the rotor a
+/// VoiceOver user can Speak, Make Primary, or Delete without leaving the row —
+/// the same affordances sighted users get from swipe actions. Which actions
+/// appear is configurable (`AccessibilityActionSettings`).
+struct LocationRow: View {
+    @Environment(WeatherStore.self) private var store
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(AppSettings.self) private var settings
+    @Environment(SpeechAnnouncer.self) private var announcer
+    @Environment(AccessibilityActionSettings.self) private var actions
+    let location: Location
+
+    var body: some View {
+        let report = store.report(for: location)
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(location.name)
+                    .font(.headline)
+                if location.isPrimary {
+                    Text("Primary")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+            if let report {
+                Text(report.current.temperature.shortDisplay(in: settings.temperatureUnit))
+                    .font(.title3.weight(.semibold))
+                    .monospacedDigit()
+            } else if store.isLoading(location) {
+                ProgressView()
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label(for: report))
+        .accessibilityActions {
+            if actions.speakActionEnabled, let report {
+                Button("Speak weather") {
+                    announcer.speak(settings.narrator.quickWeather(for: report))
+                }
+            }
+            if actions.quickManagementActionsEnabled {
+                if !location.isPrimary {
+                    Button("Make primary") {
+                        locations.setPrimary(location)
+                        Task { await store.reconcileGlanceSurfaces(primary: location, settings: settings) }
+                    }
+                }
+                Button("Delete", role: .destructive) {
+                    locations.remove(location)
+                }
+            }
+        }
+    }
+
+    private func label(for report: WeatherReport?) -> String {
+        guard let report else { return "\(location.spokenName), loading weather" }
+        return settings.narrator.quickWeather(for: report)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Locations/LocationsListView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Locations/LocationsListView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct LocationsListView: View {
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(WeatherStore.self) private var store
+    @Environment(AppSettings.self) private var settings
+    @Binding var selectedLocationID: UUID?
+    @State private var showingAdd = false
+
+    var body: some View {
+        List(selection: $selectedLocationID) {
+            ForEach(locations.locations) { location in
+                LocationRow(location: location)
+                    .tag(location.id)
+                    .swipeActions(edge: .leading) {
+                        Button("Make Primary", systemImage: "star") {
+                            locations.setPrimary(location)
+                            Task { await store.reconcileGlanceSurfaces(primary: location, settings: settings) }
+                        }
+                        .tint(.yellow)
+                    }
+            }
+            .onDelete(perform: delete)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Add Location", systemImage: "plus") { showingAdd = true }
+            }
+        }
+        .sheet(isPresented: $showingAdd) {
+            AddLocationView()
+        }
+        .refreshable {
+            await store.refreshAll(locations.locations, settings: settings)
+        }
+        .overlay {
+            if locations.locations.isEmpty {
+                ContentUnavailableView(
+                    "No locations",
+                    systemImage: "location.slash",
+                    description: Text("Add a location to start tracking its weather.")
+                )
+            }
+        }
+    }
+
+    private func delete(_ offsets: IndexSet) {
+        for location in offsets.map({ locations.locations[$0] }) {
+            locations.remove(location)
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Quick/QuickWeatherView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Quick/QuickWeatherView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// The three-second promise (PRD §3): the primary location's weather as one
+/// sentence, front and center, speakable in a tap.
+struct QuickWeatherView: View {
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(WeatherStore.self) private var store
+    @Environment(AppSettings.self) private var settings
+    @State private var announcer = SpeechAnnouncer()
+
+    var body: some View {
+        Group {
+            if let primary = locations.primary, let report = store.report(for: primary) {
+                content(primary: primary, report: report)
+            } else if let primary = locations.primary {
+                ProgressView("Loading \(primary.name)…")
+                    .task { await store.refresh(primary) }
+            } else {
+                ContentUnavailableView(
+                    "No primary location",
+                    systemImage: "location",
+                    description: Text("Add a location to see Quick Weather.")
+                )
+            }
+        }
+        .navigationTitle("Quick Weather")
+    }
+
+    @ViewBuilder
+    private func content(primary: Location, report: WeatherReport) -> some View {
+        let sentence = settings.narrator.quickWeather(for: report)
+        VStack(spacing: 28) {
+            Text(sentence)
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .accessibilityAddTraits(.updatesFrequently)
+            Button("Speak", systemImage: "speaker.wave.2.fill") {
+                announcer.speak(sentence)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+        }
+        .padding()
+        .task(id: primary.id) {
+            if store.report(for: primary) == nil {
+                await store.refresh(primary)
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/AlertsSection.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/AlertsSection.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct AlertsSection: View {
+    let alerts: [WeatherAlert]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Alerts")
+                .font(.headline)
+            ForEach(alerts) { alert in
+                DisclosureGroup {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(alert.detail)
+                            .font(.callout)
+                        if !alert.area.isEmpty {
+                            Text(alert.area)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .padding(.top, 4)
+                } label: {
+                    Label(alert.headline, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+                .accessibilityHint("\(alert.tier.spokenName) alert")
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/AttributionFooter.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/AttributionFooter.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Mandatory data attribution (PRD §6.1 D-5). WeatherKit in particular requires
+/// its name and a link to Apple's legal attribution page wherever its data
+/// appears.
+struct AttributionFooter: View {
+    let providers: [WeatherProviderID]
+    let asOf: Date
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ForEach(providers, id: \.self) { provider in
+                if let url = provider.attributionURL {
+                    Link(provider.attributionText, destination: url)
+                } else {
+                    Text(provider.attributionText)
+                }
+            }
+            Text("Updated \(asOf.formatted(date: .omitted, time: .shortened))")
+                .foregroundStyle(.tertiary)
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/CurrentConditionsCard.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/CurrentConditionsCard.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// The headline "now" card. Combined into one VoiceOver element labelled with
+/// the narrator's sentence, so it is read as one coherent statement.
+struct CurrentConditionsCard: View {
+    @Environment(AppSettings.self) private var settings
+    @Environment(WeatherStore.self) private var store
+    @Environment(SpeechAnnouncer.self) private var announcer
+    @Environment(AccessibilityActionSettings.self) private var actions
+    let report: WeatherReport
+
+    private var current: CurrentConditions { report.current }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                Text(current.temperature.shortDisplay(in: settings.temperatureUnit))
+                    .font(.system(size: 72, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                Image(systemName: current.condition.symbolName)
+                    .font(.system(size: 44))
+                    .symbolRenderingMode(.multicolor)
+            }
+            Text(current.condition.text.capitalized)
+                .font(.title3)
+            Text("Feels like \(current.apparentTemperature.shortDisplay(in: settings.temperatureUnit))")
+                .foregroundStyle(.secondary)
+            HStack(spacing: 16) {
+                Label("\(Int((current.humidity * 100).rounded()))%", systemImage: "humidity")
+                Label(windDescription, systemImage: "wind")
+            }
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(settings.narrator.quickWeather(for: report))
+        .accessibilityActions {
+            if actions.speakActionEnabled {
+                Button("Speak weather") {
+                    announcer.speak(settings.narrator.quickWeather(for: report))
+                }
+            }
+            Button("Refresh") {
+                Task { await store.refresh(report.location) }
+            }
+        }
+    }
+
+    private var windDescription: String {
+        let mph = current.windSpeed.converted(to: .milesPerHour).value
+        return "\(Int(mph.rounded())) mph"
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/DailyForecastList.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/DailyForecastList.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct DailyForecastList: View {
+    @Environment(AppSettings.self) private var settings
+    let days: [DailyForecast]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("7-Day Forecast")
+                .font(.headline)
+            ForEach(days) { day in
+                HStack {
+                    Text(day.date, format: .dateTime.weekday(.wide))
+                        .frame(width: 110, alignment: .leading)
+                    Image(systemName: day.condition.symbolName)
+                        .symbolRenderingMode(.multicolor)
+                    Spacer()
+                    Text(day.lowTemperature.shortDisplay(in: settings.temperatureUnit))
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                    Text(day.highTemperature.shortDisplay(in: settings.temperatureUnit))
+                        .monospacedDigit()
+                }
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(label(for: day))
+            }
+        }
+    }
+
+    private func label(for day: DailyForecast) -> String {
+        let weekday = day.date.formatted(.dateTime.weekday(.wide))
+        let high = day.highTemperature.spokenDisplay(in: settings.temperatureUnit)
+        let low = day.lowTemperature.spokenDisplay(in: settings.temperatureUnit)
+        return "\(weekday), \(day.condition.text), high \(high), low \(low)"
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/HourlyStripView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/HourlyStripView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct HourlyStripView: View {
+    @Environment(AppSettings.self) private var settings
+    let hours: [HourlyForecast]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Hourly")
+                .font(.headline)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 20) {
+                    ForEach(hours) { hour in
+                        VStack(spacing: 6) {
+                            Text(hour.date, format: .dateTime.hour())
+                            Image(systemName: hour.condition.symbolName)
+                                .symbolRenderingMode(.multicolor)
+                            Text(hour.temperature.shortDisplay(in: settings.temperatureUnit))
+                                .monospacedDigit()
+                        }
+                        .font(.callout)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel(label(for: hour))
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+
+    private func label(for hour: HourlyForecast) -> String {
+        let time = hour.date.formatted(.dateTime.hour())
+        var text = "At \(time), \(hour.temperature.spokenDisplay(in: settings.temperatureUnit)), \(hour.condition.text)"
+        if hour.precipitationChance >= 0.1 {
+            text += ", \(Int((hour.precipitationChance * 100).rounded())) percent chance of precipitation"
+        }
+        return text
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Report/WeatherReportView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Report/WeatherReportView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct WeatherReportView: View {
+    @Environment(WeatherStore.self) private var store
+    @Environment(AppSettings.self) private var settings
+    let location: Location
+
+    var body: some View {
+        ScrollView {
+            if let report = store.report(for: location) {
+                VStack(alignment: .leading, spacing: 24) {
+                    CurrentConditionsCard(report: report)
+                    if !report.alerts.isEmpty {
+                        AlertsSection(alerts: report.alerts)
+                    }
+                    HourlyStripView(hours: report.hourly)
+                    DailyForecastList(days: report.daily)
+                    AttributionFooter(providers: report.attributions, asOf: report.asOf)
+                }
+                .padding()
+            } else {
+                ProgressView("Loading \(location.name)…")
+                    .padding(.top, 80)
+            }
+        }
+        .navigationTitle(location.name)
+        .refreshable {
+            await store.refresh(location)
+        }
+        .task(id: location.id) {
+            if store.report(for: location) == nil {
+                await store.refresh(location)
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Settings/SettingsView.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Settings/SettingsView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(AppSettings.self) private var settings
+    @Environment(SavedLocationsStore.self) private var locations
+    @Environment(WeatherStore.self) private var store
+    @Environment(AccessibilityActionSettings.self) private var actions
+
+    var body: some View {
+        @Bindable var settings = settings
+        @Bindable var actions = actions
+        Form {
+            Section("Units") {
+                Picker("Temperature", selection: $settings.temperatureUnit) {
+                    ForEach(TemperatureUnit.allCases) { unit in
+                        Text(unit.spokenName).tag(unit)
+                    }
+                }
+            }
+
+            Section {
+                Toggle("Show current temperature on the app icon", isOn: $settings.showTemperatureBadge)
+            } footer: {
+                // The honest constraints from PRD §9 W-8, in the user's words.
+                Text("""
+                The badge is a whole number like 112 — no degree sign, no decimals — and it can't show below zero. \
+                It refreshes in the background, so treat it as approximate, not live. Turning this on replaces the \
+                unread-alert count on the app icon.
+                """)
+            }
+
+            Section {
+                Toggle("“Speak weather” action", isOn: $actions.speakActionEnabled)
+                Toggle("“Make primary” and “Delete” actions", isOn: $actions.quickManagementActionsEnabled)
+            } header: {
+                Text("VoiceOver Actions")
+            } footer: {
+                Text("Choose which actions appear in VoiceOver's rotor on location rows and the weather card. Turn a category off if you find the rotor noisy.")
+            }
+        }
+        .navigationTitle("Settings")
+        .onChange(of: settings.temperatureUnit) {
+            Task { await store.reconcileGlanceSurfaces(primary: locations.primary, settings: settings) }
+        }
+        .onChange(of: settings.showTemperatureBadge) {
+            Task {
+                if settings.showTemperatureBadge {
+                    await BadgeManager.requestAuthorization()
+                }
+                await store.reconcileGlanceSurfaces(primary: locations.primary, settings: settings)
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Features/Weather/WeatherTab.swift
+++ b/standalone/weather-ios/QuillWeather/Features/Weather/WeatherTab.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// List-detail weather browsing. `NavigationSplitView` gives iPad/Mac a sidebar
+/// and collapses to a stack on iPhone.
+struct WeatherTab: View {
+    @Environment(SavedLocationsStore.self) private var locations
+    @State private var selectedLocationID: UUID?
+
+    var body: some View {
+        NavigationSplitView {
+            LocationsListView(selectedLocationID: $selectedLocationID)
+                .navigationTitle("Weather")
+        } detail: {
+            if let id = selectedLocationID,
+               let location = locations.locations.first(where: { $0.id == id }) {
+                NavigationStack {
+                    WeatherReportView(location: location)
+                }
+            } else {
+                ContentUnavailableView(
+                    "Choose a location",
+                    systemImage: "location.circle",
+                    description: Text("Pick a saved location to see its full weather.")
+                )
+            }
+        }
+        .onAppear {
+            if selectedLocationID == nil {
+                selectedLocationID = locations.primary?.id
+            }
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Intents/GetQuickWeatherIntent.swift
+++ b/standalone/weather-ios/QuillWeather/Intents/GetQuickWeatherIntent.swift
@@ -1,0 +1,21 @@
+import AppIntents
+
+/// PRD §9 W-4: "What's my Quill weather" from Siri, Shortcuts, and the Action
+/// Button. Returns the same narrated sentence the UI and widgets use.
+struct GetQuickWeatherIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Quick Weather"
+    static let description = IntentDescription(
+        "Speaks the current weather for your primary location."
+    )
+    static let openAppWhenRun = false
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        guard let primary = SharedStore.primaryLocation else {
+            return .result(dialog: "You haven't added a location to Quill Weather yet.")
+        }
+        let report = try await WeatherService().report(for: primary)
+        SharedStore.cacheReport(report) // let the badge/widgets benefit from the fetch
+        let sentence = Narrator(units: SharedStore.temperatureUnit).quickWeather(for: report)
+        return .result(dialog: IntentDialog(stringLiteral: sentence))
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Intents/QuillWeatherShortcuts.swift
+++ b/standalone/weather-ios/QuillWeather/Intents/QuillWeatherShortcuts.swift
@@ -1,0 +1,18 @@
+import AppIntents
+
+/// Registers the spoken phrases that reach `GetQuickWeatherIntent` from Siri and
+/// the Shortcuts app. `\(.applicationName)` is required in every phrase.
+struct QuillWeatherShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: GetQuickWeatherIntent(),
+            phrases: [
+                "What's my \(.applicationName)",
+                "Get my \(.applicationName)",
+                "\(.applicationName) quick weather",
+            ],
+            shortTitle: "Quick Weather",
+            systemImageName: "cloud.sun"
+        )
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Location/LocationManager.swift
+++ b/standalone/weather-ios/QuillWeather/Location/LocationManager.swift
@@ -1,0 +1,64 @@
+import CoreLocation
+import Observation
+
+/// Thin, `@Observable` wrapper over `CLLocationManager` for one-shot "where am
+/// I" lookups when adding the current location. CoreLocation delivers its
+/// delegate callbacks on the queue the manager was created on (the main actor
+/// here), so the `nonisolated` delegate methods hop back with
+/// `MainActor.assumeIsolated`.
+@MainActor
+@Observable
+final class LocationManager: NSObject, CLLocationManagerDelegate {
+    private let manager = CLLocationManager()
+    private(set) var authorizationStatus: CLAuthorizationStatus = .notDetermined
+    private var continuation: CheckedContinuation<CLLocation, Error>?
+
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyKilometer
+        authorizationStatus = manager.authorizationStatus
+    }
+
+    func requestWhenInUseAuthorization() {
+        manager.requestWhenInUseAuthorization()
+    }
+
+    /// One-shot current location. Throws `CLError` on failure or denial.
+    func requestLocation() async throws -> CLLocation {
+        if continuation != nil {
+            throw CLError(.locationUnknown) // a request is already in flight
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            manager.requestLocation()
+        }
+    }
+
+    // MARK: - CLLocationManagerDelegate
+
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        MainActor.assumeIsolated {
+            authorizationStatus = manager.authorizationStatus
+        }
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]
+    ) {
+        MainActor.assumeIsolated {
+            guard let location = locations.last else { return }
+            continuation?.resume(returning: location)
+            continuation = nil
+        }
+    }
+
+    nonisolated func locationManager(
+        _ manager: CLLocationManager, didFailWithError error: Error
+    ) {
+        MainActor.assumeIsolated {
+            continuation?.resume(throwing: error)
+            continuation = nil
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Location/SavedLocationsStore.swift
+++ b/standalone/weather-ios/QuillWeather/Location/SavedLocationsStore.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Observation
+
+/// The app's in-memory, `@Observable` list of saved locations, backed by
+/// `SharedStore` (App Group) so the widget and intents see the same data.
+/// Enforces the invariant that exactly one location is primary.
+@MainActor
+@Observable
+final class SavedLocationsStore {
+    private(set) var locations: [Location]
+
+    init() {
+        var loaded = SharedStore.loadLocations()
+        if loaded.isEmpty {
+            // Seed a sensible default so a fresh install shows something.
+            loaded = [
+                Location(
+                    name: "Phoenix", adminRegion: "Arizona, United States",
+                    latitude: 33.4484, longitude: -112.0740,
+                    timeZoneIdentifier: "America/Phoenix", isPrimary: true
+                )
+            ]
+        }
+        locations = Self.normalizingPrimary(loaded)
+        persist()
+    }
+
+    var primary: Location? {
+        locations.first(where: \.isPrimary) ?? locations.first
+    }
+
+    func add(_ location: Location) {
+        var new = location
+        if locations.isEmpty { new.isPrimary = true }
+        locations.append(new)
+        locations = Self.normalizingPrimary(locations)
+        persist()
+    }
+
+    func remove(_ location: Location) {
+        locations.removeAll { $0.id == location.id }
+        locations = Self.normalizingPrimary(locations)
+        persist()
+    }
+
+    func setPrimary(_ location: Location) {
+        for index in locations.indices {
+            locations[index].isPrimary = locations[index].id == location.id
+        }
+        persist()
+    }
+
+    private func persist() {
+        SharedStore.saveLocations(locations)
+    }
+
+    /// Guarantee exactly one primary: keep the first flagged one, or promote the
+    /// first location when none is flagged.
+    private static func normalizingPrimary(_ input: [Location]) -> [Location] {
+        guard !input.isEmpty else { return input }
+        var result = input
+        let primaryIndex = result.firstIndex(where: \.isPrimary) ?? 0
+        for index in result.indices {
+            result[index].isPrimary = index == primaryIndex
+        }
+        return result
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Models/CurrentConditions.swift
+++ b/standalone/weather-ios/QuillWeather/Models/CurrentConditions.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A point-in-time observation/estimate for a location.
+struct CurrentConditions: Codable, Hashable, Sendable {
+    var temperature: Measurement<UnitTemperature>
+    var apparentTemperature: Measurement<UnitTemperature>
+    var condition: WeatherCondition
+    /// Relative humidity, 0...1.
+    var humidity: Double
+    var windSpeed: Measurement<UnitSpeed>
+    var isDaylight: Bool
+
+    init(
+        temperature: Measurement<UnitTemperature>,
+        apparentTemperature: Measurement<UnitTemperature>,
+        condition: WeatherCondition,
+        humidity: Double,
+        windSpeed: Measurement<UnitSpeed>,
+        isDaylight: Bool
+    ) {
+        self.temperature = temperature
+        self.apparentTemperature = apparentTemperature
+        self.condition = condition
+        self.humidity = humidity
+        self.windSpeed = windSpeed
+        self.isDaylight = isDaylight
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Models/DailyForecast.swift
+++ b/standalone/weather-ios/QuillWeather/Models/DailyForecast.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// One day of forecast.
+struct DailyForecast: Identifiable, Codable, Hashable, Sendable {
+    var id: Date { date }
+    let date: Date
+    let highTemperature: Measurement<UnitTemperature>
+    let lowTemperature: Measurement<UnitTemperature>
+    let condition: WeatherCondition
+    /// Probability of precipitation, 0...1.
+    let precipitationChance: Double
+}

--- a/standalone/weather-ios/QuillWeather/Models/HourlyForecast.swift
+++ b/standalone/weather-ios/QuillWeather/Models/HourlyForecast.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// One hour of forecast.
+struct HourlyForecast: Identifiable, Codable, Hashable, Sendable {
+    var id: Date { date }
+    let date: Date
+    let temperature: Measurement<UnitTemperature>
+    let condition: WeatherCondition
+    /// Probability of precipitation, 0...1.
+    let precipitationChance: Double
+}

--- a/standalone/weather-ios/QuillWeather/Models/Location.swift
+++ b/standalone/weather-ios/QuillWeather/Models/Location.swift
@@ -1,0 +1,54 @@
+import CoreLocation
+import Foundation
+
+/// A place the user tracks. Stored as plain coordinates (not a
+/// `CLLocationCoordinate2D`, which is neither `Codable` nor reliably
+/// `Sendable`) so it persists and crosses actor boundaries cleanly.
+struct Location: Identifiable, Codable, Hashable, Sendable {
+    let id: UUID
+    /// User-facing name, e.g. "Phoenix".
+    var name: String
+    /// Disambiguating region, e.g. "Arizona, United States".
+    var adminRegion: String
+    var latitude: Double
+    var longitude: Double
+    /// IANA identifier, e.g. "America/Phoenix", so times display in the
+    /// location's own zone rather than the device's.
+    var timeZoneIdentifier: String
+    /// The one location that drives the badge, the default widget, and Quick
+    /// Weather. Exactly one saved location is primary (`SavedLocationsStore`
+    /// enforces it).
+    var isPrimary: Bool
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        adminRegion: String = "",
+        latitude: Double,
+        longitude: Double,
+        timeZoneIdentifier: String = TimeZone.current.identifier,
+        isPrimary: Bool = false
+    ) {
+        self.id = id
+        self.name = name
+        self.adminRegion = adminRegion
+        self.latitude = latitude
+        self.longitude = longitude
+        self.timeZoneIdentifier = timeZoneIdentifier
+        self.isPrimary = isPrimary
+    }
+
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+
+    var timeZone: TimeZone {
+        TimeZone(identifier: timeZoneIdentifier) ?? .current
+    }
+
+    /// Spoken/label form: "Phoenix, Arizona, United States" when a region is
+    /// known, otherwise just the name.
+    var spokenName: String {
+        adminRegion.isEmpty ? name : "\(name), \(adminRegion)"
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Models/WeatherAlert.swift
+++ b/standalone/weather-ios/QuillWeather/Models/WeatherAlert.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// A severe-weather alert, normalized across providers. The `tier` maps onto
+/// the PRD's delivery tiers (§8.1) that decide notification urgency.
+struct WeatherAlert: Identifiable, Codable, Hashable, Sendable {
+    /// Delivery tier, ordered least-to-most severe.
+    enum Tier: Int, Codable, Sendable, Comparable {
+        case routine
+        case advisory
+        case watch
+        case warning
+        case urgent
+        case critical
+
+        static func < (lhs: Tier, rhs: Tier) -> Bool { lhs.rawValue < rhs.rawValue }
+
+        var spokenName: String {
+            switch self {
+            case .routine: "routine"
+            case .advisory: "advisory"
+            case .watch: "watch"
+            case .warning: "warning"
+            case .urgent: "urgent"
+            case .critical: "critical"
+            }
+        }
+    }
+
+    let id: String
+    let tier: Tier
+    /// Short headline, e.g. "Excessive Heat Warning".
+    let headline: String
+    /// The full official text (NWS returns this; WeatherKit returns a summary).
+    let detail: String
+    let source: String
+    /// Affected area description, e.g. "Maricopa County".
+    let area: String
+    let effective: Date
+    let expires: Date?
+}

--- a/standalone/weather-ios/QuillWeather/Models/WeatherCondition.swift
+++ b/standalone/weather-ios/QuillWeather/Models/WeatherCondition.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// A provider-neutral weather condition. Each provider maps its own raw code
+/// into this so the rest of the app (UI, narrator, widgets) never branches on a
+/// provider's vocabulary.
+struct WeatherCondition: Codable, Hashable, Sendable {
+    /// Stable code, e.g. "clear", "partlyCloudy", "rain", "thunderstorms".
+    let code: String
+    /// SF Symbol name, e.g. "sun.max", "cloud.rain". Chosen day/night aware by
+    /// the provider when it knows daylight.
+    let symbolName: String
+    /// Human, spoken-first description, e.g. "partly cloudy". Lowercased so it
+    /// drops naturally into the narrator's sentence.
+    let text: String
+
+    init(code: String, symbolName: String, text: String) {
+        self.code = code
+        self.symbolName = symbolName
+        self.text = text
+    }
+
+    static let unknown = WeatherCondition(
+        code: "unknown", symbolName: "cloud", text: "unknown conditions"
+    )
+}

--- a/standalone/weather-ios/QuillWeather/Models/WeatherProviderID.swift
+++ b/standalone/weather-ios/QuillWeather/Models/WeatherProviderID.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Which upstream produced a report. Drives the mandatory attribution surface
+/// (PRD §6.1 D-5: any WeatherKit-derived value must show Apple's attribution
+/// and legal link).
+enum WeatherProviderID: String, Codable, Sendable, CaseIterable {
+    case weatherKit
+    case openMeteo
+    case nws
+
+    var displayName: String {
+        switch self {
+        case .weatherKit: " Weather"
+        case .openMeteo: "Open-Meteo"
+        case .nws: "National Weather Service"
+        }
+    }
+
+    /// The one-line attribution string shown wherever this provider's data
+    /// appears.
+    var attributionText: String {
+        switch self {
+        case .weatherKit: "Weather data provided by  Weather."
+        case .openMeteo: "Weather data by Open-Meteo.com (CC BY 4.0)."
+        case .nws: "Data from the U.S. National Weather Service."
+        }
+    }
+
+    /// Legal/attribution link. WeatherKit mandates a link to Apple's legal
+    /// attribution page; the others link to their terms.
+    var attributionURL: URL? {
+        switch self {
+        case .weatherKit: URL(string: "https://weatherkit.apple.com/legal-attribution.html")
+        case .openMeteo: URL(string: "https://open-meteo.com/en/license")
+        case .nws: URL(string: "https://www.weather.gov/disclaimer")
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Models/WeatherReport.swift
+++ b/standalone/weather-ios/QuillWeather/Models/WeatherReport.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// The full weather picture for one location at one moment — the unit the UI,
+/// the narrator, the widgets, and the App Intents all consume.
+struct WeatherReport: Codable, Hashable, Sendable {
+    let location: Location
+    let current: CurrentConditions
+    let hourly: [HourlyForecast]
+    let daily: [DailyForecast]
+    let alerts: [WeatherAlert]
+    /// Primary provider that produced the current conditions. Fusion may draw
+    /// other sections from other providers (§6.2); `attributions` lists all.
+    let provider: WeatherProviderID
+    let attributions: [WeatherProviderID]
+    /// When the underlying data was produced (not when it was fetched).
+    let asOf: Date
+
+    init(
+        location: Location,
+        current: CurrentConditions,
+        hourly: [HourlyForecast] = [],
+        daily: [DailyForecast] = [],
+        alerts: [WeatherAlert] = [],
+        provider: WeatherProviderID,
+        attributions: [WeatherProviderID]? = nil,
+        asOf: Date
+    ) {
+        self.location = location
+        self.current = current
+        self.hourly = hourly
+        self.daily = daily
+        self.alerts = alerts
+        self.provider = provider
+        self.attributions = attributions ?? [provider]
+        self.asOf = asOf
+    }
+
+    /// The most severe active alert, if any — what the badge/widget "next
+    /// alert" surface and the notification tier key off.
+    var mostSevereAlert: WeatherAlert? {
+        alerts.max { $0.tier < $1.tier }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Narration/Narrator.swift
+++ b/standalone/weather-ios/QuillWeather/Narration/Narrator.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Turns a `WeatherReport` into the one spoken sentence that is the app's
+/// contract (PRD §3, the three-second promise). The same text is used as the
+/// UI's `accessibilityLabel`, the widget's label, and the App Intent's spoken
+/// result, so VoiceOver, a widget, and Siri all say exactly the same thing.
+struct Narrator: Sendable {
+    var units: TemperatureUnit
+
+    init(units: TemperatureUnit = .fahrenheit) {
+        self.units = units
+    }
+
+    /// e.g. "In Phoenix it's 112 degrees and sunny, feeling like 108 degrees.
+    /// Excessive Heat Warning in effect until 8 PM."
+    func quickWeather(for report: WeatherReport) -> String {
+        let current = report.current
+        let temp = current.temperature.spokenDisplay(in: units)
+        var sentence = "In \(report.location.name) it's \(temp) and \(current.condition.text)"
+
+        let feels = current.apparentTemperature
+        let apparentDelta = abs(
+            feels.converted(to: units.unit).value
+                - current.temperature.converted(to: units.unit).value
+        )
+        if apparentDelta >= 3 {
+            sentence += ", feeling like \(feels.spokenDisplay(in: units))"
+        }
+        sentence += "."
+
+        if let alert = report.mostSevereAlert {
+            sentence += " \(alert.headline) in effect\(alertWindow(alert))."
+        }
+        return sentence
+    }
+
+    /// A compact glance string for a widget's secondary line, e.g.
+    /// "112°, sunny".
+    func glance(for report: WeatherReport) -> String {
+        "\(report.current.temperature.shortDisplay(in: units)), \(report.current.condition.text)"
+    }
+
+    /// A spoken freshness clause for widgets/badges, e.g. "updated 8 minutes
+    /// ago". WidgetKit refreshes on a budgeted timeline, so surfaces state their
+    /// age rather than implying live data (PRD §9 W-1).
+    func freshness(_ asOf: Date, now: Date = .now) -> String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        return "updated \(formatter.localizedString(for: asOf, relativeTo: now))"
+    }
+
+    private func alertWindow(_ alert: WeatherAlert) -> String {
+        guard let expires = alert.expires else { return "" }
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        formatter.timeZone = alert.expires == nil ? .current : TimeZone.current
+        return " until \(formatter.string(from: expires))"
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Narration/SpeechAnnouncer.swift
+++ b/standalone/weather-ios/QuillWeather/Narration/SpeechAnnouncer.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import Observation
+
+/// Speaks a narrated sentence aloud for users who aren't running VoiceOver
+/// (VoiceOver users already hear the same text from the view's
+/// `accessibilityLabel`). Used by Quick Weather's Speak button.
+@MainActor
+@Observable
+final class SpeechAnnouncer {
+    private let synthesizer = AVSpeechSynthesizer()
+
+    func speak(_ text: String) {
+        synthesizer.stopSpeaking(at: .immediate)
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: AVSpeechSynthesisVoice.currentLanguageCode())
+        synthesizer.speak(utterance)
+    }
+
+    func stop() {
+        synthesizer.stopSpeaking(at: .immediate)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Settings/AccessibilityActionSettings.swift
+++ b/standalone/weather-ios/QuillWeather/Settings/AccessibilityActionSettings.swift
@@ -1,0 +1,28 @@
+import Observation
+
+/// User configuration for the VoiceOver *actions* exposed on elements (the
+/// rotor's action menu, PRD §5.2). Actions are on by default; a VoiceOver power
+/// user who finds them noisy can turn categories off. Persisted through
+/// `SharedStore` so the choice is durable.
+///
+/// This is the seam the PRD's "configurable rotor" work grows from: today it is
+/// two category toggles; it can become per-action ordering and custom rotors
+/// without changing the call sites, which already ask this type what to show.
+@MainActor
+@Observable
+final class AccessibilityActionSettings {
+    /// "Speak weather" on rows and the current-conditions card.
+    var speakActionEnabled: Bool {
+        didSet { SharedStore.speakRotorActionEnabled = speakActionEnabled }
+    }
+
+    /// "Make primary" and "Delete" on location rows.
+    var quickManagementActionsEnabled: Bool {
+        didSet { SharedStore.quickManagementActionsEnabled = quickManagementActionsEnabled }
+    }
+
+    init() {
+        speakActionEnabled = SharedStore.speakRotorActionEnabled
+        quickManagementActionsEnabled = SharedStore.quickManagementActionsEnabled
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Settings/AppSettings.swift
+++ b/standalone/weather-ios/QuillWeather/Settings/AppSettings.swift
@@ -1,0 +1,26 @@
+import Observation
+
+/// User preferences, `@Observable` for SwiftUI and persisted through
+/// `SharedStore` so the widget and intents read the same values.
+@MainActor
+@Observable
+final class AppSettings {
+    var temperatureUnit: TemperatureUnit {
+        didSet { SharedStore.temperatureUnit = temperatureUnit }
+    }
+
+    /// PRD §9 W-8. Default off; enabling it replaces the unread-alert count on
+    /// the app icon (both share the one badge).
+    var showTemperatureBadge: Bool {
+        didSet { SharedStore.showTemperatureBadge = showTemperatureBadge }
+    }
+
+    init() {
+        temperatureUnit = SharedStore.temperatureUnit
+        showTemperatureBadge = SharedStore.showTemperatureBadge
+    }
+
+    var narrator: Narrator {
+        Narrator(units: temperatureUnit)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Shared/SharedStore.swift
+++ b/standalone/weather-ios/QuillWeather/Shared/SharedStore.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// The App Group bridge shared by the app and the widget/intent extensions. It
+/// persists the saved locations and caches the most recent report per location
+/// so a widget can render instantly and the badge can be set without a network
+/// round-trip. Pure value APIs, `Sendable`, safe to call from any actor.
+enum SharedStore {
+    /// Must match the App Group in both targets' entitlements.
+    static let appGroup = "group.com.communityaccess.quillweather"
+
+    private static var defaults: UserDefaults {
+        UserDefaults(suiteName: appGroup) ?? .standard
+    }
+
+    private enum Key {
+        static let locations = "savedLocations"
+        static let temperatureUnit = "temperatureUnit"
+        static let showTemperatureBadge = "showTemperatureBadge"
+        static let speakRotorAction = "a11y.speakRotorAction"
+        static let quickManagementActions = "a11y.quickManagementActions"
+        static func report(_ id: UUID) -> String { "report.\(id.uuidString)" }
+    }
+
+    /// Reads a Bool that defaults to `true` when it has never been set.
+    private static func bool(_ key: String, default defaultValue: Bool) -> Bool {
+        defaults.object(forKey: key) as? Bool ?? defaultValue
+    }
+
+    // MARK: - Locations
+
+    static func loadLocations() -> [Location] {
+        guard let data = defaults.data(forKey: Key.locations) else { return [] }
+        return (try? JSONDecoder().decode([Location].self, from: data)) ?? []
+    }
+
+    static func saveLocations(_ locations: [Location]) {
+        guard let data = try? JSONEncoder().encode(locations) else { return }
+        defaults.set(data, forKey: Key.locations)
+    }
+
+    static var primaryLocation: Location? {
+        let all = loadLocations()
+        return all.first(where: \.isPrimary) ?? all.first
+    }
+
+    // MARK: - Units
+
+    static var temperatureUnit: TemperatureUnit {
+        get {
+            (defaults.string(forKey: Key.temperatureUnit)).flatMap(TemperatureUnit.init) ?? .fahrenheit
+        }
+        set { defaults.set(newValue.rawValue, forKey: Key.temperatureUnit) }
+    }
+
+    /// W-8 opt-in badge toggle. Default off.
+    static var showTemperatureBadge: Bool {
+        get { defaults.bool(forKey: Key.showTemperatureBadge) }
+        set { defaults.set(newValue, forKey: Key.showTemperatureBadge) }
+    }
+
+    // MARK: - Configurable VoiceOver actions (PRD §5.2)
+
+    /// Expose a "Speak weather" rotor action on rows and cards. Default on.
+    static var speakRotorActionEnabled: Bool {
+        get { bool(Key.speakRotorAction, default: true) }
+        set { defaults.set(newValue, forKey: Key.speakRotorAction) }
+    }
+
+    /// Expose "Make primary" / "Delete" rotor actions on location rows. Default on.
+    static var quickManagementActionsEnabled: Bool {
+        get { bool(Key.quickManagementActions, default: true) }
+        set { defaults.set(newValue, forKey: Key.quickManagementActions) }
+    }
+
+    // MARK: - Cached reports
+
+    static func cacheReport(_ report: WeatherReport) {
+        guard let data = try? JSONEncoder().encode(report) else { return }
+        defaults.set(data, forKey: Key.report(report.location.id))
+    }
+
+    static func cachedReport(for id: UUID) -> WeatherReport? {
+        guard let data = defaults.data(forKey: Key.report(id)) else { return nil }
+        return try? JSONDecoder().decode(WeatherReport.self, from: data)
+    }
+}

--- a/standalone/weather-ios/QuillWeather/State/WeatherStore.swift
+++ b/standalone/weather-ios/QuillWeather/State/WeatherStore.swift
@@ -1,0 +1,59 @@
+import Observation
+import WidgetKit
+
+/// The app-facing weather state. Owns the fusion `WeatherService`, keeps the
+/// latest report per location for the UI, caches to the App Group so widgets and
+/// the badge stay in sync, and refreshes the badge + widget timelines after a
+/// fetch.
+@MainActor
+@Observable
+final class WeatherStore {
+    private let service = WeatherService()
+    private(set) var reports: [UUID: WeatherReport] = [:]
+    private(set) var loadingLocationIDs: Set<UUID> = []
+    private(set) var lastError: String?
+
+    /// The freshest report we can show — in-memory first, then the App Group
+    /// cache (so a cold launch renders immediately).
+    func report(for location: Location) -> WeatherReport? {
+        reports[location.id] ?? SharedStore.cachedReport(for: location.id)
+    }
+
+    func isLoading(_ location: Location) -> Bool {
+        loadingLocationIDs.contains(location.id)
+    }
+
+    func refresh(_ location: Location) async {
+        loadingLocationIDs.insert(location.id)
+        defer { loadingLocationIDs.remove(location.id) }
+        do {
+            let report = try await service.report(for: location)
+            reports[location.id] = report
+            SharedStore.cacheReport(report)
+            lastError = nil
+        } catch {
+            lastError = "Couldn't load \(location.name)'s weather."
+        }
+    }
+
+    /// Refresh every saved location, then reconcile the badge and widgets from
+    /// the primary. Called on appear and on pull-to-refresh.
+    func refreshAll(_ locations: [Location], settings: AppSettings) async {
+        await withTaskGroup(of: Void.self) { group in
+            for location in locations {
+                group.addTask { await self.refresh(location) }
+            }
+        }
+        await reconcileGlanceSurfaces(primary: locations.first(where: \.isPrimary) ?? locations.first, settings: settings)
+    }
+
+    /// Push the primary location's temperature to the badge (W-8) and reload the
+    /// widget timelines (W-1) after the toggle or unit changes too.
+    func reconcileGlanceSurfaces(primary: Location?, settings: AppSettings) async {
+        let report = primary.flatMap { report(for: $0) }
+        await BadgeManager.update(
+            from: report, enabled: settings.showTemperatureBadge, unit: settings.temperatureUnit
+        )
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Support/Info.plist
+++ b/standalone/weather-ios/QuillWeather/Support/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Quill Weather</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Quill Weather uses your location to report the weather and alerts where you are. It never leaves your device except to fetch the forecast for that spot.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Allow background access so Quill Weather can refresh your current conditions and warn you about severe weather even when the app is closed.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>fetch</string>
+		<string>remote-notification</string>
+	</array>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.communityaccess.quillweather.refresh</string>
+	</array>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/standalone/weather-ios/QuillWeather/Support/QuillWeather.entitlements
+++ b/standalone/weather-ios/QuillWeather/Support/QuillWeather.entitlements
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- Add the WeatherKit capability in Xcode (Signing & Capabilities) and
+	     register the App ID for WeatherKit at developer.apple.com. Requires a
+	     paid Apple Developer account. Without it the app falls back to the
+	     keyless Open-Meteo provider. -->
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
+	<!-- App Group so the widget extension can read the app's saved locations
+	     and last-known report. Create it in Xcode and match the identifier. -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.communityaccess.quillweather</string>
+	</array>
+</dict>
+</plist>

--- a/standalone/weather-ios/QuillWeather/Units/TemperatureUnit.swift
+++ b/standalone/weather-ios/QuillWeather/Units/TemperatureUnit.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The user's preferred temperature scale. Weather values are stored as
+/// `Measurement<UnitTemperature>` so conversion is exact; this only decides how
+/// they are displayed and spoken.
+enum TemperatureUnit: String, CaseIterable, Codable, Sendable, Identifiable {
+    case fahrenheit
+    case celsius
+
+    var id: Self { self }
+
+    var unit: UnitTemperature {
+        switch self {
+        case .fahrenheit: .fahrenheit
+        case .celsius: .celsius
+        }
+    }
+
+    /// A short, screen-reader-friendly name ("Fahrenheit", not "°F").
+    var spokenName: String {
+        switch self {
+        case .fahrenheit: "Fahrenheit"
+        case .celsius: "Celsius"
+        }
+    }
+}
+
+extension Measurement where UnitType == UnitTemperature {
+    /// A compact display string, e.g. `112°`. Whole degrees — weather is never
+    /// reported to the app's users with decimals.
+    func shortDisplay(in unit: TemperatureUnit) -> String {
+        let value = converted(to: unit.unit).value
+        return "\(Int(value.rounded()))°"
+    }
+
+    /// A spoken string, e.g. `112 degrees`. Used for accessibility labels and
+    /// the narrator so VoiceOver never has to interpret a bare number or a
+    /// degree glyph.
+    func spokenDisplay(in unit: TemperatureUnit) -> String {
+        let value = Int(converted(to: unit.unit).value.rounded())
+        return "\(value) degrees"
+    }
+
+    /// The whole-degree integer used for the app-icon badge (`BadgeManager`).
+    func wholeDegrees(in unit: TemperatureUnit) -> Int {
+        Int(converted(to: unit.unit).value.rounded())
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Weather/OpenMeteoProvider.swift
+++ b/standalone/weather-ios/QuillWeather/Weather/OpenMeteoProvider.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Keyless, worldwide provider (open-meteo.com). This is the one that actually
+/// runs without a paid WeatherKit entitlement, so it doubles as the app's
+/// always-available floor. Values are fetched in Celsius + m/s and stored as
+/// `Measurement`s; the UI converts to the user's unit at display time.
+struct OpenMeteoProvider: WeatherProvider {
+    let id: WeatherProviderID = .openMeteo
+    var session: URLSession = .shared
+
+    func report(for location: Location) async throws -> WeatherReport {
+        var components = URLComponents(string: "https://api.open-meteo.com/v1/forecast")!
+        components.queryItems = [
+            .init(name: "latitude", value: String(location.latitude)),
+            .init(name: "longitude", value: String(location.longitude)),
+            .init(name: "timeformat", value: "unixtime"),
+            .init(name: "timezone", value: "auto"),
+            .init(name: "wind_speed_unit", value: "ms"),
+            .init(name: "temperature_unit", value: "celsius"),
+            .init(name: "forecast_days", value: "7"),
+            .init(
+                name: "current",
+                value: "temperature_2m,apparent_temperature,relative_humidity_2m,is_day,weather_code,wind_speed_10m"
+            ),
+            .init(name: "hourly", value: "temperature_2m,weather_code,precipitation_probability"),
+            .init(
+                name: "daily",
+                value: "weather_code,temperature_2m_max,temperature_2m_min,precipitation_probability_max"
+            ),
+        ]
+        guard let url = components.url else { throw WeatherProviderError.badResponse }
+
+        let (data, response) = try await session.data(from: url)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw WeatherProviderError.badResponse
+        }
+
+        let decoded: Payload
+        do {
+            decoded = try JSONDecoder().decode(Payload.self, from: data)
+        } catch {
+            throw WeatherProviderError.decoding(String(describing: error))
+        }
+        return report(from: decoded, location: location)
+    }
+
+    // MARK: - Mapping
+
+    private func report(from payload: Payload, location: Location) -> WeatherReport {
+        let c = payload.current
+        let current = CurrentConditions(
+            temperature: .init(value: c.temperature_2m, unit: .celsius),
+            apparentTemperature: .init(value: c.apparent_temperature, unit: .celsius),
+            condition: Self.condition(code: c.weather_code, isDay: c.is_day == 1),
+            humidity: c.relative_humidity_2m / 100,
+            windSpeed: .init(value: c.wind_speed_10m, unit: .metersPerSecond),
+            isDaylight: c.is_day == 1
+        )
+
+        let hourly = zip4(
+            payload.hourly.time, payload.hourly.temperature_2m,
+            payload.hourly.weather_code, payload.hourly.precipitation_probability
+        )
+        .prefix(24)
+        .map { time, temp, code, pop in
+            HourlyForecast(
+                date: Date(timeIntervalSince1970: TimeInterval(time)),
+                temperature: .init(value: temp, unit: .celsius),
+                condition: Self.condition(code: code, isDay: true),
+                precipitationChance: Double(pop ?? 0) / 100
+            )
+        }
+
+        let daily = zip5(
+            payload.daily.time, payload.daily.temperature_2m_max,
+            payload.daily.temperature_2m_min, payload.daily.weather_code,
+            payload.daily.precipitation_probability_max
+        )
+        .map { time, high, low, code, pop in
+            DailyForecast(
+                date: Date(timeIntervalSince1970: TimeInterval(time)),
+                highTemperature: .init(value: high, unit: .celsius),
+                lowTemperature: .init(value: low, unit: .celsius),
+                condition: Self.condition(code: code, isDay: true),
+                precipitationChance: Double(pop ?? 0) / 100
+            )
+        }
+
+        return WeatherReport(
+            location: location,
+            current: current,
+            hourly: Array(hourly),
+            daily: daily,
+            alerts: [], // Open-Meteo carries no alerts; NWS/WeatherKit do.
+            provider: .openMeteo,
+            asOf: Date(timeIntervalSince1970: TimeInterval(c.time))
+        )
+    }
+
+    /// Map a WMO weather-interpretation code to a provider-neutral condition.
+    static func condition(code: Int, isDay: Bool) -> WeatherCondition {
+        let sun = isDay ? "sun.max" : "moon.stars"
+        let partly = isDay ? "cloud.sun" : "cloud.moon"
+        switch code {
+        case 0: return .init(code: "clear", symbolName: sun, text: isDay ? "clear" : "clear skies")
+        case 1: return .init(code: "mostlyClear", symbolName: partly, text: "mostly clear")
+        case 2: return .init(code: "partlyCloudy", symbolName: partly, text: "partly cloudy")
+        case 3: return .init(code: "cloudy", symbolName: "cloud", text: "cloudy")
+        case 45, 48: return .init(code: "fog", symbolName: "cloud.fog", text: "foggy")
+        case 51, 53, 55: return .init(code: "drizzle", symbolName: "cloud.drizzle", text: "drizzle")
+        case 56, 57: return .init(code: "freezingDrizzle", symbolName: "cloud.sleet", text: "freezing drizzle")
+        case 61, 63, 65: return .init(code: "rain", symbolName: "cloud.rain", text: "rain")
+        case 66, 67: return .init(code: "freezingRain", symbolName: "cloud.sleet", text: "freezing rain")
+        case 71, 73, 75, 77: return .init(code: "snow", symbolName: "cloud.snow", text: "snow")
+        case 80, 81, 82: return .init(code: "showers", symbolName: "cloud.heavyrain", text: "rain showers")
+        case 85, 86: return .init(code: "snowShowers", symbolName: "cloud.snow", text: "snow showers")
+        case 95: return .init(code: "thunderstorms", symbolName: "cloud.bolt.rain", text: "thunderstorms")
+        case 96, 99: return .init(code: "hailstorms", symbolName: "cloud.bolt.rain", text: "thunderstorms with hail")
+        default: return .unknown
+        }
+    }
+
+    // MARK: - DTOs
+
+    private struct Payload: Decodable {
+        let current: Current
+        let hourly: Hourly
+        let daily: Daily
+    }
+
+    private struct Current: Decodable {
+        let time: Int
+        let temperature_2m: Double
+        let apparent_temperature: Double
+        let relative_humidity_2m: Double
+        let is_day: Int
+        let weather_code: Int
+        let wind_speed_10m: Double
+    }
+
+    private struct Hourly: Decodable {
+        let time: [Int]
+        let temperature_2m: [Double]
+        let weather_code: [Int]
+        let precipitation_probability: [Int?]
+    }
+
+    private struct Daily: Decodable {
+        let time: [Int]
+        let weather_code: [Int]
+        let temperature_2m_max: [Double]
+        let temperature_2m_min: [Double]
+        let precipitation_probability_max: [Int?]
+    }
+}
+
+// Small zip helpers — Swift's stdlib only ships the two-sequence `zip`.
+private func zip4<A, B, C, D>(
+    _ a: [A], _ b: [B], _ c: [C], _ d: [D]
+) -> [(A, B, C, D)] {
+    let n = min(min(a.count, b.count), min(c.count, d.count))
+    return (0..<n).map { (a[$0], b[$0], c[$0], d[$0]) }
+}
+
+private func zip5<A, B, C, D, E>(
+    _ a: [A], _ b: [B], _ c: [C], _ d: [D], _ e: [E]
+) -> [(A, B, C, D, E)] {
+    let n = min(min(min(a.count, b.count), min(c.count, d.count)), e.count)
+    return (0..<n).map { (a[$0], b[$0], c[$0], d[$0], e[$0]) }
+}

--- a/standalone/weather-ios/QuillWeather/Weather/WeatherKitProvider.swift
+++ b/standalone/weather-ios/QuillWeather/Weather/WeatherKitProvider.swift
@@ -1,0 +1,99 @@
+import CoreLocation
+import Foundation
+import WeatherKit
+
+/// Apple WeatherKit provider (PRD §6, F-22). Requires the WeatherKit capability
+/// and a registered App ID (paid Apple Developer account); without it,
+/// `weather(for:)` throws at runtime and `WeatherService` falls through to
+/// `OpenMeteoProvider`. WeatherKit already vends `Measurement`s, so mapping is
+/// mostly renaming. WeatherKit's own types are fully qualified to avoid clashing
+/// with this app's `WeatherCondition` / `WeatherAlert` / `WeatherService`.
+struct WeatherKitProvider: WeatherProvider {
+    let id: WeatherProviderID = .weatherKit
+
+    func report(for location: Location) async throws -> WeatherReport {
+        let clLocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
+        let weather = try await WeatherKit.WeatherService.shared.weather(for: clLocation)
+
+        let current = Self.map(current: weather.currentWeather)
+        let hourly = weather.hourlyForecast.forecast.prefix(24).map(Self.map(hour:))
+        let daily = weather.dailyForecast.forecast.prefix(7).map(Self.map(day:))
+        let alerts = (weather.weatherAlerts ?? []).map(Self.map(alert:))
+
+        return WeatherReport(
+            location: location,
+            current: current,
+            hourly: Array(hourly),
+            daily: Array(daily),
+            alerts: alerts,
+            provider: .weatherKit,
+            asOf: weather.currentWeather.date
+        )
+    }
+
+    // MARK: - Mapping
+
+    private static func map(current w: WeatherKit.CurrentWeather) -> CurrentConditions {
+        CurrentConditions(
+            temperature: w.temperature,
+            apparentTemperature: w.apparentTemperature,
+            condition: condition(w.condition, symbol: w.symbolName),
+            humidity: w.humidity,
+            windSpeed: w.wind.speed,
+            isDaylight: w.isDaylight
+        )
+    }
+
+    private static func map(hour h: WeatherKit.HourWeather) -> HourlyForecast {
+        HourlyForecast(
+            date: h.date,
+            temperature: h.temperature,
+            condition: condition(h.condition, symbol: h.symbolName),
+            precipitationChance: h.precipitationChance
+        )
+    }
+
+    private static func map(day d: WeatherKit.DayWeather) -> DailyForecast {
+        DailyForecast(
+            date: d.date,
+            highTemperature: d.highTemperature,
+            lowTemperature: d.lowTemperature,
+            condition: condition(d.condition, symbol: d.symbolName),
+            precipitationChance: d.precipitationChance
+        )
+    }
+
+    private static func map(alert a: WeatherKit.WeatherAlert) -> WeatherAlert {
+        WeatherAlert(
+            id: a.summary,
+            tier: tier(for: a.severity),
+            headline: a.summary,
+            detail: a.summary, // WeatherKit returns a summary; NWS carries full text.
+            source: a.source,
+            area: a.region ?? "",
+            effective: .now,
+            expires: nil
+        )
+    }
+
+    private static func condition(
+        _ condition: WeatherKit.WeatherCondition, symbol: String
+    ) -> WeatherCondition {
+        WeatherCondition(
+            code: String(describing: condition),
+            symbolName: symbol,
+            text: condition.description.lowercased()
+        )
+    }
+
+    private static func tier(for severity: WeatherKit.WeatherSeverity) -> WeatherAlert.Tier {
+        switch severity {
+        case .minor: .advisory
+        case .moderate: .watch
+        case .severe: .warning
+        case .extreme: .critical
+        case .unknown: .advisory
+        @unknown default: .advisory
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeather/Weather/WeatherProvider.swift
+++ b/standalone/weather-ios/QuillWeather/Weather/WeatherProvider.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// A source of weather for a location. Providers are `Sendable` value types with
+/// a single async entry point, so they can be called from any actor (the app's
+/// `WeatherStore`, a widget's timeline provider, or a background task).
+protocol WeatherProvider: Sendable {
+    var id: WeatherProviderID { get }
+    /// Fetch a full report, or throw. Fusion (`WeatherService`) decides what to
+    /// do with a failure — usually fall through to the next provider.
+    func report(for location: Location) async throws -> WeatherReport
+}
+
+/// Errors a provider can surface.
+enum WeatherProviderError: Error, Sendable {
+    case unsupportedRegion
+    case badResponse
+    case decoding(String)
+}

--- a/standalone/weather-ios/QuillWeather/Weather/WeatherService.swift
+++ b/standalone/weather-ios/QuillWeather/Weather/WeatherService.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The fusion coordinator (PRD §6). It asks providers in preference order and
+/// returns the first that succeeds — the scaffold's simple stand-in for the
+/// full per-question fusion in §6.2 (US ground-truth from NWS, worldwide from
+/// WeatherKit, Open-Meteo as the keyless floor). Graceful degradation (§6.3) is
+/// exactly this fall-through: a provider that throws never takes the app down,
+/// it just yields to the next.
+struct WeatherService: Sendable {
+    let providers: [any WeatherProvider]
+
+    /// Default order: WeatherKit first (best global data, needs the
+    /// entitlement), then Open-Meteo (keyless, always available). On the
+    /// Simulator or without a WeatherKit-enabled App ID, the first call throws
+    /// and Open-Meteo answers — the app still works.
+    init(providers: [any WeatherProvider] = [WeatherKitProvider(), OpenMeteoProvider()]) {
+        self.providers = providers
+    }
+
+    func report(for location: Location) async throws -> WeatherReport {
+        var lastError: Error = WeatherProviderError.badResponse
+        for provider in providers {
+            do {
+                return try await provider.report(for: location)
+            } catch {
+                lastError = error
+                continue
+            }
+        }
+        throw lastError
+    }
+}

--- a/standalone/weather-ios/QuillWeatherTests/BadgeManagerTests.swift
+++ b/standalone/weather-ios/QuillWeatherTests/BadgeManagerTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import QuillWeather
+
+@Suite("BadgeManager")
+struct BadgeManagerTests {
+    private func fahrenheit(_ value: Double) -> Measurement<UnitTemperature> {
+        Measurement(value: value, unit: .fahrenheit)
+    }
+
+    @Test("Triple-digit temperatures badge in full — no 99 ceiling")
+    func noNinetyNineCeiling() {
+        #expect(BadgeManager.badgeValue(for: fahrenheit(112), unit: .fahrenheit) == 112)
+        #expect(BadgeManager.badgeValue(for: fahrenheit(130), unit: .fahrenheit) == 130)
+    }
+
+    @Test("Zero and below cannot be badged (0 clears the badge)")
+    func cannotBadgeZeroOrBelow() {
+        #expect(BadgeManager.badgeValue(for: fahrenheit(0), unit: .fahrenheit) == nil)
+        #expect(BadgeManager.badgeValue(for: fahrenheit(-5), unit: .fahrenheit) == nil)
+    }
+
+    @Test("Rounds to a whole degree")
+    func roundsToWholeDegree() {
+        #expect(BadgeManager.badgeValue(for: fahrenheit(71.6), unit: .fahrenheit) == 72)
+    }
+
+    @Test("Converts to the user's unit before badging")
+    func convertsToUserUnit() {
+        let freezing = Measurement(value: 0, unit: UnitTemperature.celsius) // 32°F
+        #expect(BadgeManager.badgeValue(for: freezing, unit: .fahrenheit) == 32)
+        // 0°C would clear the badge, so it has no representation in Celsius.
+        #expect(BadgeManager.badgeValue(for: freezing, unit: .celsius) == nil)
+    }
+}

--- a/standalone/weather-ios/QuillWeatherTests/NarratorTests.swift
+++ b/standalone/weather-ios/QuillWeatherTests/NarratorTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import QuillWeather
+
+@Suite("Narrator")
+struct NarratorTests {
+    @Test("Mentions the place, temperature, and condition")
+    func mentionsCoreFacts() {
+        let sentence = Narrator(units: .fahrenheit).quickWeather(for: sampleReport(tempF: 112, condition: "sunny"))
+        #expect(sentence.contains("Phoenix"))
+        #expect(sentence.contains("112 degrees"))
+        #expect(sentence.contains("sunny"))
+    }
+
+    @Test("Adds feels-like when it differs by 3+ degrees")
+    func addsFeelsLikeWhenDifferent() {
+        let sentence = Narrator(units: .fahrenheit).quickWeather(for: sampleReport(tempF: 112, feelsF: 105))
+        #expect(sentence.contains("feeling like 105 degrees"))
+    }
+
+    @Test("Omits feels-like when it is within 2 degrees")
+    func omitsFeelsLikeWhenClose() {
+        let sentence = Narrator(units: .fahrenheit).quickWeather(for: sampleReport(tempF: 70, feelsF: 71))
+        #expect(!sentence.contains("feeling like"))
+    }
+
+    @Test("Appends the most severe alert headline")
+    func appendsAlert() {
+        let alert = WeatherAlert(
+            id: "1", tier: .warning, headline: "Excessive Heat Warning",
+            detail: "", source: "NWS", area: "Maricopa County",
+            effective: .now, expires: nil
+        )
+        let sentence = Narrator(units: .fahrenheit).quickWeather(for: sampleReport(alerts: [alert]))
+        #expect(sentence.contains("Excessive Heat Warning"))
+    }
+}

--- a/standalone/weather-ios/QuillWeatherTests/SampleData.swift
+++ b/standalone/weather-ios/QuillWeatherTests/SampleData.swift
@@ -1,0 +1,29 @@
+import Foundation
+@testable import QuillWeather
+
+/// Builds a deterministic report for tests.
+func sampleReport(
+    tempF: Double = 112,
+    feelsF: Double = 108,
+    condition: String = "sunny",
+    provider: WeatherProviderID = .openMeteo,
+    name: String = "Phoenix",
+    alerts: [WeatherAlert] = []
+) -> WeatherReport {
+    let location = Location(name: name, latitude: 33.4484, longitude: -112.0740)
+    let current = CurrentConditions(
+        temperature: .init(value: tempF, unit: .fahrenheit),
+        apparentTemperature: .init(value: feelsF, unit: .fahrenheit),
+        condition: WeatherCondition(code: condition, symbolName: "sun.max", text: condition),
+        humidity: 0.1,
+        windSpeed: .init(value: 3, unit: .metersPerSecond),
+        isDaylight: true
+    )
+    return WeatherReport(
+        location: location,
+        current: current,
+        alerts: alerts,
+        provider: provider,
+        asOf: Date(timeIntervalSince1970: 0)
+    )
+}

--- a/standalone/weather-ios/QuillWeatherTests/WeatherServiceTests.swift
+++ b/standalone/weather-ios/QuillWeatherTests/WeatherServiceTests.swift
@@ -1,0 +1,34 @@
+import Testing
+@testable import QuillWeather
+
+@Suite("WeatherService fusion")
+struct WeatherServiceTests {
+    private struct FailingProvider: WeatherProvider {
+        let id = WeatherProviderID.weatherKit
+        func report(for location: Location) async throws -> WeatherReport {
+            throw WeatherProviderError.badResponse
+        }
+    }
+
+    private struct StubProvider: WeatherProvider {
+        let id = WeatherProviderID.openMeteo
+        let canned: WeatherReport
+        func report(for location: Location) async throws -> WeatherReport { canned }
+    }
+
+    @Test("Falls through a failing provider to the next one")
+    func fallsThroughToNextProvider() async throws {
+        let stub = sampleReport(provider: .openMeteo)
+        let service = WeatherService(providers: [FailingProvider(), StubProvider(canned: stub)])
+        let result = try await service.report(for: stub.location)
+        #expect(result.provider == .openMeteo)
+    }
+
+    @Test("Throws when every provider fails")
+    func throwsWhenAllFail() async {
+        let service = WeatherService(providers: [FailingProvider(), FailingProvider()])
+        await #expect(throws: (any Error).self) {
+            _ = try await service.report(for: sampleReport().location)
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/CurrentConditionsWidget.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/CurrentConditionsWidget.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WidgetKit
+
+/// Home Screen widget: temperature + condition for the primary location.
+struct CurrentConditionsWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "CurrentConditions", provider: WeatherTimelineProvider()) { entry in
+            CurrentConditionsWidgetView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Current Conditions")
+        .description("Temperature and conditions for your primary location.")
+        .supportedFamilies([.systemSmall, .systemMedium])
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/CurrentConditionsWidgetView.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/CurrentConditionsWidgetView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+import WidgetKit
+
+struct CurrentConditionsWidgetView: View {
+    let entry: WeatherEntry
+
+    var body: some View {
+        if let report = entry.report {
+            let narrator = Narrator(units: entry.unit)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(report.location.name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                HStack {
+                    Text(report.current.temperature.shortDisplay(in: entry.unit))
+                        .font(.system(size: 40, weight: .semibold, design: .rounded))
+                    Image(systemName: report.current.condition.symbolName)
+                        .symbolRenderingMode(.multicolor)
+                        .font(.title2)
+                }
+                Text(report.current.condition.text.capitalized)
+                    .font(.caption)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(narrator.quickWeather(for: report)) \(narrator.freshness(report.asOf, now: entry.date)).")
+        } else {
+            ContentUnavailableView("No location", systemImage: "location.slash")
+                .accessibilityLabel("No primary location set. Open Quill Weather to add one.")
+        }
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/LockScreenTemperatureView.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/LockScreenTemperatureView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import WidgetKit
+
+struct LockScreenTemperatureView: View {
+    @Environment(\.widgetFamily) private var family
+    let entry: WeatherEntry
+
+    var body: some View {
+        content
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch family {
+        case .accessoryInline:
+            // The inline slot is a single line beside the clock.
+            Label("\(shortTemperature) \(conditionText)", systemImage: symbolName)
+
+        case .accessoryCircular:
+            ZStack {
+                AccessoryWidgetBackground()
+                VStack(spacing: 0) {
+                    Image(systemName: symbolName)
+                        .font(.caption2)
+                    Text(shortTemperature)
+                        .font(.headline)
+                        .minimumScaleFactor(0.6) // keep triple digits legible
+                }
+            }
+
+        case .accessoryRectangular:
+            HStack(spacing: 8) {
+                Image(systemName: symbolName)
+                    .font(.title2)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(shortTemperature)
+                        .font(.headline)
+                    Text(conditionText)
+                        .font(.caption)
+                }
+            }
+
+        default:
+            Text(shortTemperature)
+        }
+    }
+
+    // MARK: - Derived content
+
+    private var shortTemperature: String {
+        entry.report?.current.temperature.shortDisplay(in: entry.unit) ?? "--°"
+    }
+
+    private var conditionText: String {
+        entry.report?.current.condition.text.capitalized ?? "No data"
+    }
+
+    private var symbolName: String {
+        entry.report?.current.condition.symbolName ?? "thermometer.medium"
+    }
+
+    private var accessibilityLabel: String {
+        guard let report = entry.report else {
+            return "No primary location set. Open Quill Weather to add one."
+        }
+        let narrator = Narrator(units: entry.unit)
+        let temperature = report.current.temperature.spokenDisplay(in: entry.unit)
+        return "\(temperature), \(report.current.condition.text). \(narrator.freshness(report.asOf, now: entry.date))."
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/LockScreenTemperatureWidget.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/LockScreenTemperatureWidget.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import WidgetKit
+
+/// PRD §9 W-1: the recommended Lock Screen surface for a temperature. Unlike the
+/// app-icon badge (W-8), the accessory families render the degree sign, handle
+/// negatives, and carry a full VoiceOver label.
+struct LockScreenTemperatureWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: "LockScreenTemperature", provider: WeatherTimelineProvider()) { entry in
+            LockScreenTemperatureView(entry: entry)
+                .containerBackground(.clear, for: .widget)
+        }
+        .configurationDisplayName("Temperature")
+        .description("Your primary location's current temperature on the Lock Screen.")
+        .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/QuillWeatherWidgetBundle.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/QuillWeatherWidgetBundle.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct QuillWeatherWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        CurrentConditionsWidget()
+        LockScreenTemperatureWidget()
+    }
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/Support/Info.plist
+++ b/standalone/weather-ios/QuillWeatherWidgets/Support/Info.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>Quill Weather Widgets</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/standalone/weather-ios/QuillWeatherWidgets/Support/QuillWeatherWidgets.entitlements
+++ b/standalone/weather-ios/QuillWeatherWidgets/Support/QuillWeatherWidgets.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
+	<!-- Must match the app target's App Group so the widget can read the
+	     shared saved locations + last report. -->
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.communityaccess.quillweather</string>
+	</array>
+</dict>
+</plist>

--- a/standalone/weather-ios/QuillWeatherWidgets/WeatherEntry.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/WeatherEntry.swift
@@ -1,0 +1,15 @@
+import WidgetKit
+
+/// One timeline snapshot for the widgets. Carries the cached/fresh report and
+/// the user's unit so the views need no environment.
+struct WeatherEntry: TimelineEntry {
+    let date: Date
+    let report: WeatherReport?
+    let unit: TemperatureUnit
+
+    static let placeholder = WeatherEntry(
+        date: .now,
+        report: nil,
+        unit: .fahrenheit
+    )
+}

--- a/standalone/weather-ios/QuillWeatherWidgets/WeatherTimelineProvider.swift
+++ b/standalone/weather-ios/QuillWeatherWidgets/WeatherTimelineProvider.swift
@@ -1,0 +1,36 @@
+import WidgetKit
+
+/// Supplies entries for every Quill Weather widget from the primary saved
+/// location. It shows the App Group's cached report immediately, then tries a
+/// fresh fetch, and asks WidgetKit to refresh in ~30 minutes. WidgetKit budgets
+/// refreshes, so "current" means "as of this entry's date" — the views state
+/// their freshness (PRD §9 W-1).
+struct WeatherTimelineProvider: TimelineProvider {
+    func placeholder(in context: Context) -> WeatherEntry {
+        .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (WeatherEntry) -> Void) {
+        let unit = SharedStore.temperatureUnit
+        let report = SharedStore.primaryLocation.flatMap { SharedStore.cachedReport(for: $0.id) }
+        completion(WeatherEntry(date: .now, report: report, unit: unit))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<WeatherEntry>) -> Void) {
+        Task {
+            let unit = SharedStore.temperatureUnit
+            var report = SharedStore.primaryLocation.flatMap { SharedStore.cachedReport(for: $0.id) }
+
+            if let primary = SharedStore.primaryLocation,
+               let fresh = try? await WeatherService().report(for: primary) {
+                SharedStore.cacheReport(fresh)
+                report = fresh
+            }
+
+            let entry = WeatherEntry(date: .now, report: report, unit: unit)
+            let next = Calendar.current.date(byAdding: .minute, value: 30, to: .now)
+                ?? .now.addingTimeInterval(1800)
+            completion(Timeline(entries: [entry], policy: .after(next)))
+        }
+    }
+}

--- a/standalone/weather-ios/README.md
+++ b/standalone/weather-ios/README.md
@@ -1,0 +1,69 @@
+# Quill Weather for iOS — scaffold
+
+This is the **first-cut SwiftUI scaffold** for the Quill Weather iOS app,
+generated from `standalone/weather/docs/prd-ios.md`. It implements the core
+architecture (models, provider/fusion layer, location, narration, saved
+locations, Quick Weather, settings), the two glance surfaces we specced
+(§9 W-1 Lock Screen temperature widget and W-8 app-icon badge), and a first
+App Intent + App Shortcut.
+
+> **It has not been compiled.** It was authored on Windows, where no Xcode /
+> Swift-for-Apple toolchain exists. Expect to fix a few compile errors when you
+> first build on a Mac — treat this as a strong starting point, not a finished
+> app. The code targets **iOS 26 / Swift 6.2** with strict concurrency, per the
+> `swiftui-pro` skill's defaults; lower `deploymentTarget` in `project.yml` if
+> you need wider reach.
+
+## Building (macOS + Xcode 26)
+
+The Xcode project is described by `project.yml` (XcodeGen) rather than a
+committed `.xcodeproj`, so the project file never becomes an unreadable merge
+conflict.
+
+```bash
+brew install xcodegen        # one time
+cd standalone/weather-ios
+xcodegen generate            # writes QuillWeather.xcodeproj
+open QuillWeather.xcodeproj
+```
+
+Then in Xcode:
+
+1. Set your **Team** and a unique **bundle identifier** on both targets.
+2. Add the **WeatherKit** capability to the app target (needs a paid Apple
+   Developer account) and register the App ID for WeatherKit at
+   developer.apple.com. Without it, the app still runs against **Open-Meteo**
+   (keyless), which is the worldwide fallback provider.
+3. Build and run.
+
+## What's implemented vs. stubbed
+
+**Implemented (real code):**
+
+- `Models/` — the weather domain (`Location`, `WeatherReport`, conditions,
+  hourly/daily, alerts, units).
+- `Weather/` — a `WeatherProvider` protocol, `OpenMeteoProvider` (keyless, real
+  network + JSON), a `WeatherKitProvider` (real WeatherKit calls), and a
+  `WeatherService` fusion coordinator picking the provider per PRD §6.2.
+- `Location/` — `LocationManager` (CoreLocation) and a Codable
+  `SavedLocationsStore`.
+- `Narration/Narrator` — turns a report into the single spoken sentence used by
+  the UI's `accessibilityLabel`, the widget, and the App Intent (the
+  three-second promise, PRD §3).
+- **VoiceOver actions (PRD §5.2)** — location rows and the weather card carry
+  rotor actions (Speak / Make Primary / Delete / Refresh), and which categories
+  appear is user-configurable via `AccessibilityActionSettings` and a Settings
+  section. This is the seam the fuller "configurable rotor" work grows from.
+- `Badge/BadgeManager` — the W-8 app-icon temperature badge, with the honest
+  constraints (integer-only, no negatives, clears at 0, no 99 ceiling).
+- `Features/` — Locations list (`NavigationSplitView`), report view, Quick
+  Weather, and Settings (units + badge toggle).
+- `QuillWeatherWidgets/` — a Current Conditions widget and the Lock Screen
+  accessory **temperature** widget (W-1), both with full accessibility labels.
+- `Intents/` — `GetQuickWeatherIntent` + `QuillWeatherShortcuts` (W-4).
+- `QuillWeatherTests/` — Swift Testing tests for the narrator, badge clamping,
+  and provider selection.
+
+**Stubbed / deferred (documented in code):** NWS provider (US ground-truth),
+QuillPush alert relay (§8), Watch app, iCloud/QuillSync (§11), Live Activities.
+These have protocol seams but no implementation yet.

--- a/standalone/weather-ios/project.yml
+++ b/standalone/weather-ios/project.yml
@@ -1,0 +1,77 @@
+# XcodeGen spec for Quill Weather iOS. Generate the project with:
+#   xcodegen generate
+# See README.md. Deployment target and bundle IDs are meant to be edited.
+name: QuillWeather
+options:
+  bundleIdPrefix: com.communityaccess.quillweather
+  deploymentTarget:
+    iOS: "26.0"
+  createIntermediateGroups: true
+settings:
+  base:
+    SWIFT_VERSION: "6.0"
+    SWIFT_STRICT_CONCURRENCY: complete
+    MARKETING_VERSION: "1.0.0"
+    CURRENT_PROJECT_VERSION: "1"
+    DEVELOPMENT_TEAM: "" # set your Team ID
+    CODE_SIGN_STYLE: Automatic
+    ENABLE_USER_SCRIPT_SANDBOXING: YES
+    GENERATE_INFOPLIST_FILE: NO
+
+targets:
+  QuillWeather:
+    type: application
+    platform: iOS
+    sources:
+      - path: QuillWeather
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.communityaccess.quillweather
+        INFOPLIST_FILE: QuillWeather/Support/Info.plist
+        CODE_SIGN_ENTITLEMENTS: QuillWeather/Support/QuillWeather.entitlements
+        SUPPORTS_MACCATALYST: NO
+    dependencies:
+      - sdk: WeatherKit.framework
+      - sdk: CoreLocation.framework
+      - target: QuillWeatherWidgets
+        embed: true
+
+  QuillWeatherWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: QuillWeatherWidgets
+      # The widget reuses the app's model + narration + weather + shared layers.
+      - path: QuillWeather/Models
+      - path: QuillWeather/Weather
+      - path: QuillWeather/Narration
+      - path: QuillWeather/Units
+      - path: QuillWeather/Shared
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.communityaccess.quillweather.widgets
+        INFOPLIST_FILE: QuillWeatherWidgets/Support/Info.plist
+        CODE_SIGN_ENTITLEMENTS: QuillWeatherWidgets/Support/QuillWeatherWidgets.entitlements
+    dependencies:
+      - sdk: WeatherKit.framework
+      - sdk: CoreLocation.framework
+      - sdk: WidgetKit.framework
+      - sdk: SwiftUI.framework
+
+  QuillWeatherTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: QuillWeatherTests
+    dependencies:
+      - target: QuillWeather
+
+schemes:
+  QuillWeather:
+    build:
+      targets:
+        QuillWeather: all
+        QuillWeatherWidgets: all
+    test:
+      targets:
+        - QuillWeatherTests


### PR DESCRIPTION
A Mac-buildable **SwiftUI scaffold** for Quill Weather iOS, generated from `standalone/weather/docs/prd-ios.md`. Authored on Windows (no Xcode here), so **it has not been compiled** — expect a few compile fixes on the first Mac build; the README says so plainly. Targets iOS 26 / Swift 6.2 with strict concurrency, following the twostraws `swiftui-pro` skill's conventions (feature folders, one type per file, modern APIs, accessibility-first).

## Build
XcodeGen `project.yml` instead of a committed `.xcodeproj`:
```bash
brew install xcodegen
cd standalone/weather-ios && xcodegen generate && open QuillWeather.xcodeproj
```
Set your Team + bundle IDs, add the WeatherKit capability (paid account). Without it, the app runs against **Open-Meteo** (keyless).

## What's here (57 files)
- **Models** — weather domain (Location, WeatherReport, conditions, hourly/daily, alerts, units).
- **Weather** — `WeatherProvider` protocol, `OpenMeteoProvider` (real network/JSON), `WeatherKitProvider`, and a `WeatherService` fusion coordinator (§6.2 + §6.3 graceful degradation).
- **Location / State / Settings / Shared** — CoreLocation, `@Observable` app state, prefs, and an App Group bridge to the widget/intents.
- **Narration** — `Narrator` (the three-second spoken sentence) shared by UI, widget, and Siri.
- **Badge** — `BadgeManager` implementing §9 **W-8** with the integer-only / no-negative / no-99-ceiling constraints.
- **Features** — Locations list (`NavigationSplitView`), full report, Quick Weather, Settings.
- **Widgets** — Current Conditions + the Lock Screen accessory **temperature** widget (§9 **W-1**), full a11y labels.
- **Intents** — `GetQuickWeatherIntent` + App Shortcut (§9 W-4).
- **Tests** — Swift Testing suites (narrator, badge clamping incl. triple-digit AZ temps, provider fall-through).

## Accessibility
Every row/card/widget is one VoiceOver element labelled with the narrator's sentence. Location rows and the weather card also carry **configurable VoiceOver rotor actions** (Speak / Make Primary / Delete / Refresh) via `AccessibilityActionSettings` + a Settings section (§5.2).

## Not built yet (protocol seams only)
NWS provider, QuillPush alert relay (§8), Watch app, iCloud/QuillSync (§11), Live Activities.

> Docs/code only; there's no Swift CI in this repo, so nothing compiles it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)