### PR TITLE
An update was installing no code at all: the shared runtime skipped every same-Python refresh

### DIFF
--- a/installer/shared-runtime.iss
+++ b/installer/shared-runtime.iss
@@ -17,6 +17,10 @@
 ;   {code:RuntimeExe} -m <the app's module>     (e.g. -m quill.apps.radio)
 
 [Files]
+; The payload's own marker, extracted to {tmp} before anything is copied, so
+; RuntimeNeedsInstall can compare the build this setup CARRIES against the
+; build already installed. Without it the check could only see one side.
+Source: "{#RuntimeSourceDir}\quillville-runtime.json"; Flags: dontcopy noencryption
 ; The whole runtime, gated by RuntimeNeedsInstall so a second app skips it.
 Source: "{#RuntimeSourceDir}\*"; DestDir: "{code:RuntimeDir}"; Components: runtime; \
   Check: RuntimeNeedsInstall; \
@@ -39,29 +43,27 @@ begin
   Result := RuntimeDir('') + '\QuillVilleRuntime.exe';
 end;
 
-// Extract the "python" value from the runtime's quillville-runtime.json marker
-// with plain string ops (the marker is a tiny, fixed-shape JSON object, so a
-// full parser is overkill and would not be available in Pascal anyway).
-function InstalledRuntimeVersion(): string;
+// Read one value out of a quillville-runtime.json marker with plain string ops
+// (the marker is a tiny, fixed-shape JSON object, so a full parser is overkill
+// and would not be available in Pascal anyway). '' when absent or unreadable.
+function MarkerValue(MarkerFile, Key: string): string;
 var
-  MarkerFile: string;
   Content: AnsiString;
-  Text, Key: string;
+  Text, Quoted: string;
   P, Q: Integer;
 begin
   Result := '';
-  MarkerFile := RuntimeDir('') + '\quillville-runtime.json';
   if not FileExists(MarkerFile) then
     exit;
   if not LoadStringFromFile(MarkerFile, Content) then
     exit;
   Text := String(Content);
-  Key := '"python"';
-  P := Pos(Key, Text);
+  Quoted := '"' + Key + '"';
+  P := Pos(Quoted, Text);
   if P = 0 then
     exit;
   // Move past the key and its colon to the opening quote of the value.
-  Text := Copy(Text, P + Length(Key), Length(Text));
+  Text := Copy(Text, P + Length(Quoted), Length(Text));
   P := Pos('"', Text);
   if P = 0 then
     exit;
@@ -72,18 +74,55 @@ begin
   Result := Copy(Text, 1, Q - 1);
 end;
 
-// The [Files] Check: install the runtime only when the wanted version is not
-// already present. Cached so it is not recomputed for every file.
+function InstalledMarkerFile(): string;
+begin
+  Result := RuntimeDir('') + '\quillville-runtime.json';
+end;
+
+function InstalledRuntimeVersion(): string;
+begin
+  Result := MarkerValue(InstalledMarkerFile(), 'python');
+end;
+
+// The [Files] Check: install the shared runtime unless what is already there is
+// the same CPython AND at least as new as the payload this setup carries.
+//
+// The version-only test this replaced was the whole bug: the runtime carries
+// the entire `quill` package -- every app's actual code -- so two builds on the
+// same CPython are NOT interchangeable. An update installed beside an existing
+// runtime skipped the copy and the app kept running the old code, with the
+// installer reporting success (#1217 was the same fault with a coarser
+// symptom; the build id gained time granularity here so two builds on one day
+// are no longer indistinguishable).
+//
+// Newer-or-equal installed build is left alone, so installing an older sibling
+// app never downgrades the shared runtime. An unreadable or missing build on
+// either side means install: correctness beats bandwidth.
+// Mirrors quill.core.runtime_marker.needs_install, which is unit-tested.
 var
   gRuntimeChecked: Boolean;
   gRuntimeNeeded: Boolean;
 
 function RuntimeNeedsInstall(): Boolean;
+var
+  PayloadBuild, InstalledBuild: string;
 begin
   if not gRuntimeChecked then
   begin
-    gRuntimeNeeded := (InstalledRuntimeVersion() <> '{#RuntimeVersion}');
     gRuntimeChecked := True;
+    gRuntimeNeeded := True;
+    if InstalledRuntimeVersion() = '{#RuntimeVersion}' then
+    begin
+      ExtractTemporaryFile('quillville-runtime.json');
+      PayloadBuild := MarkerValue(
+        ExpandConstant('{tmp}\quillville-runtime.json'), 'build');
+      InstalledBuild := MarkerValue(InstalledMarkerFile(), 'build');
+      // Build ids are sortable stamps (yyyy-mm-ddThh:mm:ssZ), so a plain
+      // string compare orders them.
+      if (PayloadBuild <> '') and (InstalledBuild <> '')
+         and (InstalledBuild >= PayloadBuild) then
+        gRuntimeNeeded := False;
+    end;
   end;
   Result := gRuntimeNeeded;
 end;

--- a/standalone/runtime/build_runtime.ps1
+++ b/standalone/runtime/build_runtime.ps1
@@ -120,7 +120,12 @@ Get-ChildItem $LibmpvDir -File -Filter *.txt -ErrorAction SilentlyContinue |
 
 # -- stamp the version marker (installer's skip-if-present check reads this) ---
 $pyver = (& $Python -c "import platform; print(platform.python_version())").Trim()
-$build = Get-Date -Format "yyyy-MM-dd"
+# A sortable UTC stamp, not a bare date: the installer's skip-if-present check
+# compares this string, and two runtimes built on the SAME DAY are different
+# payloads (they carry the whole quill package). With date-only ids the second
+# build of a day looked identical to the first, so an update installed over it
+# was skipped and the app kept running yesterday's code.
+$build = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 & $Python -c "from pathlib import Path; from quill.core import runtime_marker as m; m.write_marker(Path(r'$dist'), python_version='$pyver', build_id='$build'); print('marker', m.read_marker(Path(r'$dist')))"
 
 Write-Host "Shared runtime ready: $dist (Python $pyver)"

--- a/tests/unit/core/test_runtime_marker.py
+++ b/tests/unit/core/test_runtime_marker.py
@@ -75,3 +75,22 @@ def test_needs_install_without_required_build_is_version_only(tmp_path: Path) ->
     m.write_marker(tmp_path, python_version="3.13.1", build_id="2026-07-24")
     assert m.needs_install(tmp_path, "3.13.1") is False
     assert m.needs_install(tmp_path, "3.14.0") is True
+
+
+def test_two_builds_on_one_day_are_distinguishable(tmp_path: Path) -> None:
+    """The 2026-08-16 fault: build ids were bare dates, so the morning's
+    runtime and the afternoon's compared equal and an update installed over
+    the old one was skipped -- the app kept running the earlier code while
+    the installer reported success. Stamps carry the time now."""
+    m.write_marker(tmp_path, python_version="3.13.14", build_id="2026-08-16T08:30:00Z")
+    assert m.needs_install(tmp_path, "3.13.14", required_build="2026-08-16T11:12:00Z") is True
+    # ...and the reverse is still a no-op, so an older sibling never downgrades.
+    m.write_marker(tmp_path, python_version="3.13.14", build_id="2026-08-16T11:12:00Z")
+    assert m.needs_install(tmp_path, "3.13.14", required_build="2026-08-16T08:30:00Z") is False
+
+
+def test_a_date_only_marker_is_older_than_any_stamp_from_the_same_day(tmp_path: Path) -> None:
+    """Upgrading from a pre-fix install: "2026-08-16" < "2026-08-16T..." by
+    plain string compare, so the first fixed installer refreshes it."""
+    m.write_marker(tmp_path, python_version="3.13.14", build_id="2026-08-16")
+    assert m.needs_install(tmp_path, "3.13.14", required_build="2026-08-16T00:01:00Z") is True

--- a/tests/unit/structure/test_shared_runtime_installer.py
+++ b/tests/unit/structure/test_shared_runtime_installer.py
@@ -1,0 +1,54 @@
+"""The shared-runtime installer fragment must compare *builds*, not just Python.
+
+The QuillVille Runtime carries the whole ``quill`` package -- every app's real
+code -- so "same CPython" never means "same payload". On 2026-08-16 a Quill
+Radio update installed cleanly over a runtime built four hours earlier and the
+app kept running the older code: the fragment's skip test compared only the
+CPython version, and the build id it could have compared was a bare date that
+two builds on one day shared.
+
+These are source-level guards. The decision logic itself is unit-tested in
+``quill.core.runtime_marker`` (:func:`needs_install`); what is pinned here is
+that the installer -- the thing that actually decides -- keeps asking the
+question at all, for every app that ships the shared runtime.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+FRAGMENT = REPO / "installer" / "shared-runtime.iss"
+
+
+def test_the_skip_test_compares_the_payload_build_against_the_installed_one() -> None:
+    source = FRAGMENT.read_text(encoding="utf-8")
+    # It must read the build from BOTH sides: the marker already installed,
+    # and the one this setup carries (extracted to {tmp} before any copy).
+    assert "ExtractTemporaryFile('quillville-runtime.json')" in source
+    assert "'build'" in source, "the build id is never read"
+    assert "InstalledBuild >= PayloadBuild" in source, (
+        "an installed build that is older than the payload must trigger a reinstall"
+    )
+    # The payload marker has to be shipped as a dontcopy file or the extract
+    # above fails at install time.
+    assert "quillville-runtime.json" in source and "dontcopy" in source
+
+
+def test_every_app_that_includes_the_fragment_gets_the_fix() -> None:
+    """One fragment, five installers: the fix cannot be half-applied."""
+    including = sorted(
+        path.relative_to(REPO).as_posix()
+        for path in REPO.glob("standalone/*/installer/*.iss")
+        if "shared-runtime.iss" in path.read_text(encoding="utf-8")
+    )
+    assert len(including) >= 5, f"expected every app's installer to include it, found {including}"
+
+
+def test_the_runtime_build_id_carries_a_time_not_just_a_date() -> None:
+    """Two builds on one day must not look identical to the installer."""
+    build_script = (REPO / "standalone" / "runtime" / "build_runtime.ps1").read_text(
+        encoding="utf-8"
+    )
+    assert "yyyy-MM-ddTHH:mm:ssZ" in build_script
+    assert 'Get-Date -Format "yyyy-MM-dd"' not in build_script


### PR DESCRIPTION
## The bug

`C:\qr` holds only the launcher and docs; all real code lives in the shared QuillVille Runtime. The fragment that installs it gated the copy on the CPython version alone:

```pascal
gRuntimeNeeded := (InstalledRuntimeVersion() <> '{#RuntimeVersion}');
```

Every Quill Radio (and Studio/Weather/Inkwell) update onto a machine that already had a same-Python runtime therefore **skipped the copy and reported success**, leaving the app on the old code. Caught live 2026-08-16: installed from the 11:25 setup, `quill/core/radio/` in the installed runtime still had no `branch_find.py` and no `audiopub.py` — a runtime built at 08:42 that morning was in place.

This is #1217's fault with a wider blast radius. `runtime_marker.needs_install` gained build comparison then; the installer — the thing that actually decides — was never wired to use it.

Second half: build ids were bare dates, so the 08:42 and 11:12 runtimes carried the *same* id and even a build-aware check would have skipped.

## The fix

- **`installer/shared-runtime.iss`**: ships the payload's own `quillville-runtime.json` as a `dontcopy` file, extracts it to `{tmp}` before any copying, and installs when CPython differs **or** the installed build is older than the payload's. Newer-or-equal is left alone (an older sibling app never downgrades the shared runtime); an unreadable marker on either side means install. All five apps that `#include` the fragment are covered with no per-app change.
- **`standalone/runtime/build_runtime.ps1`**: sortable UTC timestamp (`yyyy-MM-ddTHH:mm:ssZ`) instead of a date. A pre-fix date-only marker sorts older than any stamp from that day, so the first fixed installer refreshes it.

## Tests

- `test_runtime_marker`: same-day ordering both directions, and the date-only → timestamp upgrade path.
- `test_shared_runtime_installer` (new): the installer still compares builds, still ships the marker it needs to do that, and every app including the fragment gets the fix.

48 runtime/structure tests pass; ruff, format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)