### PR TITLE
Close the open crash-report issues: fix the two live classes, verify the rest

### DIFF
--- a/quill/core/ssh/client.py
+++ b/quill/core/ssh/client.py
@@ -20,10 +20,33 @@ from quill.core.error_codes import CodedError
 from quill.core.ssh.sites import AUTH_AGENT, AUTH_KEY, DEFAULT_PORT
 from quill.core.ssh.transfer import backup_name
 
-_INSTALL_HINT = (
-    "Editing files over SSH needs the 'paramiko' package, which is not installed. "
-    "Install it with: pip install paramiko"
-)
+
+def _install_hint() -> str:
+    """The install command that actually works, built at error time.
+
+    "pip install paramiko" was the old hint, and it sent a real user in a
+    circle (#1443): QUILL ships its own Python, so a pip install into the
+    system Python succeeds and changes nothing QUILL can see. The command has
+    to name *this* interpreter -- ``sys.executable -m pip`` -- which is also
+    how the AI SDK packs install themselves (core/ai/sdk_install.py).
+    """
+    import importlib.util
+    import sys
+
+    if importlib.util.find_spec("pip") is not None:
+        return (
+            "Editing files over SSH needs the 'paramiko' package, and it is not "
+            "installed in QUILL's own copy of Python -- installing it into "
+            "another Python on this machine will not be seen. Install it with:\n"
+            f'  "{sys.executable}" -m pip install paramiko\n'
+            "then restart QUILL."
+        )
+    return (
+        "Editing files over SSH needs the 'paramiko' package, and this build of "
+        "QUILL cannot install Python packages itself (pip is not bundled). "
+        f"Install paramiko into QUILL's own Python at {sys.executable} and "
+        "restart QUILL."
+    )
 
 
 class SshDependencyError(CodedError):
@@ -128,8 +151,15 @@ class SftpConnection:
 def _import_paramiko() -> Any:
     try:
         import paramiko  # type: ignore[import-untyped]
+    except ModuleNotFoundError as exc:
+        raise SshDependencyError(_install_hint()) from exc
     except Exception as exc:  # noqa: BLE001
-        raise SshDependencyError(_INSTALL_HINT) from exc
+        # Present but broken is a different fact from absent, and telling
+        # somebody to install a package they have installed is how #1443 went
+        # in a circle. Say what actually failed.
+        raise SshDependencyError(
+            f"The 'paramiko' package is installed but could not be loaded: {exc}"
+        ) from exc
     return paramiko
 
 

--- a/quill/ui/agent_validator_dialog.py
+++ b/quill/ui/agent_validator_dialog.py
@@ -164,6 +164,8 @@ class AgentValidatorDialog:
         self.dialog.CentreOnParent()
         focus_primary_control(self.dialog)
         try:
-            self._show_modal(self.dialog)
+            # The label is required (the #1442 crash class: _show_modal_dialog
+            # takes (dialog, label)); this twin call site was found in the sweep.
+            self._show_modal(self.dialog, "Validate Agents")
         finally:
             self.dialog.Destroy()

--- a/quill/ui/copilot_onboarding_dialog.py
+++ b/quill/ui/copilot_onboarding_dialog.py
@@ -273,6 +273,8 @@ class CopilotOnboardingDialog:
         self.dialog.CentreOnParent()
         focus_primary_control(self.dialog)
         try:
-            self._show_modal(self.dialog)
+            # _show_modal is MainFrame._show_modal_dialog(dialog, label) -- the
+            # label is required, and omitting it was crash report #1442.
+            self._show_modal(self.dialog, "Set Up GitHub Copilot")
         finally:
             self.dialog.Destroy()

--- a/tests/unit/core/test_ssh_client.py
+++ b/tests/unit/core/test_ssh_client.py
@@ -126,3 +126,54 @@ def test_load_system_host_keys_always_runs(stub_paramiko: _StubParamiko) -> None
 
     client_mod.connect("example.com", username="alice", auth="password", password="x")
     assert stub_paramiko.client.loaded_system_keys is True
+
+
+# --- the install hint that works (#1443) --------------------------------------
+
+
+def test_a_missing_paramiko_names_quills_own_interpreter(monkeypatch):
+    """'pip install paramiko' sent a real user in a circle: it lands in the
+    system Python, and QUILL runs its own. The hint must name this
+    interpreter and say to restart."""
+    import builtins
+    import sys
+
+    from quill.core.ssh import client
+
+    real_import = builtins.__import__
+
+    def _no_paramiko(name, *args, **kwargs):
+        if name == "paramiko":
+            raise ModuleNotFoundError("No module named 'paramiko'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_paramiko)
+    with pytest.raises(client.SshDependencyError) as caught:
+        client._import_paramiko()
+    text = str(caught.value)
+    assert sys.executable in text
+    assert "-m pip install paramiko" in text
+    assert "restart QUILL" in text
+
+
+def test_a_broken_paramiko_reports_the_real_failure(monkeypatch):
+    """Present-but-broken is a different fact from absent; telling somebody to
+    install a package they installed is how #1443 went in a circle."""
+    import builtins
+
+    from quill.core.ssh import client
+
+    real_import = builtins.__import__
+
+    def _broken_paramiko(name, *args, **kwargs):
+        if name == "paramiko":
+            raise ImportError("DLL load failed while importing _cffi_backend")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _broken_paramiko)
+    with pytest.raises(client.SshDependencyError) as caught:
+        client._import_paramiko()
+    text = str(caught.value)
+    assert "installed but could not be loaded" in text
+    assert "_cffi_backend" in text
+    assert "pip install paramiko" not in text

--- a/tests/unit/ui/test_agent_validator_dialog.py
+++ b/tests/unit/ui/test_agent_validator_dialog.py
@@ -20,7 +20,8 @@ def test_uses_the_shared_linter_rules() -> None:
 def test_follows_modal_contract_and_destroys() -> None:
     body = _source()
     assert "apply_modal_ids(self.dialog, escape_id=wx.ID_CANCEL)" in body
-    assert "self._show_modal(self.dialog)" in body
+    # The label is required -- omitting it was the #1442 crash.
+    assert 'self._show_modal(self.dialog, "Validate Agents")' in body
     assert "self.dialog.Destroy()" in body
     assert "focus_primary_control(self.dialog)" in body
 

--- a/tests/unit/ui/test_copilot_onboarding_dialog.py
+++ b/tests/unit/ui/test_copilot_onboarding_dialog.py
@@ -18,7 +18,8 @@ def _source() -> str:
 def test_follows_modal_contract_and_destroys() -> None:
     body = _source()
     assert "apply_modal_ids(self.dialog, escape_id=wx.ID_CANCEL)" in body
-    assert "self._show_modal(self.dialog)" in body
+    # The label is required -- omitting it was the #1442 crash.
+    assert 'self._show_modal(self.dialog, "Set Up GitHub Copilot")' in body
     assert "self.dialog.Destroy()" in body
     assert "focus_primary_control(self.dialog)" in body
 

--- a/tests/unit/ui/test_show_modal_call_shape.py
+++ b/tests/unit/ui/test_show_modal_call_shape.py
@@ -1,0 +1,44 @@
+"""Every hand-off of ``_show_modal_dialog`` is called with its label.
+
+``MainFrame._show_modal_dialog(dialog, label)`` requires the label -- it is
+what the dialog contract announces -- and a dialog module that receives the
+bound method under a shorter name (``self._show_modal``) has no signature in
+front of it when it calls. Two modules called it with one argument, and the
+result was a TypeError **when the user pressed the button**, not at startup:
+crash report #1442 (the Copilot Set Up flow), plus its unreported twin in the
+agent validator, found while fixing it.
+
+Source-level, because that is where the drift happens: the pattern
+``._show_modal(self.dialog)`` with nothing after the argument is exactly the
+call that compiles fine and crashes live.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_UI = Path(__file__).resolve().parents[3] / "quill" / "ui"
+
+#: A one-argument call of a stored show-modal callable. The comma test is the
+#: point: ``_show_modal(self.dialog, "Label")`` does not match.
+_ONE_ARG_CALL = re.compile(r"\._show_modal\(\s*self\.(?:_)?dialog\s*\)")
+
+
+def test_no_show_modal_call_omits_the_label() -> None:
+    offenders = []
+    for path in _UI.rglob("*.py"):
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for match in _ONE_ARG_CALL.finditer(text):
+            line = text[: match.start()].count("\n") + 1
+            offenders.append(f"{path.relative_to(_UI.parent.parent)}:{line}")
+    assert not offenders, (
+        "_show_modal called without its label (the #1442 crash shape):\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_two_fixed_sites_pass_real_labels() -> None:
+    copilot = (_UI / "copilot_onboarding_dialog.py").read_text(encoding="utf-8")
+    validator = (_UI / "agent_validator_dialog.py").read_text(encoding="utf-8")
+    assert '_show_modal(self.dialog, "Set Up GitHub Copilot")' in copilot
+    assert '_show_modal(self.dialog, "Validate Agents")' in validator


### PR DESCRIPTION
Eleven open issues, six distinct crash classes, each checked against current main:

**Fixed here (still reproducible on main):**
- **#1442** — `_show_modal_dialog` called without its required `label` in the Copilot Set Up flow, plus an identical unreported call in the agent validator. Both fixed; the two tests that had pinned the buggy call corrected; new gate `test_show_modal_call_shape.py` fails the one-argument shape anywhere in `quill/ui`.
- **#1443** — the paramiko hint said `pip install paramiko`, which lands in the system Python while QUILL runs its own; the reporter did exactly that and stayed stuck. The hint now names QUILL's own interpreter with the full command and a restart note, and an installed-but-broken paramiko reports the real import failure. Both cases tested.

**Verified already fixed on main (close on merge, no code needed):**
- **#1425 / #1426 / #1427** — `tree.Expand(root)` on the hidden root is gone from `_show_tree_navigator` (comment on site cites the #885 fix).
- **#1428 / #1457** — `_sync_editor_change` now defaults `status="Modified"`; the no-argument call from `word_view` is legal (verified via runtime signature).
- **#1431 / #1447 / #1456** — the Speech Hub caller now spreads `kokoro_ok` / `kokoro_can_install` into both dictation kwargs dicts.
- **#1455** — `_on_auto_probe_done` carries the `dialog_alive` guard (#1067's fix) on the exact crashing line.

All reports came from 0.9.0-era builds; the verified-fixed classes shipped in the releases since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)