### PR TITLE
fix(installers): the thin "-Lite" setups shipped unsigned

### DIFF
--- a/standalone/radio/installer/quill-radio-lite.iss
+++ b/standalone/radio/installer/quill-radio-lite.iss
@@ -17,6 +17,15 @@
 #define RuntimeUrl "https://github.com/Community-Access/quill/releases/latest/download/QuillVille-Runtime-Setup.exe"
 
 [Setup]
+#ifdef Sign
+; Code signing (opt-in). Present only when ISCC is invoked with /DSign plus a
+; matching /Squilltrusted=<sign command>; Inno then signs the compiled Setup.exe
+; and the generated uninstaller. A plain build passes neither, so these
+; directives are absent and the unsigned build compiles unchanged. See
+; docs/code-signing.md.
+SignTool=quilltrusted
+SignedUninstaller=yes
+#endif
 AppId={{35DAB52F-94BB-475C-BA97-A5059C85B3D1}}
 AppName={#AppName}
 AppVersion={#AppVersion}

--- a/standalone/studio/installer/quill-audio-studio-lite.iss
+++ b/standalone/studio/installer/quill-audio-studio-lite.iss
@@ -26,6 +26,15 @@
 #define RuntimeUrl "https://github.com/Community-Access/quill/releases/latest/download/QuillVille-Runtime-Setup.exe"
 
 [Setup]
+#ifdef Sign
+; Code signing (opt-in). Present only when ISCC is invoked with /DSign plus a
+; matching /Squilltrusted=<sign command>; Inno then signs the compiled Setup.exe
+; and the generated uninstaller. A plain build passes neither, so these
+; directives are absent and the unsigned build compiles unchanged. See
+; docs/code-signing.md.
+SignTool=quilltrusted
+SignedUninstaller=yes
+#endif
 ; Same AppId as the full/shared installer: this is the same product.
 AppId={{64D6B5F9-01E3-47D5-B49F-794DFC0106BF}}
 AppName={#AppName}

--- a/standalone/weather/installer/quill-weather-lite.iss
+++ b/standalone/weather/installer/quill-weather-lite.iss
@@ -16,6 +16,15 @@
 #define RuntimeUrl "https://github.com/Community-Access/quill/releases/latest/download/QuillVille-Runtime-Setup.exe"
 
 [Setup]
+#ifdef Sign
+; Code signing (opt-in). Present only when ISCC is invoked with /DSign plus a
+; matching /Squilltrusted=<sign command>; Inno then signs the compiled Setup.exe
+; and the generated uninstaller. A plain build passes neither, so these
+; directives are absent and the unsigned build compiles unchanged. See
+; docs/code-signing.md.
+SignTool=quilltrusted
+SignedUninstaller=yes
+#endif
 AppId={{7B0C2E14-9A3D-4F6B-B1E2-8C5D3A9F0E21}}
 AppName={#AppName}
 AppVersion={#AppVersion}


### PR DESCRIPTION
Code signing is gated behind an `#ifdef Sign` block that ISCC activates with `/DSign` plus the `/Squilltrusted=` command mapping. Every app main installer carries that block. **None of the three thin ones did** — so `Quill-Radio-Lite-Setup`, `Quill-Audio-Studio-Lite-Setup` and `Quill-Weather-Lite-Setup` compiled unsigned even with signing turned on, and nothing said a word about it.

Caught cutting Quill Radio 3.0.0: the Lite installer built clean and `Get-AuthenticodeSignature` came back **NotSigned**.

It is also the worst one to miss. The thin installer is the *small* download — 2.6 MB against 232 MB — so it is the one most people take, and an unsigned Setup.exe fetched from the internet is exactly what SmartScreen exists to stop.

The block added here is byte-identical to the one the main installers use and is inert without `/DSign`, so unsigned builds compile exactly as before.

**Verified** by rebuilding Quill Radio Lite with signing on:

```
Lite: Valid | CN=Jeffrey Bishop, O=Jeffrey Bishop, L=Tucson, S=az, C=US
```

Two related files deliberately left alone:
- `installer/shared-runtime.iss` — an includable fragment with no `[Setup]` section of its own; the parent installer signs the compiled Setup and its payload is signed before packaging.
- `standalone/radio/installer/quill-radio-shared.iss` — the superseded validation-only script that `quill-radio.iss` was promoted from; nothing builds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)