### PR TITLE
fix(signing): sanitize the rcedit-stamped launcher's PE before signing

### DIFF
--- a/scripts/code_signing.py
+++ b/scripts/code_signing.py
@@ -315,6 +315,41 @@ def resolve_config(
 # -- signing + verification ---------------------------------------------------
 
 
+def _sanitize_pe_for_signing(path: Path) -> None:
+    """Zero a dangling Certificate Table data directory before signing.
+
+    rcedit (which stamps the launcher's VERSIONINFO) rewrites a PE copied from
+    an already-signed binary -- the embeddable ``pythonw.exe`` -> ``quill.exe``
+    -- but leaves the optional header's Certificate Table entry
+    (IMAGE_DIRECTORY_ENTRY_SECURITY, index 4) pointing at the old signature it
+    removed: an offset at or past EOF. ``signtool`` then fails with 0x800700C1
+    (badexeformat) trying to parse a certificate that is not there.
+
+    A genuine signature sits fully *inside* the file and is left untouched --
+    signtool replaces it. Only an entry that points outside the file (rva >=
+    size, or rva + size > size) is zeroed. Best-effort: any parse problem is
+    swallowed so signtool, not this helper, reports real errors.
+    """
+    try:
+        data = bytearray(path.read_bytes())
+        if data[:2] != b"MZ":
+            return
+        e_lfanew = int.from_bytes(data[0x3C:0x40], "little")
+        if data[e_lfanew : e_lfanew + 4] != b"PE\x00\x00":
+            return
+        opt = e_lfanew + 24  # PE signature (4) + COFF header (20)
+        magic = int.from_bytes(data[opt : opt + 2], "little")
+        ddir = opt + (112 if magic == 0x20B else 96)  # PE32+ vs PE32 data-dir offset
+        cert = ddir + 4 * 8  # index 4, 8 bytes per entry
+        rva = int.from_bytes(data[cert : cert + 4], "little")
+        size = int.from_bytes(data[cert + 4 : cert + 8], "little")
+        if rva and (rva >= len(data) or rva + size > len(data)):
+            data[cert : cert + 8] = b"\x00" * 8
+            path.write_bytes(bytes(data))
+    except (OSError, IndexError, ValueError):
+        return
+
+
 def _sign_command(config: SigningConfig, files: Sequence[Path]) -> list[str]:
     return [
         str(config.signtool),
@@ -348,6 +383,8 @@ def sign_files(files: Iterable[Path], config: SigningConfig, *, batch: int = 50)
         raise SigningError(f"Cannot sign missing files: {', '.join(map(str, missing))}")
     if not resolved:
         return []
+    for f in resolved:
+        _sanitize_pe_for_signing(f)
     for start in range(0, len(resolved), batch):
         chunk = resolved[start : start + batch]
         command = _sign_command(config, chunk)

--- a/tests/unit/scripts/test_code_signing.py
+++ b/tests/unit/scripts/test_code_signing.py
@@ -164,3 +164,51 @@ def test_sign_paths_signs_collected_files(
 def test_version_key_orders_sdk_builds() -> None:
     assert cs._version_key("10.0.26100.0") > cs._version_key("10.0.22621.0")
     assert cs._version_key("10.0.22621.0") > cs._version_key("10.0.19041.0")
+
+
+def _fake_pe(cert_rva: int, cert_size: int, total: int = 320) -> bytearray:
+    """A minimal PE32+ header buffer with a Certificate Table directory entry."""
+    import struct
+
+    data = bytearray(total)
+    data[0:2] = b"MZ"
+    e_lfanew = 0x80
+    struct.pack_into("<I", data, 0x3C, e_lfanew)
+    data[e_lfanew : e_lfanew + 4] = b"PE\x00\x00"
+    opt = e_lfanew + 24
+    struct.pack_into("<H", data, opt, 0x20B)  # PE32+
+    cert = opt + 112 + 4 * 8
+    struct.pack_into("<II", data, cert, cert_rva, cert_size)
+    return data
+
+
+def _cert_entry(data: bytes) -> tuple[int, int]:
+    import struct
+
+    e_lfanew = struct.unpack_from("<I", data, 0x3C)[0]
+    opt = e_lfanew + 24
+    cert = opt + 112 + 4 * 8
+    return struct.unpack_from("<II", data, cert)
+
+
+def test_sanitize_zeros_a_dangling_cert_directory(tmp_path: Path) -> None:
+    # rva points past EOF (the rcedit-stamped-launcher case) -> zeroed.
+    exe = tmp_path / "quill.exe"
+    exe.write_bytes(bytes(_fake_pe(cert_rva=90112, cert_size=14048, total=320)))
+    cs._sanitize_pe_for_signing(exe)
+    assert _cert_entry(exe.read_bytes()) == (0, 0)
+
+
+def test_sanitize_leaves_an_in_file_cert_directory_untouched(tmp_path: Path) -> None:
+    # A genuine, in-bounds signature is left for signtool to replace.
+    exe = tmp_path / "signed.dll"
+    exe.write_bytes(bytes(_fake_pe(cert_rva=200, cert_size=50, total=320)))
+    cs._sanitize_pe_for_signing(exe)
+    assert _cert_entry(exe.read_bytes()) == (200, 50)
+
+
+def test_sanitize_ignores_non_pe_files(tmp_path: Path) -> None:
+    plain = tmp_path / "notes.txt"
+    plain.write_text("hello", encoding="utf-8")
+    cs._sanitize_pe_for_signing(plain)  # must not raise
+    assert plain.read_text(encoding="utf-8") == "hello"


### PR DESCRIPTION
## Problem
Regenerating a **signed** QUILL build aborted at the payload-signing step:

```
SignTool Error: SignedCode::Sign returned error: 0x800700C1  (badexeformat)
An error occurred while attempting to sign: dist\windows\portable\quill.exe
```

44 DLLs signed fine; `quill.exe` failed. It's a copy of the PSF-signed embeddable `pythonw.exe` that **rcedit** re-stamps with VERSIONINFO. rcedit removes the appended signature bytes but leaves the optional header's **Certificate Table** data directory pointing at the old location (`rva=90112` = EOF, `size=14048`). signtool then tries to parse a certificate that isn't there and fails. The file reports `NotSigned`, yet can't be signed, and `signtool remove` also fails (nothing valid to remove).

## Fix
`sign_files` now zeroes a **dangling** Certificate Table entry (`rva >= file size` or `rva + size > file size`) on each PE before signing. A genuine, in-bounds signature is left untouched — signtool replaces it normally. Best-effort and guarded, so a parse hiccup never blocks signing.

Verified end to end: the stamped `quill.exe` now signs and `signtool verify /pa` reports valid. Adds unit tests for the dangling / in-bounds / non-PE cases (13 pass, lint clean).

Found while regenerating the signed 1.0.0 installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)