### PR TITLE
fix(radio build): staging the OptiLab adapter copied a file onto itself

### DIFF
--- a/standalone/radio/scripts/build_release.ps1
+++ b/standalone/radio/scripts/build_release.ps1
@@ -175,7 +175,16 @@ if (Test-Path $optilabExe) {
         # runtime is where an *installed* app finds it (the per-app installer
         # ships only the launcher and docs, so the runtime is beside
         # sys.executable -- exactly where optilab_adapter.find_adapter looks).
-        Copy-Item $optilabExe (Join-Path $dest "quill-optilab.exe") -Force
+        $optilabTarget = Join-Path $dest "quill-optilab.exe"
+        # ...but `--out $appDir` above already wrote it into the first of those,
+        # so that copy is the file onto itself -- which PowerShell treats as a
+        # hard error, not a no-op. With $ErrorActionPreference = "Stop" that
+        # took the whole release build down at the last step before signing, on
+        # any machine with a C++ toolchain to build the adapter in the first
+        # place.
+        if ([IO.Path]::GetFullPath($optilabTarget) -ne [IO.Path]::GetFullPath($optilabExe)) {
+            Copy-Item $optilabExe $optilabTarget -Force
+        }
         Copy-Item (Join-Path $upstream "LICENSE") (Join-Path $dest "OptiLabCore-LICENSE.txt") -Force
         Copy-Item (Join-Path $upstream "NOTICE")  (Join-Path $dest "OptiLabCore-NOTICE.txt")  -Force
     }


### PR DESCRIPTION
`build_native_optilab.py --out $appDir` already writes `quill-optilab.exe` into the app folder, and the staging loop then copied it there again. PowerShell treats `Copy-Item` onto the same path as a hard error, not a no-op, so with `$ErrorActionPreference = "Stop"` the entire release build died at the last step before signing:

```
Cannot overwrite the item ...\dist\QuillRadio\quill-optilab.exe with itself
```

It fails for anyone who **has** a C++ toolchain — which is why it hid. Without one the adapter is never built and the block is skipped, so the machines most likely to cut a release were the least likely to hit it.

Now compares full paths and skips the copy that is already home. The shared-runtime copy and both licence files (sourced from the vendored upstream directory, so never self-copies) are unchanged.

Found while cutting Quill Radio 3.0.0; verified by the release build getting past this step and into signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)